### PR TITLE
Répare les identifiants des emails techniques et propose un refactor des emails 

### DIFF
--- a/src/components/ErrorBlock.vue
+++ b/src/components/ErrorBlock.vue
@@ -1,9 +1,8 @@
 <template>
   <div id="error" class="alert alert-danger" role="alert">
-    <h2
-      ><i class="fa fa-warning" aria-hidden="true"></i> Une erreur est
-      survenue.</h2
-    >
+    <h2>
+      <i class="fa fa-warning" aria-hidden="true"></i> Une erreur est survenue.
+    </h2>
 
     <div v-if="isTimeoutError" class="notification warning">
       <p
@@ -18,50 +17,36 @@
       >
     </div>
 
-    <p
-      ><a
+    <p>
+      <a
         v-analytics="{ action: 'Support', category: 'Contact' }"
-        v-mail="{
-          subject: `[${resultatsId}] Problème technique`,
-          body: `Bonjour,
-
-  J'ai tenté de XXX,
-  Et en cliquant sur XXX,
-  J'ai rencontré l'erreur ci-dessous.
-
-  Je vous joins également une capture d'écran pour faciliter la compréhension du problème.
-
-  ————
-  ID : ${resultatsId}
-  Erreur : ${errorText}
-  ————`,
-        }"
+        v-mail="this.sendErrorMail()"
         >Signalez ce problème</a
       >
       en décrivant ce que vous faisiez avant que cette erreur n'apparaisse, et
       en joignant si possible une capture d'écran. Nous vous répondrons au plus
-      vite et corrigerons le problème dès que possible.</p
-    >
-
+      vite et corrigerons le problème dès que possible.
+    </p>
     <p
       >Pour ne pas perdre les données que vous avez déclarées, vous pouvez
       garder cet onglet ouvert, puis actualiser la page une fois que le problème
       sera résolu.</p
     >
-
     <div>
-      <button v-on:click="showDetails = !showDetails">
+      <button class="button" v-on:click="showDetails = !showDetails">
         Afficher les détails techniques
       </button>
     </div>
     <small v-if="showDetails">
-      Informations techniques :
+      Informations techniques :
       <pre v-html="errorText"></pre>
     </small>
   </div>
 </template>
 
 <script>
+import { sendError } from "@/plugins/mails"
+
 export default {
   name: "ErrorBlock",
   data: function () {
@@ -85,8 +70,10 @@ export default {
     resultats: function () {
       return this.$store.state.calculs.resultats
     },
-    resultatsId: function () {
-      return (this.resultats && this.resultats._id) || "???"
+  },
+  methods: {
+    sendErrorMail() {
+      return sendError(this.$store.state.situation._id, this.errorText)
     },
   },
 }

--- a/src/components/Feedback.vue
+++ b/src/components/Feedback.vue
@@ -16,9 +16,7 @@
             action: 'Support',
             category: 'General',
           }"
-          v-mail="{
-            subject: `[${resultatsId}] Suggestion`,
-          }"
+          v-mail="this.sendMailSuggestion()"
           >Vous avez une suggestion d'amélioration</a
         >.
       </li>
@@ -29,19 +27,7 @@
             action: 'Support',
             category: 'General',
           }"
-          v-mail="{
-            subject: `[${resultatsId}] Montants inattendus`,
-            body: `Bonjour,
-En effectuant une simulation sur votre simulateur, j'ai obtenu le résultat suivant :
-- XXX € / mois pour la prestation «  ».
-Mais en effectuant la même simulation sur le site XXX, j'ai obtenu le résultat suivant :
-- XXX € / mois pour la prestation «  ».
-Vous pouvez me joindre par téléphone au XX XX XX XX XX (de préférence en semaine) pour une dizaine de minutes d'échange afin de comprendre d'où provient cet écart.
-Bonne journée,
-————
-ID : ${resultatsId} (à conserver impérativement pour traitement de votre demande)
-————`,
-          }"
+          v-mail="this.sendMailEcartSimulation()"
           >Ces résultats ne correspondent pas à ceux d'un autre simulateur</a
         >.
       </li>
@@ -52,36 +38,23 @@ ID : ${resultatsId} (à conserver impérativement pour traitement de votre deman
             action: 'Support',
             category: 'General',
           }"
