### PR TITLE
Ignore openfisca-france

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ v8-compile-cache-*/
 
 .*idea
 *yarn.lock
-.DS_Store
+openfisca-france


### PR DESCRIPTION
Cette PR permet d'ignorer le dossier openfisca-france lorsqu'il est téléchargé depuis la source.  