### PR TITLE
Améliore les informations sur certains dispositifs

### DIFF
--- a/app/js/constants/benefits/fonds_solidarite_logement.js
+++ b/app/js/constants/benefits/fonds_solidarite_logement.js
@@ -524,7 +524,7 @@ module.exports = {
         code: 'lyon',
         resources: {
             link: 'https://www.grandlyon.com/services/aides-fonds-solidarite-logement.html',
-            form: 'https://www.grandlyon.com/fileadmin/user_upload/media/pdf/habitat/20190111_fsl_demande-aide-acces-logement.pdf',
+            instructions: 'https://www.grandlyon.com/services/aides-fonds-solidarite-logement.html',
         }
     }),
     departement_saone_et_loire: fsl_generator({

--- a/data/benefits/depart1825_montant_maximum.yml
+++ b/data/benefits/depart1825_montant_maximum.yml
@@ -2,9 +2,10 @@ label: départ 18-25
 institution: etat
 description: Le programme Départ 18:25 permet aux jeunes de financer jusqu’à 75% de leurs vacances pour 200€ maximum par personne et par an.
 conditions:
+  - Réserver vos vacances sur <a target="_blank" rel="noopener" href="https://www.lesstations.com/">un site partenaire</a>.
   - Financer au moins 50€ de vos vacances.
-link: https://programme-depart-1825.com/cest-quoi/
-instructions: https://programme-depart-1825.com/
+link: https://depart1825.com/nos-sejours/
+teleservice: https://www.lesstations.com/
 prefix: 'l’accès au dispositif '
 type: float
 legend: 'maximum'


### PR DESCRIPTION
## FSL Grand Lyon

> Le formulaire précédent n'est plus disponible et le nouveau formulaire permet uniquement les demandes FSL pour l'accès à un logement.
>
> La meilleure ressource restante pour les autres aides dans le cas du fond de solidarité logement est la page avec le détail des différentes déclinaisons : https://www.grandlyon.com/services/aides-fonds-solidarite-logement.html

## Départ 18-25

Suite à une investigation menée pour répondre à une usagère, nous avons découvert les contraintes supplémentaires pour bénéficier du dispositif. Nous l'ajoutons dans la liste des conditions supplémentaires pour informer au plus juste les jeunes.