-          v-mail="{
-            subject: `[${resultatsId}] Montants inattendus`,
-            body: `Bonjour,
-En effectuant une simulation sur votre simulateur, j'ai obtenu le résultat suivant :
-- XXX € / mois pour la prestation «  ».
-Mais XXX a fini par m'attribuer le montant suivant :
-- XXX € / mois pour la prestation «  ».
-J'ai bien compris que vous n'étiez pas décisionnaires et ne pourrez pas intervenir en ma faveur.
-Vous pouvez me joindre par téléphone au XX XX XX XX XX (de préférence en semaine) pour une dizaine de minutes d'échange afin de comprendre d'où provient cet écart et améliorer le simulateur pour d'autres utilisateurs.
-Bonne journée,
-————
-ID : ${resultatsId} (à conserver impérativement pour traitement de votre demande)
-————`,
-          }"
+          v-mail="this.sendMailEcartInstruction()"
           >Ces résultats ne correspondent pas à ce que l'administration vous a
           attribué</a
         >.
       </li>
     </ul>
-    <small v-if="resultatsId"
+    <small v-if="situationID"
       >Cette simulation a pour identifiant
-      <span class="preformatted">{{ resultatsId }}</span> (en savoir plus sur
+      <span class="preformatted">{{ situationID }}</span> (en savoir plus sur
       <router-link to="/confidentialite"
         >le traitement de vos données personnelles</router-link
       >).</small
     ><br />
-    <small v-if="resultatsId">
-      <button v-if="!showExpertLinks" class="button small" @click="toggleLinks"
-        >Je suis partenaire</button
-      >
+    <small v-if="situationID">
+      <button v-if="!showExpertLinks" class="button small" @click="toggleLinks">
+        Je suis partenaire
+      </button>
       <div v-if="showExpertLinks" class="aj-feedback-partenaire">
         Je suis partenaire&nbsp;:
         <ul>
@@ -112,10 +85,16 @@ ID : ${resultatsId} (à conserver impérativement pour traitement de votre deman
   </div>
 </template>
 <script>
+import {
+  sendEcartSimulation,
+  sendEcartInstructions,
+  sendSuggestion,
+} from "@/plugins/mails"
+
 export default {
   name: "Feedback",
   props: {
-    resultatsId: String,
+    situationID: String,
   },
   data: function () {
     return {
@@ -140,6 +119,15 @@ export default {
           })
       }
       this.showExpertLinks = !this.showExpertLinks
+    },
+    sendMailEcartSimulation() {
+      return sendEcartSimulation(this.situationID)
+    },
+    sendMailEcartInstruction() {
+      return sendEcartInstructions(this.situationID)
+    },
+    sendMailSuggestion() {
+      return sendSuggestion(this.situationID)
     },
   },
 }

