### PR TITLE
Met à jour Sentry et ajoute la possibilité d'identifier les bugs par release

### DIFF
--- a/configure.js
+++ b/configure.js
@@ -4,6 +4,11 @@ var bodyParser = require("body-parser")
 var morgan = require("morgan")
 var utils = require("./backend/lib/utils")
 var Sentry = require("@sentry/node")
+var fs = require("fs")
+var path = require("path")
+var packageFile = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "package.json"), "utf8")
+)
 
 module.exports = function (app) {
   Sentry.init({
@@ -13,6 +18,7 @@ module.exports = function (app) {
       process.env.NODE_ENV === "production"
         ? "https://dff4dd1245ed4ed2b05a11f513c23cb4@o548798.ingest.sentry.io/5709109"
         : null,
+    release: packageFile["version"],
   })
 
   // The request handler must be the first middleware on the app

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
       "dependencies": {
         "@babel/runtime": "^7.9.6",
         "@etalab/decoupage-administratif": "^0.8.0",
+        "@sentry/browser": "^6.2.5",
         "@sentry/integrations": "^5.15.5",
         "@sentry/node": "^5.15.5",
-        "@sentry/vue": "^6.2.5",
+        "@sentry/tracing": "^5.29.2",
+        "@sentry/vue": "^6.4.1",
         "axios": "^0.21.1",
         "body-parser": "^1.19.0",
         "communes-lonlat": "^1.1.0",
@@ -2087,13 +2089,13 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.2.5.tgz",
-      "integrity": "sha512-nlvaE+D7oaj4MxoY9ikw+krQDOjftnDYJQnOwOraXPk7KYM6YwmkakLuE+x/AkaH3FQVTQF330VAa9d6SWETlA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.4.1.tgz",
+      "integrity": "sha512-3cDud6GWutnJqcnheIq0lPNTsUJbrRLevQ+g1YfawVXFUxfmmY2bOsGd/Mxq17LxYeBHgKTitXv3DU1bsQ+WBQ==",
       "dependencies": {
-        "@sentry/core": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/core": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2101,14 +2103,14 @@
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/core": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.5.tgz",
-      "integrity": "sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.4.1.tgz",
+      "integrity": "sha512-Lx13oTiP+Tjvm5VxulcCszNVd2S1wY4viSnr+ygq62ySVERR+t7uOZDSARZ0rZ259GwW6nkbMh9dDmD0d6VCGQ==",
       "dependencies": {
-        "@sentry/hub": "6.2.5",
-        "@sentry/minimal": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/hub": "6.4.1",
+        "@sentry/minimal": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2116,12 +2118,12 @@
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/hub": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.5.tgz",
-      "integrity": "sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.4.1.tgz",
+      "integrity": "sha512-7IZRP5buDE6s/c3vWzzPR/ySE+8GUuHPgTEPiDCPOCWwUN11zXDafJDKkJqY3muJfebUKmC/JG67RyBx+XlnlQ==",
       "dependencies": {
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2129,12 +2131,12 @@
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/minimal": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.5.tgz",
-      "integrity": "sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.4.1.tgz",
+      "integrity": "sha512-4x/PRbDZACCKJqjta9EkhiIMyGMf7VgBX13EEWEDVWLP7ymFukBuTr4ap/Tz9429kB/yXZuDGGMIZp/G618H3g==",
       "dependencies": {
-        "@sentry/hub": "6.2.5",
-        "@sentry/types": "6.2.5",
+        "@sentry/hub": "6.4.1",
+        "@sentry/types": "6.4.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2142,19 +2144,19 @@
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/types": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.5.tgz",
-      "integrity": "sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-sTu/GaLsLYk1AkAqpkMT4+4q665LtZjhV0hkgiTD4N3zPl5uSf1pCIzxPRYjOpe7NEANmWv8U4PaGKGtc2eMfA==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/browser/node_modules/@sentry/utils": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.5.tgz",
-      "integrity": "sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.4.1.tgz",
+      "integrity": "sha512-xJ1uVa5fvg23pXQfulvCIBb9pQ3p1awyd1PapK2AYi+wKjTuYl4B9edmhjRREEQEExznl/d2OVm78fRXLq7M9Q==",
       "dependencies": {
-        "@sentry/types": "6.2.5",
+        "@sentry/types": "6.4.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2279,15 +2281,15 @@
       }
     },
     "node_modules/@sentry/vue": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-6.2.5.tgz",
-      "integrity": "sha512-56R43jYVV11ECe7K1//0bmRkvfCI8gnQ5HAOxfNP6FStpe6Twi2zOr8K4Mc6WmvEj03rcIj0yE6H+0Tmn1o1xA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-6.4.1.tgz",
+      "integrity": "sha512-Bq7HVbhXqcJlVd9cLs4gnCi+mwPksZ0K4E7w6ZZH1jpNYVziymL5EdhM28o83aD4YfgxEf3PHnOLBmfLfg7izA==",
       "dependencies": {
-        "@sentry/browser": "6.2.5",
-        "@sentry/core": "6.2.5",
-        "@sentry/minimal": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/browser": "6.4.1",
+        "@sentry/core": "6.4.1",
+        "@sentry/minimal": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2299,14 +2301,14 @@
       }
     },
     "node_modules/@sentry/vue/node_modules/@sentry/core": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.5.tgz",
-      "integrity": "sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.4.1.tgz",
+      "integrity": "sha512-Lx13oTiP+Tjvm5VxulcCszNVd2S1wY4viSnr+ygq62ySVERR+t7uOZDSARZ0rZ259GwW6nkbMh9dDmD0d6VCGQ==",
       "dependencies": {
-        "@sentry/hub": "6.2.5",
-        "@sentry/minimal": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/hub": "6.4.1",
+        "@sentry/minimal": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2314,12 +2316,12 @@
       }
     },
     "node_modules/@sentry/vue/node_modules/@sentry/hub": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.5.tgz",
-      "integrity": "sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.4.1.tgz",
+      "integrity": "sha512-7IZRP5buDE6s/c3vWzzPR/ySE+8GUuHPgTEPiDCPOCWwUN11zXDafJDKkJqY3muJfebUKmC/JG67RyBx+XlnlQ==",
       "dependencies": {
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2327,12 +2329,12 @@
       }
     },
     "node_modules/@sentry/vue/node_modules/@sentry/minimal": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.5.tgz",
-      "integrity": "sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.4.1.tgz",
+      "integrity": "sha512-4x/PRbDZACCKJqjta9EkhiIMyGMf7VgBX13EEWEDVWLP7ymFukBuTr4ap/Tz9429kB/yXZuDGGMIZp/G618H3g==",
       "dependencies": {
-        "@sentry/hub": "6.2.5",
-        "@sentry/types": "6.2.5",
+        "@sentry/hub": "6.4.1",
+        "@sentry/types": "6.4.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2340,19 +2342,19 @@
       }
     },
     "node_modules/@sentry/vue/node_modules/@sentry/types": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.5.tgz",
-      "integrity": "sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-sTu/GaLsLYk1AkAqpkMT4+4q665LtZjhV0hkgiTD4N3zPl5uSf1pCIzxPRYjOpe7NEANmWv8U4PaGKGtc2eMfA==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/vue/node_modules/@sentry/utils": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.5.tgz",
-      "integrity": "sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.4.1.tgz",
+      "integrity": "sha512-xJ1uVa5fvg23pXQfulvCIBb9pQ3p1awyd1PapK2AYi+wKjTuYl4B9edmhjRREEQEExznl/d2OVm78fRXLq7M9Q==",
       "dependencies": {
-        "@sentry/types": "6.2.5",
+        "@sentry/types": "6.4.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3582,15 +3584,6 @@
         "node": ">= 8.9.0"
       }
     },
-    "node_modules/@vue/cli-service/node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/@vue/cli-service/node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -4519,14 +4512,6 @@
         "follow-redirects": "^1.10.0"
       }
     },
