### PR TITLE
Supprime le lien vers le formulaire papier du FSL maintien dans un logement du Grand Lyon

### DIFF
--- a/app/js/constants/benefits/fonds_solidarite_logement.js
+++ b/app/js/constants/benefits/fonds_solidarite_logement.js
@@ -524,7 +524,7 @@ module.exports = {
         code: 'lyon',
         resources: {
             link: 'https://www.grandlyon.com/services/aides-fonds-solidarite-logement.html',
-            form: 'https://www.grandlyon.com/fileadmin/user_upload/media/pdf/habitat/20190111_fsl_demande-aide-acces-logement.pdf',
+            instructions: 'https://www.grandlyon.com/services/aides-fonds-solidarite-logement.html',
         }
     }),
     departement_saone_et_loire: fsl_generator({


### PR DESCRIPTION
Le formulaire précédent n'est plus disponible et le nouveau formulaire permet uniquement les demandes FSL pour l'accès à un logement.

La meilleure ressource restante pour les autres aides dans le cas du fond de solidarité logement est la page avec le détail des différentes déclinaisons : https://www.grandlyon.com/services/aides-fonds-solidarite-logement.html