### PR TITLE
Corrige la redirection en cas d'arrivée sur une page intermédiaire

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -436,8 +436,12 @@ router.beforeEach((to, from, next) => {
   } else {
     store.commit('setTitle', 'Évaluez vos droits aux aides sociales')
   }
+
   if (store.state.error) {
     store.dispatch('updateError', false)
+  }
+  if (store.state.message.text) {
+    store.commit('decrementMessageRemainingViewTime')
   }
 
   next()

--- a/src/router.js
+++ b/src/router.js
@@ -265,6 +265,7 @@ const router = new Router({
         }]
       }, 
       {
+        name: 'resultats',
         path: 'resultats',
         component: () => import(/* webpackChunkName: "resultats" */ './views/Simulation/Resultats.vue'),
       },
@@ -407,7 +408,7 @@ router.beforeEach((to, from, next) => {
   if (from.name === null) {
     store.commit('initialize')
     store.dispatch('verifyBenefitVariables')
-    if (to.matched.some(r => r.name === 'foyer') && ['demandeur', 'resultat'].indexOf(to.name) === -1 && ! store.getters.passSanityCheck) {
+    if (to.matched.some(r => r.name === 'foyer' || r.name === 'simulation') && ['date_naissance', 'resultats'].indexOf(to.name) === -1 && ! store.getters.passSanityCheck) {
       return store.dispatch('redirection', route => next(route))
     }
 
@@ -435,7 +436,9 @@ router.beforeEach((to, from, next) => {
   } else {
     store.commit('setTitle', 'Évaluez vos droits aux aides sociales')
   }
-  store.dispatch('updateError', false)
+  if (store.state.error) {
+    store.dispatch('updateError', false)
+  }
 
   next()
 })

--- a/src/store.js
+++ b/src/store.js
@@ -405,7 +405,7 @@ const store = new Vuex.Store({
     },
     redirection: function(state, next) {
       state.commit('setMessage', 'Vous avez été redirigé·e sur la première page du simulateur. Vous pensez que c\'est une erreur&nbsp;? Contactez-nous&nbsp: <a href="mailto:aides-jeunes@beta.gouv.fr">aides-jeunes@beta.gouv.fr</a>.')
-      next('/foyer/demandeur')
+      next('/simulation')
     },
     verifyBenefitVariables: function(state) {
       return axios.get('api/openfisca/variables')

--- a/src/store.js
+++ b/src/store.js
@@ -59,7 +59,10 @@ function defaultCalculs() {
 function defaultStore() {
   const now = moment().format()
   return {
-    message: null,
+    message: {
+      text: null,
+      counter: null,
+    },
     debug: false,
     situation: {
       _id: null,
@@ -283,11 +286,21 @@ const store = new Vuex.Store({
       state.calculs.error = true
       state.calculs.exception = error.response && error.response.data || error
     },
-    setMessage: function(state, message) {
-      state.message = message
+    setMessage: function(state, message, counter) {
+      state.message = {
+        text: message,
+        counter: counter || 1,
+      }
     },
-    clearMessage: function(state) {
-      state.message = null
+    decrementMessageRemainingViewTime: function(state) {
+      if (!state.message.text) {
+        return
+      }
+
+      state.message.counter = state.message.counter - 1
+      if (state.message.counter < 0) {
+        state.message.text = null
+      }
     },
     setTitle: function(state, newTitle) {
       state.title = newTitle

--- a/src/views/Simulation.vue
+++ b/src/views/Simulation.vue
@@ -6,6 +6,9 @@
       <div v-if="debug" class="aj-debug-switch">
           <button class="button small" @click="disableDebug">Quitter le mode debug</button>
       </div>
+      <div v-if="$store.state.message.text" class="notification warning">
+        <div class="message" v-html="$store.state.message.text" />
+      </div>
       <div class="aj-box-wrapper">
         <router-view/>
       </div>


### PR DESCRIPTION
Certaines personnes arrivent en milieu de parcours avec une simulation mal construite. Cela génère diverses erreurs remontées dans Sentry. Le cas classique est l'absence de `demandeur` qui génère des
> Cannot read property 'XXX' of undefined

![Screenshot_2021-04-20 Évaluez vos droits aux aides sociales](https://user-images.githubusercontent.com/1410356/115368102-0dfa3f80-a1c7-11eb-8358-f8e0e64200fb.png)