-    "node_modules/axios/node_modules/follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -4620,93 +4605,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/@babel/generator": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
-      "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.9.6",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
-        "source-map": "^0.5.0"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/@babel/helper-function-name": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-      "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.9.5"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/@babel/helper-get-function-arity": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/@babel/template": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/@babel/traverse": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
-      "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.6",
-        "@babel/helper-function-name": "^7.9.5",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.9.6",
-        "@babel/types": "^7.9.6",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.13"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/babel-jest": {
@@ -5408,11 +5306,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "node_modules/bl/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/bl/node_modules/readable-stream": {
       "version": "2.3.7",
@@ -6757,11 +6650,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "node_modules/concat-stream/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "node_modules/concat-stream/node_modules/readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -7906,18 +7794,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cypress/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/cypress/node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7949,18 +7825,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cypress/node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.17.0"
       }
     },
     "node_modules/cypress/node_modules/universalify": {
@@ -8663,12 +8527,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "node_modules/duplexify/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
     "node_modules/duplexify/node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -8850,12 +8708,6 @@
       "engines": {
         "node": ">=4.3.0 <5.0.0 || >=5.10"
       }
-    },
-    "node_modules/enhanced-resolve/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
     },
     "node_modules/enhanced-resolve/node_modules/readable-stream": {
       "version": "2.3.7",
@@ -9624,14 +9476,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/eslint/node_modules/import-fresh": {
@@ -10690,12 +10534,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "node_modules/flush-write-stream/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
     "node_modules/flush-write-stream/node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -10724,7 +10562,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
       "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -10829,12 +10666,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "node_modules/from2/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "node_modules/from2/node_modules/readable-stream": {
@@ -11032,15 +10863,6 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
-      }
-    },
-    "node_modules/get-intrinsic/node_modules/has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-package-type": {
@@ -11504,12 +11326,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "node_modules/hpack.js/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "node_modules/hpack.js/node_modules/readable-stream": {
@@ -13563,13 +13379,6 @@
         "node": ">= 4.0"
       }
     },
