### PR TITLE
Corrige le wording du loader

### DIFF
--- a/src/views/Simulation/Resultats.vue
+++ b/src/views/Simulation/Resultats.vue
@@ -1,7 +1,8 @@
 <template>
-<div class="aj-unbox">
-    <LoadingModal v-if="resultatStatus.updating">
-        <p v-show="resultatStatus.updating" class="aj-loading-text">Calcul en cours de vos droits…</p>
+  <div class="aj-unbox">
+    <LoadingModal v-if="accessStatus.fetching || resultatStatus.updating">
+      <p v-show="accessStatus.fetching">Récupération de la situation en cours…</p>
+      <p v-show="resultatStatus.updating">Calcul en cours de vos droits…</p>
     </LoadingModal>
 
     <div class="notification warning" v-if="hasWarning">

--- a/src/views/Simulation/Resultats.vue
+++ b/src/views/Simulation/Resultats.vue
@@ -1,8 +1,7 @@
 <template>
 <div class="aj-unbox">
-    <LoadingModal v-if="resultatStatus.fetching || resultatStatus.updating">
-        <p v-show="resultatStatus.updating" class="aj-loading-text">Récupération de la situation en cours…</p>
-        <p v-show="resultatStatus.fetching" class="aj-loading-text">Calcul en cours de vos droits…</p>
+    <LoadingModal v-if="resultatStatus.updating">
+        <p v-show="resultatStatus.updating" class="aj-loading-text">Calcul en cours de vos droits…</p>
     </LoadingModal>
 
     <div class="notification warning" v-if="hasWarning">


### PR DESCRIPTION
De ce que je vois la variable resultatStatus.fetching n'intervient jamais dans le workflow de récupération après plusieurs tests.
Elle n'est pas déclaré non plus dans defaultCalculs.
J'ai donc changer pour ne pas gérer le deux états mais uniquement updating.