### PR TITLE
Force la regénération des vues d'une route à l'autre

### DIFF
--- a/src/views/Simulation.vue
+++ b/src/views/Simulation.vue
@@ -12,7 +12,7 @@
         <div class="message" v-html="$store.state.message.text" />
       </div>
       <div class="aj-box-wrapper">
-        <router-view />
+        <router-view v-bind:key="$route.path" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
* Assure le recalcul de data entre deux routes. Problématique sur les écrans de saisie des types de ressources perçues lorsque le demandeur n'est perçoit aucune et que le conjoint est en situation de handicap, l'AAH n'apparaissait pas pour le conjoint car l'individu de référence restait le demandeur

Dédicace à @LucasCharrier 

@Kout95 ça devrait permet de limiter encore plus la complexité de #1670 .