### PR TITLE
Supprime l'affichage superflu de EnfantACharge

### DIFF
--- a/src/lib/State/blocks.js
+++ b/src/lib/State/blocks.js
@@ -141,7 +141,9 @@ function housingBlock() {
      {
         isActive: (menage, situation) => {
           const demandeur = situation.demandeur
-          return demandeur && demandeur.activite == 'etudiant' && demandeur.enfant_a_charge && !demandeur.habite_chez_parents
+          const thisYear = datesGenerator(situation.dateDeValeur).thisYear.id
+          const enfant_a_charge = demandeur.enfant_a_charge && demandeur.enfant_a_charge[thisYear]
+          return demandeur && demandeur.activite == 'etudiant' && enfant_a_charge && !demandeur.habite_chez_parents
         },
         steps: [
           new Step({entity: 'individu', id: 'demandeur', variable: 'bourse_criteres_sociaux_commune_domicile_familial'}),
@@ -195,7 +197,11 @@ function generateBlocks(situation) {
     },
     {
       subject: situation => situation.demandeur,
-      isActive: subject => subject && subject.activite == 'etudiant' && subject.enfant_a_charge,
+      isActive: (subject, situation) => {
+        const thisYear = datesGenerator(situation.dateDeValeur).thisYear.id
+        const enfant_a_charge = subject.enfant_a_charge && subject.enfant_a_charge[thisYear]
+        return subject && subject.activite == 'etudiant' && enfant_a_charge
+      },
       steps: [
         new Step({entity:'famille', variable: 'bourse_criteres_sociaux_nombre_enfants_a_charge'}),
         new Step({entity:'famille', variable: 'bourse_criteres_sociaux_nombre_enfants_a_charge_dans_enseignement_superieur'}),

--- a/src/lib/State/blocks.js
+++ b/src/lib/State/blocks.js
@@ -139,11 +139,11 @@ function housingBlock() {
         ],
      },
      {
-        isActive: (menage, situation) => {
-          const demandeur = situation.demandeur
+        subject: (menage, situation) => situation.demandeur,
+        isActive: (subject, situation) => {
           const thisYear = datesGenerator(situation.dateDeValeur).thisYear.id
-          const enfant_a_charge = demandeur.enfant_a_charge && demandeur.enfant_a_charge[thisYear]
-          return demandeur && demandeur.activite == 'etudiant' && enfant_a_charge && !demandeur.habite_chez_parents
+          const enfant_a_charge = subject.enfant_a_charge && subject.enfant_a_charge[thisYear]
+          return subject.activite == 'etudiant' && enfant_a_charge && !subject.habite_chez_parents
         },
         steps: [
           new Step({entity: 'individu', id: 'demandeur', variable: 'bourse_criteres_sociaux_commune_domicile_familial'}),
@@ -200,7 +200,7 @@ function generateBlocks(situation) {
       isActive: (subject, situation) => {
         const thisYear = datesGenerator(situation.dateDeValeur).thisYear.id
         const enfant_a_charge = subject.enfant_a_charge && subject.enfant_a_charge[thisYear]
-        return subject && subject.activite == 'etudiant' && enfant_a_charge
+        return subject.activite == 'etudiant' && enfant_a_charge
       },
       steps: [
         new Step({entity:'famille', variable: 'bourse_criteres_sociaux_nombre_enfants_a_charge'}),

--- a/src/lib/State/index.js
+++ b/src/lib/State/index.js
@@ -13,7 +13,7 @@ function processBlock({journey, subject, situation, isActive}, b) {
       throw Error('' + b + ' (' + (b instanceof Array ? 'array' : '?') + ')')
     }
     let blockSubject = b.subject ? b.subject(subject, situation) : (subject || situation)
-    const localActive = isActive && (!b.isActive || b.isActive(blockSubject, situation))
+    const localActive = isActive && (!b.isActive || (blockSubject && b.isActive(blockSubject, situation)))
     b.steps.forEach(s => processBlock({journey, subject: blockSubject, situation, isActive: localActive}, s))
   }
 }


### PR DESCRIPTION
L'écran `enfant_a_charge` pouvait être affiché alors que sa valeur n'était pas pertinent. Cela était du au fait que cette variable est définie sur une année et que l'objet JS ne contient pas `true//false` mais ` {[yearID]: true/false}`. Le test précédent était sur l'objet plutôt que la valeur à l'intérieur. 