### PR TITLE
Étend la place pour le déroulé des questions et surtout les résultats

### DIFF
--- a/src/styles/partials/desktop/_ui-kit.scss
+++ b/src/styles/partials/desktop/_ui-kit.scss
@@ -93,7 +93,7 @@ html {
     }
 
     .aj-main-container {
-      padding: 3% 15% 12% 15%;
+      padding: 4% 4% 4% 4%;
       background-color: #f2f5f9;
       width: 100%;
 


### PR DESCRIPTION
En répondant aux usagers, je me suis rendu compte que sur ordinateur la place donnée au simulateur en tant que telle avait beaucoup diminuée suite à l'introduction du sommaire sur la gauche.

Avant
 https://mes-aides.1jeune1solution.beta.gouv.fr/simulation/resultats?debug=aide_mobilite_parcoursup,aide_mobilite_master

Après
https://60cb7c79381eb10008af5526--aides-jeunes.netlify.app/simulation/resultats?debug=aide_mobilite_parcoursup,aide_mobilite_master