-    "node_modules/jest-haste-map/node_modules/nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/jest-haste-map/node_modules/normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -14316,17 +14125,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/js-beautify/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/js-message": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.7.tgz",
@@ -14962,11 +14760,6 @@
         "json5": "lib/cli.js"
       }
     },
-    "node_modules/loader-utils/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
     "node_modules/localforage": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.8.1.tgz",
@@ -15306,12 +15099,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "node_modules/memory-fs/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "node_modules/memory-fs/node_modules/readable-stream": {
@@ -16256,14 +16043,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
-    "node_modules/mongoose/node_modules/bson": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
-      "engines": {
-        "node": ">=0.6.19"
-      }
-    },
     "node_modules/mongoose/node_modules/debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -16281,24 +16060,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
       "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
-    },
-    "node_modules/mongoose/node_modules/mongodb": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
-      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
-      "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "optionalDependencies": {
-        "saslprep": "^1.0.0"
-      }
     },
     "node_modules/mongoose/node_modules/mpath": {
       "version": "0.8.3",
@@ -16628,12 +16389,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "node_modules/node-libs-browser/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "node_modules/node-libs-browser/node_modules/punycode": {
@@ -17229,12 +16984,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "node_modules/parallel-transform/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "node_modules/parallel-transform/node_modules/readable-stream": {
@@ -18786,70 +18535,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/regexp.prototype.flags/node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/regexp.prototype.flags/node_modules/has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/regexp.prototype.flags/node_modules/is-callable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/regexp.prototype.flags/node_modules/is-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-      "dev": true,
-      "dependencies": {
-        "has-symbols": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/regexp.prototype.flags/node_modules/object-inspect": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
       "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
       "dev": true
-    },
-    "node_modules/regexp.prototype.flags/node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/regexpp": {
       "version": "3.1.0",
@@ -20082,15 +19772,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "node_modules/sockjs/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true,
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -20423,12 +20104,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "node_modules/stream-browserify/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
     "node_modules/stream-browserify/node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -20488,12 +20163,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "node_modules/stream-http/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "node_modules/stream-http/node_modules/readable-stream": {
@@ -20713,11 +20382,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "node_modules/superagent/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/superagent/node_modules/readable-stream": {
       "version": "2.3.7",
@@ -21301,12 +20965,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "node_modules/through2/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "node_modules/through2/node_modules/readable-stream": {
@@ -22561,20 +22219,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/watchpack-chokidar2/node_modules/nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/watchpack-chokidar2/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/watchpack-chokidar2/node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -23248,13 +22892,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/webpack-dev-server/node_modules/p-locate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
@@ -23266,12 +22903,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/webpack-dev-server/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
     },
     "node_modules/webpack-dev-server/node_modules/readable-stream": {
       "version": "2.3.7",
@@ -25713,59 +25344,59 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.2.5.tgz",
-      "integrity": "sha512-nlvaE+D7oaj4MxoY9ikw+krQDOjftnDYJQnOwOraXPk7KYM6YwmkakLuE+x/AkaH3FQVTQF330VAa9d6SWETlA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.4.1.tgz",
+      "integrity": "sha512-3cDud6GWutnJqcnheIq0lPNTsUJbrRLevQ+g1YfawVXFUxfmmY2bOsGd/Mxq17LxYeBHgKTitXv3DU1bsQ+WBQ==",
       "requires": {
-        "@sentry/core": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/core": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.5.tgz",
-          "integrity": "sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.4.1.tgz",
+          "integrity": "sha512-Lx13oTiP+Tjvm5VxulcCszNVd2S1wY4viSnr+ygq62ySVERR+t7uOZDSARZ0rZ259GwW6nkbMh9dDmD0d6VCGQ==",
           "requires": {
-            "@sentry/hub": "6.2.5",
-            "@sentry/minimal": "6.2.5",
-            "@sentry/types": "6.2.5",
-            "@sentry/utils": "6.2.5",
+            "@sentry/hub": "6.4.1",
+            "@sentry/minimal": "6.4.1",
+            "@sentry/types": "6.4.1",
+            "@sentry/utils": "6.4.1",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/hub": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.5.tgz",
-          "integrity": "sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.4.1.tgz",
+          "integrity": "sha512-7IZRP5buDE6s/c3vWzzPR/ySE+8GUuHPgTEPiDCPOCWwUN11zXDafJDKkJqY3muJfebUKmC/JG67RyBx+XlnlQ==",
           "requires": {
-            "@sentry/types": "6.2.5",
-            "@sentry/utils": "6.2.5",
+            "@sentry/types": "6.4.1",
+            "@sentry/utils": "6.4.1",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/minimal": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.5.tgz",
-          "integrity": "sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.4.1.tgz",
+          "integrity": "sha512-4x/PRbDZACCKJqjta9EkhiIMyGMf7VgBX13EEWEDVWLP7ymFukBuTr4ap/Tz9429kB/yXZuDGGMIZp/G618H3g==",
           "requires": {
-            "@sentry/hub": "6.2.5",
-            "@sentry/types": "6.2.5",
+            "@sentry/hub": "6.4.1",
+            "@sentry/types": "6.4.1",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/types": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.5.tgz",
-          "integrity": "sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w=="
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.4.1.tgz",
+          "integrity": "sha512-sTu/GaLsLYk1AkAqpkMT4+4q665LtZjhV0hkgiTD4N3zPl5uSf1pCIzxPRYjOpe7NEANmWv8U4PaGKGtc2eMfA=="
         },
         "@sentry/utils": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.5.tgz",
-          "integrity": "sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.4.1.tgz",
+          "integrity": "sha512-xJ1uVa5fvg23pXQfulvCIBb9pQ3p1awyd1PapK2AYi+wKjTuYl4B9edmhjRREEQEExznl/d2OVm78fRXLq7M9Q==",
           "requires": {
-            "@sentry/types": "6.2.5",
+            "@sentry/types": "6.4.1",
             "tslib": "^1.9.3"
           }
         }
@@ -25864,61 +25495,61 @@
       }
     },
     "@sentry/vue": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-6.2.5.tgz",
-      "integrity": "sha512-56R43jYVV11ECe7K1//0bmRkvfCI8gnQ5HAOxfNP6FStpe6Twi2zOr8K4Mc6WmvEj03rcIj0yE6H+0Tmn1o1xA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-6.4.1.tgz",
+      "integrity": "sha512-Bq7HVbhXqcJlVd9cLs4gnCi+mwPksZ0K4E7w6ZZH1jpNYVziymL5EdhM28o83aD4YfgxEf3PHnOLBmfLfg7izA==",
       "requires": {
-        "@sentry/browser": "6.2.5",
-        "@sentry/core": "6.2.5",
-        "@sentry/minimal": "6.2.5",
-        "@sentry/types": "6.2.5",
-        "@sentry/utils": "6.2.5",
+        "@sentry/browser": "6.4.1",
+        "@sentry/core": "6.4.1",
+        "@sentry/minimal": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.5.tgz",
-          "integrity": "sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.4.1.tgz",
+          "integrity": "sha512-Lx13oTiP+Tjvm5VxulcCszNVd2S1wY4viSnr+ygq62ySVERR+t7uOZDSARZ0rZ259GwW6nkbMh9dDmD0d6VCGQ==",
           "requires": {
-            "@sentry/hub": "6.2.5",
-            "@sentry/minimal": "6.2.5",
-            "@sentry/types": "6.2.5",
-            "@sentry/utils": "6.2.5",
+            "@sentry/hub": "6.4.1",
+            "@sentry/minimal": "6.4.1",
+            "@sentry/types": "6.4.1",
+            "@sentry/utils": "6.4.1",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/hub": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.5.tgz",
-          "integrity": "sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.4.1.tgz",
+          "integrity": "sha512-7IZRP5buDE6s/c3vWzzPR/ySE+8GUuHPgTEPiDCPOCWwUN11zXDafJDKkJqY3muJfebUKmC/JG67RyBx+XlnlQ==",
           "requires": {
-            "@sentry/types": "6.2.5",
-            "@sentry/utils": "6.2.5",
+            "@sentry/types": "6.4.1",
+            "@sentry/utils": "6.4.1",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/minimal": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.5.tgz",
-          "integrity": "sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.4.1.tgz",
+          "integrity": "sha512-4x/PRbDZACCKJqjta9EkhiIMyGMf7VgBX13EEWEDVWLP7ymFukBuTr4ap/Tz9429kB/yXZuDGGMIZp/G618H3g==",
           "requires": {
-            "@sentry/hub": "6.2.5",
-            "@sentry/types": "6.2.5",
+            "@sentry/hub": "6.4.1",
+            "@sentry/types": "6.4.1",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/types": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.5.tgz",
-          "integrity": "sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w=="
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.4.1.tgz",
+          "integrity": "sha512-sTu/GaLsLYk1AkAqpkMT4+4q665LtZjhV0hkgiTD4N3zPl5uSf1pCIzxPRYjOpe7NEANmWv8U4PaGKGtc2eMfA=="
         },
         "@sentry/utils": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.5.tgz",
-          "integrity": "sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.4.1.tgz",
+          "integrity": "sha512-xJ1uVa5fvg23pXQfulvCIBb9pQ3p1awyd1PapK2AYi+wKjTuYl4B9edmhjRREEQEExznl/d2OVm78fRXLq7M9Q==",
           "requires": {
-            "@sentry/types": "6.2.5",
+            "@sentry/types": "6.4.1",
             "tslib": "^1.9.3"
           }
         }
@@ -27020,17 +26651,6 @@
             "source-map": "^0.6.1",
             "terser": "^4.6.12",
             "webpack-sources": "^1.4.3"
-          },
-          "dependencies": {
-            "serialize-javascript": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-              "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-              "dev": true,
-              "requires": {
-                "randombytes": "^2.1.0"
-              }
-            }
           }
         },
         "wrap-ansi": {
@@ -27850,13 +27470,6 @@
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
         "follow-redirects": "^1.10.0"
-      },
-      "dependencies": {
-        "follow-redirects": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
-        }
       }
     },
     "babel-code-frame": {
@@ -27936,92 +27549,6 @@
         "@babel/types": "^7.7.0",
         "eslint-visitor-keys": "^1.0.0",
         "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.9.6",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
-          "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.9.6",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.9.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-          "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.8.3",
-            "@babel/template": "^7.8.3",
-            "@babel/types": "^7.9.5"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/template": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/parser": "^7.8.6",
-            "@babel/types": "^7.8.6"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.9.6",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
-          "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.9.6",
-            "@babel/helper-function-name": "^7.9.5",
-            "@babel/helper-split-export-declaration": "^7.8.3",
-            "@babel/parser": "^7.9.6",
-            "@babel/types": "^7.9.6",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "babel-jest": {
@@ -28627,11 +28154,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "readable-stream": {
           "version": "2.3.7",
@@ -29799,11 +29321,6 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-        },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -30765,15 +30282,6 @@
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
         "shebang-command": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -30796,15 +30304,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        },
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "dev": true,
-          "requires": {
-            "rimraf": "^3.0.0"
           }
         },
         "universalify": {
@@ -31384,12 +30883,6 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-          "dev": true
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -31553,12 +31046,6 @@
             "errno": "^0.1.3",
             "readable-stream": "^2.0.1"
           }
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
@@ -31880,11 +31367,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
         "import-fresh": {
           "version": "3.2.1",
@@ -33003,12 +32485,6 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-          "dev": true
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -33038,8 +32514,7 @@
     "follow-redirects": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==",
-      "dev": true
+      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
     },
     "font-awesome": {
       "version": "4.7.0",
@@ -33120,12 +32595,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
         "readable-stream": {
@@ -33297,14 +32766,6 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
-      },
-      "dependencies": {
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        }
       }
     },
     "get-package-type": {
@@ -33704,12 +33165,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
         "readable-stream": {
@@ -35491,13 +34946,6 @@
             "nan": "^2.12.1"
           }
         },
