### PR TITLE
Permet l'ouverture des pages dédiées dans de nouveaux onglets

### DIFF
--- a/src/components/TitreChapitre.vue
+++ b/src/components/TitreChapitre.vue
@@ -10,12 +10,12 @@
         name: 'TitreChapitre',
         computed: {
             title() {
-                return this.getTitleByRoute(this.$route)
+                return this.getTitleByRoute(this.$route, this.$store.state.situation)
             }
         },
         methods: {
-            getTitleByRoute(route) {
-                const step = this.$state.current(route.path, this.$store.state.situation)
+            getTitleByRoute(route, situation) {
+                const step = this.$store.getters.passSanityCheck && this.$state.current(route.path, situation)
                 const chapter = step && step.chapter || ''
                 switch (chapter) {
                     case 'profil':

--- a/src/router.js
+++ b/src/router.js
@@ -278,6 +278,7 @@ const router = new Router({
         }
       },
       {
+        name: 'resultatsDetails',
         path: 'resultats/:droitId',
         component: () => import(/* webpackChunkName: "resultats" */ './views/Simulation/ResultatsDetail.vue'),
       },
@@ -408,7 +409,7 @@ router.beforeEach((to, from, next) => {
   if (from.name === null) {
     store.commit('initialize')
     store.dispatch('verifyBenefitVariables')
-    if (to.matched.some(r => r.name === 'foyer' || r.name === 'simulation') && ['date_naissance', 'resultats'].indexOf(to.name) === -1 && ! store.getters.passSanityCheck) {
+    if (to.matched.some(r => r.name === 'foyer' || r.name === 'simulation') && ['date_naissance', 'resultats', 'resultatsDetails'].indexOf(to.name) === -1 && ! store.getters.passSanityCheck) {
       return store.dispatch('redirection', route => next(route))
     }
 

--- a/src/views/Simulation/ResultatsDetail.vue
+++ b/src/views/Simulation/ResultatsDetail.vue
@@ -63,7 +63,7 @@ export default {
   methods: {
     goBack: function(event) {
       event.preventDefault()
-      if (window && window.history.length > 1) {
+      if (window && window.history.length > 2) {
         history.back()
       } else {
         this.$router.push('/simulation/resultats')


### PR DESCRIPTION
Avec #1605 les pages dédiées ajoutées par #1566 ne peuvent plus être ouvertes dans de nouveaux onglets.


Cette PR corrige cette nouvelle limitation.