### PR TITLE
[+] Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ tmp
 
 .v8flags.*.json
 v8-compile-cache-*/
+
+.*idea
+*yarn.lock


### PR DESCRIPTION
Cette PR permet :
- d'ignorer les fichiers de configuration liés à l'IDE WebStorm.
- d'ignorer le fichier `yarn-lock` généré par Yarn.