### PR TITLE
Modification placement indication AAHRestrictionSubstantielleDurableAccesEmploi.vue

### DIFF
--- a/src/views/Simulation/Individu/Handicap/AAHRestrictionSubstantielleDurableAccesEmploi.vue
+++ b/src/views/Simulation/Individu/Handicap/AAHRestrictionSubstantielleDurableAccesEmploi.vue
@@ -4,7 +4,6 @@
       {{ getLabel('avoir') | capitalize }} une restriction substantielle et durable d'accès à l'emploi reconnue par la <abbr title="Commission des droits et de l'autonomie des personnes handicapées">CDAPH</abbr>&nbsp;?
     <p>Attention, cette restriction est différente de la reconnaissance de la qualité de travailleur handicapé.</p>
     </YesNoQuestion>
-  
     <Actions v-bind:onSubmit='onSubmit'/>
   </form>
 </template>

--- a/src/views/Simulation/Individu/Handicap/AAHRestrictionSubstantielleDurableAccesEmploi.vue
+++ b/src/views/Simulation/Individu/Handicap/AAHRestrictionSubstantielleDurableAccesEmploi.vue
@@ -2,8 +2,9 @@
   <form @submit.prevent='onSubmit'>
     <YesNoQuestion v-model="value">
       {{ getLabel('avoir') | capitalize }} une restriction substantielle et durable d'accès à l'emploi reconnue par la <abbr title="Commission des droits et de l'autonomie des personnes handicapées">CDAPH</abbr>&nbsp;?
-    </YesNoQuestion>
     <p>Attention, cette restriction est différente de la reconnaissance de la qualité de travailleur handicapé.</p>
+    </YesNoQuestion>
+  
     <Actions v-bind:onSubmit='onSubmit'/>
   </form>
 </template>


### PR DESCRIPTION
En terme d'accessibilité, mieux vaut placer l'indication "Attention, cette restriction est différente de la reconnaissance de la qualité de travailleur handicapé." avant les questions si c'est possible. Qu'en pensez-vous ?

(Bien vérifier l'emplacement du paragraphe car je ne suis pas sûr que cela fonctionne vraiment de cette façon.