### PR TITLE
Utilise 8 workers pour OpenFisca

### DIFF
--- a/openfisca/config.py
+++ b/openfisca/config.py
@@ -2,7 +2,7 @@ import os
 
 bind = os.getenv('OPENFISCA_BIND_HOST', '127.0.0.1:2000')
 timeout = 120
-workers = os.getenv('OPENFISCA_WORKERS', 1)
+workers = os.getenv('OPENFISCA_WORKERS', 8)
 
 profiler = False
 if profiler:


### PR DESCRIPTION
La machine sur laquelle tourne le service à 6 coeurs / 12 threads.

On est bien en dessous de [la recommandation](https://docs.gunicorn.org/en/stable/design.html#how-many-workers) (`nombre_de_coeurs` * 2 + 1) = 13 mais c'est mieux qu'un seul worker.