### PR TITLE
Persiste le code INSEE de la résidence parentale

### DIFF
--- a/src/views/Simulation/Individu/_BourseCriteresSociauxCommuneDomicileFamilial.vue
+++ b/src/views/Simulation/Individu/_BourseCriteresSociauxCommuneDomicileFamilial.vue
@@ -74,7 +74,7 @@ export default {
       }
       const communeMatches = this.communes.filter(c => c.nom == this.nomCommune)
       if (communeMatches.length) {
-          this.individu._BourseCriteresSociauxCommuneDomicileFamilial = communeMatches[0].code
+          this.individu._bourseCriteresSociauxCommuneDomicileFamilial = communeMatches[0].code
           this.individu._bourseCriteresSociauxCommuneDomicileFamilialCodePostal = this.codePostal.toString()
           this.individu._bourseCriteresSociauxCommuneDomicileFamilialNomCommune = this.nomCommune
           this.$store.dispatch('updateIndividu', this.individu)


### PR DESCRIPTION
Le B majuscule dans `_BourseCriteresSociauxCommuneDomicileFamilial` empêche la bonne persistance dans la base de données. Cela génère un mauvais calcul de la distance au foyer familial qui peut générer un mauvais calcul de la bourse sur critères sociaux.