### PR TITLE
Corrige la page de résultats dédiée

### DIFF
--- a/backend/controllers/situations.js
+++ b/backend/controllers/situations.js
@@ -23,7 +23,9 @@ exports.situation = function(req, res, next, situationId) {
 };
 
 exports.attachAccessCookie = function(req, res) {
-    res.cookie(req.situation.cookieName, req.situation.token, { maxAge: 7 * 24 * 3600 * 1000, httpOnly: true });
+    const maxAge = 7 * 24 * 3600 * 1000
+    res.cookie(req.situation.cookieName, req.situation.token, { maxAge, httpOnly: true })
+    res.cookie('lastestSituation', req.situation._id.toString(), { maxAge })
 };
 
 exports.validateAccess = function(req, res, next) {

--- a/src/components/DroitsList.vue
+++ b/src/components/DroitsList.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="droits-list">
     <div v-if="!ineligible">
-        <a v-for="(droit, index) in list"
-          class="aj-aide-box a-unstyled" v-bind:key="index" @click="push(droit)"
+        <router-link v-for="(droit, index) in list"
+          class="aj-aide-box a-unstyled" v-bind:key="index" v-bind:to="`/simulation/resultats/${droit.id}`"
           itemscope itemtype="http://schema.org/GovernmentService"
           >
             <img class="aj-aide-illustration" v-bind:src="require(`./../../public/img/${ droit.provider.imgSrc }`)" v-bind:alt="droit.label">
@@ -22,7 +22,7 @@
             <div class="aj-aide-cta">
                 <a class="button primary">Demander cette aide</a>
             </div>
-        </a>
+        </router-link>
     </div>
     <div v-if="ineligible">
       <a v-for="(droit, index) in list"

--- a/src/mixins/Resultats.js
+++ b/src/mixins/Resultats.js
@@ -1,0 +1,44 @@
+export default {
+  computed: {
+    droits: function() {
+      return this.resultats && this.resultats.droitsEligibles
+    },
+    droitsNonEligibles: function() {
+      return (this.droitsNonEligiblesShow && this.resultats && this.resultats.droitsNonEligibles) || [] },
+    droitsNonEligiblesShown: function() { return this.droitsNonEligibles.filter(i => i.id === "css_participation_forfaitaire") },
+    droitsNonEligiblesShow: function() { return this.$store.state.ameliNoticationDone },
+    resultatsId: function() { return this.resultats && this.resultats._id || '???' },
+    accessStatus: function() { return this.$store.state.access },
+    resultatStatus: function() { return this.$store.state.calculs },
+    resultats: function() { return this.$store.state.calculs.resultats },
+    hasWarning: function() {
+      return this.accessStatus.forbidden
+    },
+    hasError: function() {
+      return this.resultatStatus.error
+    },
+    shouldDisplayResults: function() {
+      return !(this.resultatStatus.updating || this.hasWarning || this.hasError) && this.droits
+    },
+  },
+  methods: {
+    restoreLatest: function() {
+        const lastestSituation = document.cookie.split('; ').reduce((accum, pair) => {
+          const [key, value] = pair.split('=', 2)
+          accum[key] = value
+          return accum
+        }, {}).lastestSituation
+        if (lastestSituation) {
+          this.$store.dispatch('fetch', lastestSituation)
+            .then(() => this.$store.dispatch('compute'))
+        }
+        return lastestSituation
+    },
+    mock: function(detail) {
+      if (this.$route.query.debug !== undefined) {
+        this.$store.dispatch('mockResults', detail || this.$route.query.debug)
+      }
+      return this.$route.query.debug !== undefined
+    }
+  }
+}

--- a/src/views/Simulation/Resultats.vue
+++ b/src/views/Simulation/Resultats.vue
@@ -54,6 +54,8 @@ import ErrorBlock from './../../components/ErrorBlock'
 import Feedback from './../../components/Feedback'
 import OfflineResults from './../../components/OfflineResults'
 import LoadingModal from '@/components/LoadingModal'
+import ResultatsMixin from '@/mixins/Resultats'
+
 
 export default {
   name: 'SimulationResultats',
@@ -64,34 +66,12 @@ export default {
     OfflineResults,
     LoadingModal
   },
-  computed: {
-    droits: function() {
-      return this.resultats && this.resultats.droitsEligibles
-    },
-    droitsNonEligibles: function() {
-      return (this.droitsNonEligiblesShow && this.resultats && this.resultats.droitsNonEligibles) || [] },
-    droitsNonEligiblesShown: function() { return this.droitsNonEligibles.filter(i => i.id === "css_participation_forfaitaire") },
-    droitsNonEligiblesShow: function() { return this.$store.state.ameliNoticationDone },
-    resultatsId: function() { return this.resultats && this.resultats._id || '???' },
-    accessStatus: function() { return this.$store.state.access },
-    resultatStatus: function() { return this.$store.state.calculs },
-    resultats: function() { return this.$store.state.calculs.resultats },
-    hasWarning: function() {
-      return this.accessStatus.forbidden
-    },
-    hasError: function() {
-      return this.resultatStatus.error
-    },
-    shouldDisplayResults: function() {
-      return !(this.resultatStatus.updating || this.hasWarning || this.hasError) && this.droits
-    },
-  },
+  mixins: [ResultatsMixin],
   methods: {
     isEmpty: function(array) { return ! array || array.length === 0 },
   },
   mounted: function () {
-    if (this.$route.query.debug !== undefined) {
-      this.$store.dispatch('mockResults', this.$route.query.debug)
+    if (this.mock(this.$route.params.droitId)) {
       return
     } else if (this.$route.query && this.$route.query.situationId) {
       if (this.$store.state.situation._id !== this.$route.query.situationId) {
@@ -111,8 +91,10 @@ export default {
             }
             return this.$store.dispatch('compute')
           })
-      } else if(! this.$store.getters.hasResults) {
+      } else if (! this.$store.getters.hasResults) {
         this.$store.dispatch('compute')
+      } else if (! this.$store.state.situation._id) {
+        this.restoreLatest()
       }
     }
 

--- a/src/views/Simulation/ResultatsDetail.vue
+++ b/src/views/Simulation/ResultatsDetail.vue
@@ -1,11 +1,17 @@
 <template>
     <div class="aj-unbox">
-        <button class="aj-droit-details-back-button button outline small with-icon" type="button" v-on:click="window && window.history.back()">
+        <LoadingModal v-if="accessStatus.fetching || resultatStatus.updating">
+          <p v-show="accessStatus.fetching">Récupération de la situation en cours…</p>
+          <p v-show="resultatStatus.updating">Récupération de vos droits…</p>
+        </LoadingModal>
+
+        <button class="aj-droit-details-back-button button outline small with-icon" type="button" v-on:click="goBack($event)">
             <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M11.25 5.24998H2.87249L6.53249 1.58998C6.82499 1.29748 6.82499 0.817478 6.53249 0.524978C6.23999 0.232478 5.76749 0.232478 5.47499 0.524978L0.532485 5.46748C0.239985 5.75998 0.239985 6.23248 0.532485 6.52498L5.47499 11.4675C5.76749 11.76 6.23999 11.76 6.53249 11.4675C6.82499 11.175 6.82499 10.7025 6.53249 10.41L2.87249 6.74998H11.25C11.6625 6.74998 12 6.41248 12 5.99998C12 5.58748 11.6625 5.24998 11.25 5.24998Z" fill="#030F8F"/>
             </svg>
             Retour aux résultats
         </button>
+
         <div class="aj-box normal-padding-bottom aj-results-details">
             <DroitsDetails
                 :droit="droit"
@@ -21,28 +27,32 @@
 
 <script>
 import DroitsDetails from '../../components/DroitsDetails.vue'
-import Institution from '@/lib/Institution'
 import Feedback from '@/components/Feedback'
+import LoadingModal from '@/components/LoadingModal'
+import ResultatsMixin from '@/mixins/Resultats'
+
 
 export default {
   name: 'SimulationResultatsDetail',
   components: {
     DroitsDetails,
-    Feedback
+    Feedback,
+    LoadingModal
   },
-  data() {
-    return {
-        window
-    }
+  mixins: [ResultatsMixin],
+  mounted: function () {
+      if (this.mock(this.$route.params.droitId)) {
+        return
+      }
+      if ((! this.droits) && this.restoreLatest()) {
+        this.$matomo && this.$matomo.trackEvent('General', 'compute', this.$route.params.droitId)
+      }
   },
   computed: {
-    droits: function() { return this.resultats && this.resultats.droitsEligibles },
-    resultats: function() { return this.$store.state.calculs.resultats },
-    resultatsId: function() { return this.resultats && this.resultats._id || '???' },
     situation: function() { return this.$store.state.situation },
     droit: function() {
         const droitId = this.$route.params.droitId
-        const droit = (this.droits || Institution.mockResults(droitId).droitsEligibles).find(function(droit) {
+        const droit = (this.droits || []).find(function(droit) {
             return droit.id === droitId;
         });
         return droit
@@ -50,5 +60,15 @@ export default {
     patrimoineCaptured: function() { return this.$store.getters.hasPatrimoine !== undefined },
     ressourcesYearMinusTwoCaptured: function() { return this.$store.getters.ressourcesYearMinusTwoCaptured },
   },
+  methods: {
+    goBack: function(event) {
+      event.preventDefault()
+      if (window && window.history.length > 1) {
+        history.back()
+      } else {
+        this.$router.push('/simulation/resultats')
+      }
+    }
+  }
 }
 </script>


### PR DESCRIPTION
Lors d'un test utilisateur, et lors d'un rafraîchissement de la page de résultats dédiée à la prime d'activité, le montant de la prime d'activité est passé de 240€ à 1 €, j'ai l'impression que les résultats de calculs ne sont pas bien conservés pour l'affichage des pages dédiées en particulier en cas de rafraîchissement.