-        "nan": {
-          "version": "2.14.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-          "dev": true,
-          "optional": true
-        },
         "normalize-path": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -35993,13 +35441,6 @@
         "glob": "^7.1.3",
         "mkdirp": "^1.0.4",
         "nopt": "^5.0.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        }
       }
     },
     "js-message": {
@@ -36523,11 +35964,6 @@
           "requires": {
             "minimist": "^1.2.0"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -36832,12 +36268,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
         "readable-stream": {
@@ -37682,11 +37112,6 @@
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
           "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
-        "bson": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
-        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -37706,19 +37131,6 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
           "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
-        },
-        "mongodb": {
-          "version": "3.6.3",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
-          "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
-          "requires": {
-            "bl": "^2.2.1",
-            "bson": "^1.1.4",
-            "denque": "^1.4.1",
-            "require_optional": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "saslprep": "^1.0.0"
-          }
         },
         "mpath": {
           "version": "0.8.3",
@@ -38015,12 +37427,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
         "punycode": {
@@ -38507,12 +37913,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
         "readable-stream": {
@@ -39851,55 +39251,11 @@
             "string.prototype.trimstart": "^1.0.1"
           }
         },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-          "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-          "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-          "dev": true,
-          "requires": {
-            "has-symbols": "^1.0.1"
-          }
-        },
         "object-inspect": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
           "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
           "dev": true
-        },
-        "object.assign": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3",
-            "has-symbols": "^1.0.1",
-            "object-keys": "^1.1.1"
-          }
         }
       }
     },
