### PR TITLE
Ajoute une aide durant la saisie sur bourse_criteres_sociaux_base_ressources_parentale

### DIFF
--- a/cypress/integration/family.spec.js
+++ b/cypress/integration/family.spec.js
@@ -42,4 +42,21 @@ context("Full simulation", () => {
     steps.hasPrimeActivite(2)
     // steps.hasLogementSocial()
   })
+  it("displays a tooltip if the parents are separated ", () => {
+    steps.home()
+    steps.etudiant_public()
+    steps.zeroEnfants()
+    steps.celibataire()
+    steps.parentsSepares()
+    steps.unEnfantSuperieur()
+    steps.heberge()
+    steps.neParticipePasLogement()
+    steps.hebergeParents()
+
+    cy.get('input[type="number"').type("45200")
+    steps.submit()
+    // Ressources
+    steps.submit()
+    cy.get(".aj-tooltip")
+  })
 })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -47,6 +47,38 @@ export function demandeur(params = {}) {
   // Handicap
   handicap(params)
 }
+export function etudiant_public(params = {}) {
+  // Naissance
+  cy.get("label").invoke("text").should("contain", "naissance")
+  cy.get("#date_naissance").type(params.date_naissance || "12122000")
+  submit()
+  // Nationalite
+  cy.get("legend").invoke("text").should("contain", "nationalité")
+  autoSubmit()
+
+  cy.get('input[type="radio"]').check("fr")
+  autoSubmit()
+
+  // Activite
+  etudiant()
+
+  // Type d'études
+  enseignementSuperieur()
+
+  // Niveau d'étude
+  master1()
+
+  // Type d'établissement
+  etablissementPublic()
+
+  // Alternance
+  sansAlternance()
+
+  // Handicap
+  handicap(params)
+  // Déclaration impôts parents
+  surDeclarationParents()
+}
 
 export function handicap(params) {
   cy.get("legend").invoke("text").should("contain", "handicap")
@@ -74,7 +106,34 @@ export function handicap(params) {
     autoSubmit()
   }
 }
-
+export function etudiant() {
+  cy.get('input[type="radio"]').check("etudiant")
+  submit()
+}
+export function enseignementSuperieur() {
+  cy.get("legend").invoke("text").should("contain", `scolarisé·e`)
+  cy.get('input[type="radio"]').check("enseignement_superieur")
+  submit()
+}
+export function etablissementPublic() {
+  cy.get("legend").invoke("text").should("contain", `type`)
+  cy.get('input[type="radio"]').check("public")
+  submit()
+}
+export function master1() {
+  cy.get("legend").invoke("text").should("contain", `classe`)
+  cy.get('input[type="radio"]').check("master_1")
+  submit()
+}
+export function sansAlternance() {
+  cy.get("legend").invoke("text").should("contain", `alternance`)
+  cy.get('input[type="radio"]').check("false")
+  submit()
+}
+export function surDeclarationParents() {
+  cy.get('input[type="radio"]').check("true")
+  submit()
+}
 export function submit() {
   cy.get('button[type="submit"]').click()
 }
@@ -100,6 +159,15 @@ export function deuxEnfants() {
   cy.get("button#add-pac").click()
   enfant()
   cy.get("h2").invoke("text").should("contain", "enfants")
+  submit()
+}
+
+export function unEnfantSuperieur() {
+  cy.get("legend").invoke("text").should("contain", "la charge")
+  cy.get('input[type="number"').type("1")
+  submit()
+  cy.get("legend").invoke("text").should("contain", "des études supérieures")
+  cy.get('input[type="number"').type("1")
   submit()
 }
 
@@ -174,13 +242,55 @@ export function couple() {
   autoSubmit()
 }
 
+export function parentsSepares() {
+  cy.get("legend").invoke("text").should("contain", "parents")
+  cy.get('input[name="_situation"]').get('[value="separes"]').check()
+  submit()
+}
+export function parentsEnCouple() {
+  cy.get("legend").invoke("text").should("contain", "parents")
+  cy.get('input[name="_situation"]').get('[value="en_couple"]').check()
+  submit()
+}
+export function parentsVeufs() {
+  cy.get("legend").invoke("text").should("contain", "parents")
+  cy.get('input[name="_situation"]').get('[value="veuve"]').check()
+  submit()
+}
+export function parentsSansAutorite() {
+  cy.get("legend").invoke("text").should("contain", "parents")
+  cy.get('input[name="_situation"]').get('[value="sans_autorite"]').check()
+  submit()
+}
+
 export function sansDomicileStable() {
   cy.get('input[name="logementType"').get('[value="sansDomicile"]').check()
   submit() // Logement
   cy.get('input[type="number"').type("94120")
-  submit() // Commune de résidence
+  submit()
+}
+export function heberge() {
+  cy.get('input[name="logementType"]').get('[value="heberge"]').check()
+  submit()
+}
+export function hebergeParents() {
+  cy.get("legend").invoke("text").should("contain", "parents")
+  cy.get('input[type="radio"]').check("true")
+  submit()
 }
 
