### PR TITLE
Rapproche le texte d'aide des intitulés de question

### DIFF
--- a/src/components/YesNoQuestion.vue
+++ b/src/components/YesNoQuestion.vue
@@ -1,8 +1,8 @@
 <template>
   <fieldset>
     <legend
-      ><h2 class="aj-question"><slot></slot><slot name="help"></slot></h2>
-      <slot name="description"></slot>
+      ><h2 class="aj-question"><slot></slot></h2>
+      <slot name="help"></slot>
     </legend>
     <div class="aj-selection-wrapper">
       <input

--- a/src/components/YesNoQuestion.vue
+++ b/src/components/YesNoQuestion.vue
@@ -1,8 +1,9 @@
 <template>
   <fieldset>
     <legend
-      ><h2 class="aj-question"><slot></slot><slot name="help"></slot></h2
-    ></legend>
+      ><h2 class="aj-question"><slot></slot><slot name="help"></slot></h2>
+      <slot name="description"></slot>
+    </legend>
     <div class="aj-selection-wrapper">
       <input
         :id="'yes-' + uniqueFieldName"

--- a/src/views/Foyer/Ressources/Patrimoine.vue
+++ b/src/views/Foyer/Ressources/Patrimoine.vue
@@ -38,7 +38,9 @@
     <YesNoQuestion class="form__group" v-model="hasBatisNonLoues">
       Avez-vous des appartements/immeubles <b>non loués</b> ?
       <template v-slot:help>
-        Sauf résidence principale et bâtiments de l'exploitation agricole.
+        <p>
+          Sauf résidence principale et bâtiments de l'exploitation agricole.
+        </p>
       </template>
     </YesNoQuestion>
 

--- a/src/views/Simulation/Individu/Handicap/AAHRestrictionSubstantielleDurableAccesEmploi.vue
+++ b/src/views/Simulation/Individu/Handicap/AAHRestrictionSubstantielleDurableAccesEmploi.vue
@@ -14,7 +14,6 @@
         >
       </template>
     </YesNoQuestion>
-
     <Actions v-bind:onSubmit="onSubmit" />
   </form>
 </template>

--- a/src/views/Simulation/Individu/Handicap/AAHRestrictionSubstantielleDurableAccesEmploi.vue
+++ b/src/views/Simulation/Individu/Handicap/AAHRestrictionSubstantielleDurableAccesEmploi.vue
@@ -7,11 +7,14 @@
         title="Commission des droits et de l'autonomie des personnes handicapées"
         >CDAPH</abbr
       >&nbsp;?
+      <template v-slot:description>
+        <p
+          >Attention, cette restriction est différente de la reconnaissance de
+          la qualité de travailleur handicapé.</p
+        >
+      </template>
     </YesNoQuestion>
-    <p
-      >Attention, cette restriction est différente de la reconnaissance de la
-      qualité de travailleur handicapé.</p
-    >
+
     <Actions v-bind:onSubmit="onSubmit" />
   </form>
 </template>

--- a/src/views/Simulation/Individu/Handicap/AAHRestrictionSubstantielleDurableAccesEmploi.vue
+++ b/src/views/Simulation/Individu/Handicap/AAHRestrictionSubstantielleDurableAccesEmploi.vue
@@ -7,7 +7,7 @@
         title="Commission des droits et de l'autonomie des personnes handicapées"
         >CDAPH</abbr
       >&nbsp;?
-      <template v-slot:description>
+      <template v-slot:help>
         <p
           >Attention, cette restriction est différente de la reconnaissance de
           la qualité de travailleur handicapé.</p

--- a/src/views/Simulation/Menage/Loyer.vue
+++ b/src/views/Simulation/Menage/Loyer.vue
@@ -62,7 +62,7 @@ export default {
         loyerQuestion: {
           label: loyerLabel,
           selectedValue: menage.loyer,
-          hint: "Hors aides au logement.",
+          hint: "Sans déduire vos aides au logement si vous en avez.",
         },
         chargesQuestion: {
           label: "Quel est le montant de vos charges locatives ?",

--- a/src/views/Simulation/Menage/Loyer.vue
+++ b/src/views/Simulation/Menage/Loyer.vue
@@ -62,6 +62,7 @@ export default {
         loyerQuestion: {
           label: loyerLabel,
           selectedValue: menage.loyer,
+          hint: "Hors aides au logement…",
         },
         chargesQuestion: {
           label: "Quel est le montant de vos charges locatives ?",

--- a/src/views/Simulation/Menage/Loyer.vue
+++ b/src/views/Simulation/Menage/Loyer.vue
@@ -62,7 +62,7 @@ export default {
         loyerQuestion: {
           label: loyerLabel,
           selectedValue: menage.loyer,
-          hint: "Hors aides au logement…",
+          hint: "Hors aides au logement.",
         },
         chargesQuestion: {
           label: "Quel est le montant de vos charges locatives ?",


### PR DESCRIPTION
Permet d'avoir un texte de description dans les `YesNoQuestion`

![image](https://user-images.githubusercontent.com/65901733/119979138-d303dc80-bfba-11eb-9aff-0b5302b29e2b.png)