--- a/src/plugins/mails.js
+++ b/src/plugins/mails.js
@@ -3,12 +3,17 @@ export const sendEcartInstructions = (situationID) => {
   return {
     subject: `[${situationID}] Montants inattendus`,
     body: `Bonjour,
+
     En effectuant une simulation sur votre simulateur, j'ai obtenu le résultat suivant :
     - XXX € / mois pour la prestation «  ».
     Mais en effectuant la même simulation sur le site XXX, j'ai obtenu le résultat suivant :
     - XXX € / mois pour la prestation «  ».
-    Vous pouvez me joindre par téléphone au XX XX XX XX XX (de préférence en semaine) pour une dizaine de minutes d'échange afin de comprendre d'où provient cet écart.
+
+    J'ai bien compris que vous n'étiez pas décisionnaires et ne pourrez pas intervenir en ma faveur.
+    Vous pouvez me joindre par téléphone au XX XX XX XX XX (de préférence en semaine) pour une dizaine de minutes d'échange afin de comprendre d'où provient cet écart et améliorer le simulateur pour d'autres utilisateurs.
+
     Bonne journée,
+
     ————
     ID : ${situationID} (à conserver impérativement pour traitement de votre demande)
             ————`,
@@ -19,12 +24,16 @@ export const sendEcartSimulation = (situationID) => {
   return {
     subject: `[${situationID}] Montants inattendus`,
     body: `Bonjour,
+
     En effectuant une simulation sur votre simulateur, j'ai obtenu le résultat suivant :
     - XXX € / mois pour la prestation «  ».
     Mais en effectuant la même simulation sur le site XXX, j'ai obtenu le résultat suivant :
     - XXX € / mois pour la prestation «  ».
+
     Vous pouvez me joindre par téléphone au XX XX XX XX XX (de préférence en semaine) pour une dizaine de minutes d'échange afin de comprendre d'où provient cet écart.
+
     Bonne journée,
+
     ————
     ID : ${situationID} (à conserver impérativement pour traitement de votre demande)
             ————`,
@@ -44,6 +53,7 @@ export const sendError = (situationID, error) => {
   return {
     subject: `[${situationID}] Problème technique`,
     body: `Bonjour,
+
   J'ai tenté de XXX,
   Et en cliquant sur XXX,
   J'ai rencontré l'erreur ci-dessous.

--- a/src/plugins/mails.js
+++ b/src/plugins/mails.js
@@ -1,0 +1,58 @@
+export const sendEcartInstructions = (situationID) => {
+  if (!situationID) situationID = "??"
+  return {
+    subject: `[${situationID}] Montants inattendus`,
+    body: `Bonjour,
+    En effectuant une simulation sur votre simulateur, j'ai obtenu le résultat suivant :
+    - XXX € / mois pour la prestation «  ».
+    Mais en effectuant la même simulation sur le site XXX, j'ai obtenu le résultat suivant :
+    - XXX € / mois pour la prestation «  ».
+    Vous pouvez me joindre par téléphone au XX XX XX XX XX (de préférence en semaine) pour une dizaine de minutes d'échange afin de comprendre d'où provient cet écart.
+    Bonne journée,
+    ————
+    ID : ${situationID} (à conserver impérativement pour traitement de votre demande)
+            ————`,
+  }
+}
+export const sendEcartSimulation = (situationID) => {
+  if (!situationID) situationID = "??"
+  return {
+    subject: `[${situationID}] Montants inattendus`,
+    body: `Bonjour,
+    En effectuant une simulation sur votre simulateur, j'ai obtenu le résultat suivant :
+    - XXX € / mois pour la prestation «  ».
+    Mais en effectuant la même simulation sur le site XXX, j'ai obtenu le résultat suivant :
+    - XXX € / mois pour la prestation «  ».
+    Vous pouvez me joindre par téléphone au XX XX XX XX XX (de préférence en semaine) pour une dizaine de minutes d'échange afin de comprendre d'où provient cet écart.
+    Bonne journée,
+    ————
+    ID : ${situationID} (à conserver impérativement pour traitement de votre demande)
+            ————`,
+  }
+}
+
+export const sendSuggestion = (situationID) => {
+  if (!situationID) situationID = "??"
+  return {
+    subject: `[${situationID}] Suggestion`,
+  }
+}
+
+export const sendError = (situationID, error) => {
+  if (!situationID) situationID = "??"
+  if (!error) error = "Impossible de récupérer l'erreur."
+  return {
+    subject: `[${situationID}] Problème technique`,
+    body: `Bonjour,
+  J'ai tenté de XXX,
+  Et en cliquant sur XXX,
+  J'ai rencontré l'erreur ci-dessous.
+
+  Je vous joins également une capture d'écran pour faciliter la compréhension du problème.
+
+  ————
+  ID : ${situationID}
+  Erreur : ${error}
+  ————`,
+  }
+}

--- a/src/views/Simulation/Resultats.vue
+++ b/src/views/Simulation/Resultats.vue
@@ -68,7 +68,7 @@
           v-if="!resultatStatus.updating && !isEmpty(droits)"
           v-bind:id="resultatsId"
         />
-        <Feedback :resultatsId="resultatsId" />
+        <Feedback :situationID="this.$store.state.situation._id" />
       </div>
     </div>
   </div>

--- a/src/views/Simulation/ResultatsDetail.vue
+++ b/src/views/Simulation/ResultatsDetail.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="aj-unbox">
     <LoadingModal v-if="accessStatus.fetching || resultatStatus.updating">
-      <p v-show="accessStatus.fetching"
-        >Récupération de la situation en cours…</p
-      >
+      <p v-show="accessStatus.fetching">
+        Récupération de la situation en cours…
+      </p>
       <p v-show="resultatStatus.updating">Récupération de vos droits…</p>
     </LoadingModal>
 
@@ -37,7 +37,7 @@
       />
     </div>
     <div class="aj-box normal-padding-bottom aj-results-details-feedback-box">
-      <Feedback :resultatsId="resultatsId" />
+      <Feedback :situationID="situation._id" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Cette PR :
- répare les identifiants de certains emails qui étaient cassés lorsqu'un utilisateur remonte une erreur technique (voir mail reçu 20/05/2021, 18:32)
- va plus loin que la demande initiale en proposant un refactor des emails dans le fichier FeedBack.vue

Ticket associé : https://trello.com/c/v7hp80KL/156-ajouter-lid-de-la-simulation-en-retour-derreur-openfisca