### PR TITLE
Supprime l'utilisation de source dans les scripts npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ pip install pip --upgrade  # make sure we're using the latest pip version
 npm run install-openfisca  # install dependencies
 ```
 
-Then, to start the OpenFisca server, simply run `npm run openfisca`.
+Then, to start the OpenFisca server, simply run `source .venv/bin/activate` followed by `npm run openfisca`.
+
+In order to start a single worker for OpenFisca, you can run `OPENFISCA_WORKERS=1 npm run openfisca`.
 
 ### Development mode
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "fast-install": "PUPPETEER_SKIP_DOWNLOAD=1 npm ci",
     "front": "NODE_ENV=front_only npm run serve",
     "install-openfisca": "pip install --upgrade -r openfisca/requirements.txt",
-    "openfisca": "source .venv/bin/activate && cd openfisca && gunicorn api --config config.py",
+    "openfisca": "gunicorn openfisca.api --config openfisca/config.py",
     "predb": "mkdir -p db",
     "prestart": "npm run build && npm run stats",
     "start": "NODE_ENV=production node server.js",


### PR DESCRIPTION
* source n'est pas fonctionnel partout et la proposition faite pour `npm run openfisca` contraint à utiliser un venv dans un dossier spécifique (.venv)