+export function participeLogement() {
+  cy.get("legend").invoke("text").should("contain", "Participez-vous")
+  cy.get("legend").invoke("text").should("contain", "logement")
+  cy.get('input[type="radio"]').check("true")
+  submit()
+}
+export function neParticipePasLogement() {
+  cy.get("legend").invoke("text").should("contain", "Participez-vous")
+  cy.get("legend").invoke("text").should("contain", "logement")
+  cy.get('input[type="radio"]').check("false")
+  submit()
+}
 export function salaireSeul() {
   cy.get("form").find('input[type="checkbox"] ').first().check()
   submit()

--- a/src/lib/Hint.js
+++ b/src/lib/Hint.js
@@ -17,6 +17,9 @@ const texts = {
   inapte_travail: function () {
     return "Vous pouvez être « inapte au travail » après un accident ou une maladie. C'est le médecin du travail qui détermine cela."
   },
+  bourse_criteres_sociaux_base_ressources_parentale: () => {
+    return "Lorsque les parents sont séparés, il faut prendre les ressources du parent ayant à la charge l'étudiant. Si l'étudiant est en garde alternée, il faut faire la somme des ressources des deux foyers fiscaux des parents séparés."
+  },
 }
 
 const Hint = {

--- a/src/views/Simulation/Individu/BourseCriteresSociauxBaseRessourcesParentale.vue
+++ b/src/views/Simulation/Individu/BourseCriteresSociauxBaseRessourcesParentale.vue
@@ -1,12 +1,14 @@
 <template>
   <form @submit.prevent="onSubmit">
     <fieldset>
-      <legend
-        ><h2 class="aj-question"
+      <legend>
+        <h2 class="aj-question"
           >Quel est le revenu brut global 2019 figurant sur l’avis fiscal 2020
-          de vos parents&nbsp;?</h2
-        ></legend
-      >
+          de vos parents&nbsp;?
+        </h2>
+        <EnSavoirPlus />
+      </legend>
+
       <label>
         <input type="number" v-select-on-click v-model.number="value" />
       </label>
@@ -18,11 +20,12 @@
 <script>
 import Actions from "@/components/Actions"
 import { createIndividuMixin } from "@/mixins/IndividuMixin"
-
+import EnSavoirPlus from "@/components/EnSavoirPlus"
 export default {
   name: "SimulationIndividuBourseCriteresSociauxBaseRessourcesParentale",
   components: {
     Actions,
+    EnSavoirPlus,
   },
   mixins: [
     createIndividuMixin("bourse_criteres_sociaux_base_ressources_parentale"),

--- a/src/views/Simulation/Individu/BourseCriteresSociauxBaseRessourcesParentale.vue
+++ b/src/views/Simulation/Individu/BourseCriteresSociauxBaseRessourcesParentale.vue
@@ -6,7 +6,8 @@
           >Quel est le revenu brut global 2019 figurant sur l’avis fiscal 2020
           de vos parents&nbsp;?
         </h2>
-        <EnSavoirPlus />
+        <!-- We only display this button if the parents are divided -->
+        <EnSavoirPlus v-if="isSepares" />
       </legend>
 
       <label>
@@ -30,5 +31,12 @@ export default {
   mixins: [
     createIndividuMixin("bourse_criteres_sociaux_base_ressources_parentale"),
   ],
+  computed: {
+    isSepares() {
+      return this.$store.state.situation.parents._situation === "separes"
+        ? true
+        : false
+    },
+  },
 }
 </script>


### PR DESCRIPTION
Cette PR ajoute une bulle d'informations qui aide l'utilisateur durant la saisie du revenu brut global.

Ticket associé : https://trello.com/c/7JiI0uP2/175-ajouter-une-aide-%C3%A0-la-saisie-sur-boursecriteressociauxbaseressourcesparentale