@@ -40928,14 +40284,6 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^3.4.0",
         "websocket-driver": "^0.7.4"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        }
       }
     },
     "sockjs-client": {
@@ -41255,12 +40603,6 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-          "dev": true
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -41322,12 +40664,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
         "readable-stream": {
@@ -41514,11 +40850,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "readable-stream": {
           "version": "2.3.7",
@@ -42023,12 +41354,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
         "readable-stream": {
@@ -43101,20 +42426,6 @@
             "is-buffer": "^1.1.5"
           }
         },
-        "nan": {
-          "version": "2.14.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-          "dev": true,
-          "optional": true
-        },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -43695,13 +43006,6 @@
             "path-exists": "^3.0.0"
           }
         },
-        "nan": {
-          "version": "2.14.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-          "dev": true,
-          "optional": true
-        },
         "p-locate": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
@@ -43710,12 +43014,6 @@
           "requires": {
             "p-limit": "^2.0.0"
           }
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   "dependencies": {
     "@babel/runtime": "^7.9.6",
     "@etalab/decoupage-administratif": "^0.8.0",
+    "@sentry/browser": "^6.2.5",
     "@sentry/integrations": "^5.15.5",
     "@sentry/node": "^5.15.5",
-    "@sentry/vue": "^6.2.5",
+    "@sentry/tracing": "^5.29.2",
+    "@sentry/vue": "^6.4.1",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "communes-lonlat": "^1.1.0",

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import Vue from "vue"
 import App from "./App.vue"
 import router from "./router"
 import store from "./store"
-
+import pck from "../package.json"
 import moment from "moment"
 
 import ScrollService from "./plugins/ScrollService"
@@ -13,7 +13,6 @@ import AsyncComputed from "vue-async-computed"
 import * as Sentry from "@sentry/vue"
 import Vuelidate from "vuelidate"
 import VueMatomo from "vue-matomo"
-
 import "template.data.gouv.fr/dist/main.css"
 import "font-awesome/scss/font-awesome.scss"
 import "@/styles/main.scss"
@@ -37,6 +36,7 @@ if (process.env.NODE_ENV === "production") {
   Sentry.init({
     Vue,
     dsn: "https://80847fcdc7e74cbfb9d2f47751e42889@o548798.ingest.sentry.io/5709078",
+    release: pck.version,
   })
 }
 


### PR DESCRIPTION
Cette PR permet de mettre à jour la version de Sentry tout en ajoutant la possibilité d'avoir une visibilité des erreurs par realease. 

A savoir : J'ai bien vérifié que je n'avais rien cassé, en levant une exception personnalisée, lorsque j'ai mis à jour les dépendances : https://sentry.io/organizations/betagouv-f7/issues/2418365227/?project=5709078 