### PR TITLE
Ajoute les descriptifs des aides du Fonds de Solidarité au Logement du CD28

### DIFF
--- a/data/benefits/eure_et_loir_eligibilite_fsl_acces_logement.yml
+++ b/data/benefits/eure_et_loir_eligibilite_fsl_acces_logement.yml
@@ -7,8 +7,10 @@ description: >
   par le même bailleur, l’assurance habitation (6 premiers mois), les frais de déménagement,
   l’ouverture des compteurs, l’achat d’appareils ménagers et de mobilier de première nécessité.
 conditions:
-link: https://www.eurelien.fr/guide/logement
-prefix: la
+  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté 
+  (ressources hors aide personnelle au logement, allocation logement, 
+  allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
+link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
+prefix: l'
 type: bool
-floorAt: 10
 entity: individus

--- a/data/benefits/eure_et_loir_eligibilite_fsl_acces_logement.yml
+++ b/data/benefits/eure_et_loir_eligibilite_fsl_acces_logement.yml
@@ -13,4 +13,4 @@ conditions:
 link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
 prefix: l'
 type: bool
-entity: individus
+entity: menages

--- a/data/benefits/eure_et_loir_eligibilite_fsl_acces_logement.yml
+++ b/data/benefits/eure_et_loir_eligibilite_fsl_acces_logement.yml
@@ -7,9 +7,9 @@ description: >
   par le même bailleur, l’assurance habitation (6 premiers mois), les frais de déménagement,
   l’ouverture des compteurs, l’achat d’appareils ménagers et de mobilier de première nécessité.
 conditions:
-  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté 
-  (ressources hors aide personnelle au logement, allocation logement, 
-  allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
+  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté
+    (ressources hors aide personnelle au logement, allocation logement,
+    allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
 link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
 prefix: l'
 type: bool

--- a/data/benefits/eure_et_loir_eligibilite_fsl_acces_logement.yml
+++ b/data/benefits/eure_et_loir_eligibilite_fsl_acces_logement.yml
@@ -1,0 +1,14 @@
+label: aide à l'accès au logement du fonds de solidarité pour le logement
+institution: departement_eure_et_loir
+description: >
+  Cette une aide, sous forme de subvention ou de prêt remboursable, est accordée
+  pour le dépôt de garantie, le 1er loyer, les frais d’agence, la garantie
+  de loyers et de charges locatives, les dettes locatives en vue d’un relogement
+  par le même bailleur, l’assurance habitation (6 premiers mois), les frais de déménagement,
+  l’ouverture des compteurs, l’achat d’appareils ménagers et de mobilier de première nécessité.
+conditions:
+link: https://www.eurelien.fr/guide/logement
+prefix: la
+type: bool
+floorAt: 10
+entity: individus

--- a/data/benefits/eure_et_loir_eligibilite_pch_domicile.yml
+++ b/data/benefits/eure_et_loir_eligibilite_pch_domicile.yml
@@ -9,7 +9,7 @@ description: >-
   exceptionnelles.
 conditions:
   - Ne pas déjà bénéficier d’Allocation compensatrice pour tierce
-    personne (ACTP), d’Allocation personnalisée d’autonomie (APA) ou 
+    personne (ACTP), d’Allocation personnalisée d’autonomie (APA) ou
     d’Allocation d’éducation de l’enfant handicapé (AEEH).
   - Faire évaluer votre situation personnelle par la maison départementale de l'autonomie (MDA).
 link: https://www.eurelien.fr/guide/autonomie

--- a/data/benefits/eure_et_loir_fsl_eligibilite_installation_logement.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_installation_logement.yml
@@ -1,0 +1,11 @@
+label: aide à l'installation dans le logement du fonds de solidarité pour le logement
+institution: departement_eure_et_loir
+description: >
+  Cette aide pour des équipements de première nécessité est destinée à favoriser
+  l'installation dans le cadre d'un premier accès au logement sur le département.
+conditions:
+link: https://www.eurelien.fr/guide/logement
+prefix: la
+type: bool
+floorAt: 10
+entity: individus

--- a/data/benefits/eure_et_loir_fsl_eligibilite_installation_logement.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_installation_logement.yml
@@ -10,4 +10,4 @@ conditions:
 link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
 prefix: l'
 type: bool
-entity: individus
+entity: menages

--- a/data/benefits/eure_et_loir_fsl_eligibilite_installation_logement.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_installation_logement.yml
@@ -4,8 +4,10 @@ description: >
   Cette aide pour des équipements de première nécessité est destinée à favoriser
   l'installation dans le cadre d'un premier accès au logement sur le département.
 conditions:
-link: https://www.eurelien.fr/guide/logement
-prefix: la
+  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté 
+  (ressources hors aide personnelle au logement, allocation logement, 
+  allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
+link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
+prefix: l'
 type: bool
-floorAt: 10
 entity: individus

--- a/data/benefits/eure_et_loir_fsl_eligibilite_installation_logement.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_installation_logement.yml
@@ -4,9 +4,9 @@ description: >
   Cette aide pour des équipements de première nécessité est destinée à favoriser
   l'installation dans le cadre d'un premier accès au logement sur le département.
 conditions:
-  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté 
-  (ressources hors aide personnelle au logement, allocation logement, 
-  allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
+  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté
+    (ressources hors aide personnelle au logement, allocation logement,
+    allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
 link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
 prefix: l'
 type: bool

--- a/data/benefits/eure_et_loir_fsl_eligibilite_maintien_fourniture.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_maintien_fourniture.yml
@@ -11,4 +11,4 @@ conditions:
 link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
 prefix: l'
 type: bool
-entity: individus
+entity: menages

--- a/data/benefits/eure_et_loir_fsl_eligibilite_maintien_fourniture.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_maintien_fourniture.yml
@@ -5,9 +5,9 @@ description: >
   et de permettre de vivre décemment dans son logement.
 conditions:
   - Être locataire ou propriétaire.
-  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté 
-  (ressources hors aide personnelle au logement, allocation logement,
-  allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
+  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté
+    (ressources hors aide personnelle au logement, allocation logement,
+    allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
 link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
 prefix: l'
 type: bool

--- a/data/benefits/eure_et_loir_fsl_eligibilite_maintien_fourniture.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_maintien_fourniture.yml
@@ -1,0 +1,11 @@
+label: aide au maintien des fournitures « Énergie-Eau-Téléphone » du fonds de solidarité pour le logement
+institution: departement_eure_et_loir
+description: >
+  Cette aide peut être versée au créancier afin de maintenir les flux
+  et de permettre de vivre décemment dans son logement.
+conditions:
+link: https://www.eurelien.fr/guide/logement
+prefix: la
+type: bool
+floorAt: 10
+entity: individus

--- a/data/benefits/eure_et_loir_fsl_eligibilite_maintien_fourniture.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_maintien_fourniture.yml
@@ -1,11 +1,14 @@
 label: aide au maintien des fournitures « Énergie-Eau-Téléphone » du fonds de solidarité pour le logement
 institution: departement_eure_et_loir
 description: >
-  Cette aide peut être versée au créancier afin de maintenir les flux
+  Cette aide peut être versée au créancier afin de maintenir les flux (Énergie-Eau-Téléphone)
   et de permettre de vivre décemment dans son logement.
 conditions:
-link: https://www.eurelien.fr/guide/logement
-prefix: la
+  - Être locataire ou propriétaire.
+  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté 
+  (ressources hors aide personnelle au logement, allocation logement,
+  allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
+link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
+prefix: l'
 type: bool
-floorAt: 10
 entity: individus

--- a/data/benefits/eure_et_loir_fsl_eligibilite_maintien_logement.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_maintien_logement.yml
@@ -1,0 +1,12 @@
+label: aide au maintien dans le logement du fonds de solidarité pour le logement
+institution: departement_eure_et_loir
+description: >
+  Cette aide, sous forme de subvention ou de prêt remboursable, peut être accordée
+  pour la mise en jeu du cautionnement, les impayés de loyer et le nettoyage
+  et les petits travaux du logement.
+conditions:
+link: https://www.eurelien.fr/guide/logement
+prefix: la
+type: bool
+floorAt: 10
+entity: individus

--- a/data/benefits/eure_et_loir_fsl_eligibilite_maintien_logement.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_maintien_logement.yml
@@ -5,8 +5,11 @@ description: >
   pour la mise en jeu du cautionnement, les impayés de loyer et le nettoyage
   et les petits travaux du logement.
 conditions:
-link: https://www.eurelien.fr/guide/logement
-prefix: la
+  - Être locataire ou propriétaire.
+  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté 
+  (ressources hors aide personnelle au logement, allocation logement,
+  allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
+link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
+prefix: l'
 type: bool
-floorAt: 10
 entity: individus

--- a/data/benefits/eure_et_loir_fsl_eligibilite_maintien_logement.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_maintien_logement.yml
@@ -12,4 +12,4 @@ conditions:
 link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
 prefix: l'
 type: bool
-entity: individus
+entity: menages

--- a/data/benefits/eure_et_loir_fsl_eligibilite_maintien_logement.yml
+++ b/data/benefits/eure_et_loir_fsl_eligibilite_maintien_logement.yml
@@ -6,9 +6,9 @@ description: >
   et les petits travaux du logement.
 conditions:
   - Être locataire ou propriétaire.
-  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté 
-  (ressources hors aide personnelle au logement, allocation logement,
-  allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
+  - Avoir des ressources inférieures ou égales à 60% du seuil de pauvreté
+    (ressources hors aide personnelle au logement, allocation logement,
+    allocation de rentrée scolaire, allocation d’éducation spéciale et ses compléments).
 link: https://www.eurelien.fr/guide/action-et-aides-sociales#guide-block-30
 prefix: l'
 type: bool

--- a/data/benefits/loire_atlantique_aide_mobilite_permis_am.yml
+++ b/data/benefits/loire_atlantique_aide_mobilite_permis_am.yml
@@ -4,7 +4,7 @@ description: |
   Cette aide est un coup de pouce du Département de Loire Atlantique pour favoriser
   l’autonomie et l’insertion des jeunes de 14 à 24 ans en finançant
   <a target="_blank" rel="noopener" href="https://www.service-public.fr/particuliers/vosdroits/F2890">le permis scooter (AM)</a>.
-conditions: 
+conditions:
   - Occuper, à titre de résidence principale, un logement sur le territoire du département de Loire Atlantique depuis <strong>plus d’un an<strong>.
   - Ne pas bénéficier d’une autre aide au permis de conduire.
   - Être inscrit·e dans une auto-école.

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -4,7 +4,7 @@ pytest == 5.3.5
 git+https://github.com/betagouv/openfisca-france.git@prd_aj_2021_04_20T15_33_12_02_00#egg=openfisca-France[bourse_criteres_sociaux]
 Openfisca-Core[web-api]==35.2.0
 # git+https://github.com/mes-aides/openfisca-core.git@fix-source-bug#egg=Openfisca-Core[web-api]
-git+https://github.com/mes-aides/openfisca-france-local.git@prod#egg=openfisca-France-Local[excel-reader]
+git+https://github.com/mes-aides/openfisca-france-local.git@prod_20210426#egg=openfisca-France-Local[excel-reader]
 git+https://github.com/openfisca/openfisca-paris.git@1333030#egg=openfisca-paris
 git+https://github.com/openfisca/openfisca-brestmetropole.git@d0a4696#egg=openfisca-BrestMetropole
 git+https://github.com/openfisca/openfisca-rennesmetropole.git@acfeae3#egg=openfisca-RennesMetropole


### PR DESCRIPTION
Ajoute le descriptif pour 4 aides de l'Eure-et-Loir (Conseil Départemental 28).
> Commentaires à venir avant demande de revue.

Informations complémentaires : 
PR de modélisation des 4 aides et périmètre modélisé (dans la description de la PR) : 
https://github.com/openfisca/openfisca-france-local/pull/75