### PR TITLE
Affiche plus souvent la question sur les ressources parentales pour les BCS

### DIFF
--- a/src/lib/State/blocks.js
+++ b/src/lib/State/blocks.js
@@ -281,7 +281,7 @@ function generateBlocks(situation) {
     {
       isActive: situation => {
         const demandeur = situation.demandeur
-        const demandeur_ok = demandeur.activite == 'etudiant' && !demandeur.alternant && !situation.enfants.length
+        const demandeur_ok = demandeur && demandeur.activite == 'etudiant' && !demandeur.alternant && !situation.enfants.length
         const parents_ok = (!situation.parents) || ['decedes', 'sans_autorite'].indexOf(situation.parents._situation) < 0
         return demandeur_ok && parents_ok
       },

--- a/src/lib/State/blocks.js
+++ b/src/lib/State/blocks.js
@@ -282,7 +282,7 @@ function generateBlocks(situation) {
       isActive: situation => {
         const demandeur = situation.demandeur
         const demandeur_ok = demandeur.activite == 'etudiant' && !demandeur.alternant && !situation.enfants.length
-        const parents_ok = (!situation.parents) || ['decedes', 'sans_autorite'].indexOf(situation.parents._situation) < 0,
+        const parents_ok = (!situation.parents) || ['decedes', 'sans_autorite'].indexOf(situation.parents._situation) < 0
         return demandeur_ok && parents_ok
       },
       steps: [

--- a/src/lib/State/blocks.js
+++ b/src/lib/State/blocks.js
@@ -279,8 +279,12 @@ function generateBlocks(situation) {
     housingBlock(situation),
     resourceBlocks(situation),
     {
-      subject: situation => situation,
-      isActive: situation => situation.famille && situation.famille.bourse_criteres_sociaux_nombre_enfants_a_charge_dans_enseignement_superieur > 0,
+      isActive: situation => {
+        const demandeur = situation.demandeur
+        const demandeur_ok = demandeur.activite == 'etudiant' && !demandeur.alternant && !situation.enfants.length
+        const parents_ok = (!situation.parents) || ['decedes', 'sans_autorite'].indexOf(situation.parents._situation) < 0,
+        return demandeur_ok && parents_ok
+      },
       steps: [
         new Step({entity:'individu', id:'demandeur', variable: 'bourse_criteres_sociaux_base_ressources_parentale'}),
       ]


### PR DESCRIPTION
Plusieurs personnes nous ont contacté à cause d'écart constaté sur la BCS.

Il semblerait que les personnes indiquent 0 à la question « [Combien d'enfants (vous y compris) à la charge de vos parents] font des études supérieures ? » alors qu'il faudrait que ces personnes sont elles-même en études supérieures.

En attendant d'améliorer cet autre écran, à la place de n'afficher la question sur les ressources parentales uniquement lorsqu'il y a des enfants à charge en études supérieures, la question sur les ressources est posée dès que celle sur le nombre d'enfants à charge l'est.