### PR TITLE
Répare une erreur de typo dans la description des garanties jeunes

### DIFF
--- a/app/js/constants/benefits/index.js
+++ b/app/js/constants/benefits/index.js
@@ -361,7 +361,7 @@ var droitsDescription = {
         garantie_jeunes: {
           label: "garantie Jeunes",
           description:
-            "La garantie jeunes permet d’accompagner vers l’emploi ou la formation les jeunes entre 16 et 25 ans en situation difficile. C’est un parcours d´un an en partenariat avec la mission locale qui peut être prolongé jusqu’à 6 mois.",
+            "La garantie jeunes permet d’accompagner vers l’emploi ou la formation des jeunes entre 16 et 25 ans en situation difficile. C’est un parcours d´un an en partenariat avec la mission locale qui peut être prolongé jusqu’à 6 mois.",
           conditions: [
             'Faire votre demande d´accompagnement auprès de <a target="_blank" rel="noopener" href="https://www.unml.info/les-missions-locales/annuaire/" title="Annuaire des missions locales" >la Mission Locale</a> dont vous dépendez.',
             "Être indépendant.",


### PR DESCRIPTION
Cette PR répare une typo présente dans la description de la garantie jeune
Lien du ticket Trello : https://trello.com/c/QF8RiXVL/185-corriger-lerreur-de-typo-la-description-de-garantiejeune