### PR TITLE
Ne délègue par le calcul de l'éligibilite au logement CROUS à OpenFisca

### DIFF
--- a/backend/lib/mes-aides/index.js
+++ b/backend/lib/mes-aides/index.js
@@ -34,7 +34,7 @@ function valueAt(ressourceId, ressources, period, aide) {
 }
 
 function round(amount, aide) {
-  if (aide.type && aide.type !== "float") {
+  if (aide.type && aide.type == "bool") {
     return Boolean(amount)
   }
 
@@ -90,10 +90,8 @@ function computeAides(situation, openfiscaResponse, showPrivate) {
     var value = valueAt(aideId + "_non_calculable", computedRessources, period)
 
     if (!value || value === "calculable") {
-      value = round(
-        valueAt(aide.internal_flag || aideId, computedRessources, period, aide),
-        aide
-      )
+      const source = aide.openfisca_eligibility_source || aideId
+      value = round(valueAt(source, computedRessources, period, aide), aide)
     }
 
     var dest = value ? result.droitsEligibles : result.droitsNonEligibles

--- a/backend/lib/mes-aides/index.js
+++ b/backend/lib/mes-aides/index.js
@@ -35,7 +35,7 @@ function valueAt(ressourceId, ressources, period, aide) {
 
 function round(amount, aide) {
   if (aide.type && aide.type !== "float") {
-    return amount
+    return Boolean(amount)
   }
 
   var rounding = aide.floorAt || 1
@@ -90,7 +90,10 @@ function computeAides(situation, openfiscaResponse, showPrivate) {
     var value = valueAt(aideId + "_non_calculable", computedRessources, period)
 
     if (!value || value === "calculable") {
-      value = round(valueAt(aideId, computedRessources, period, aide), aide)
+      value = round(
+        valueAt(aide.internal_flag || aideId, computedRessources, period, aide),
+        aide
+      )
     }
 
     var dest = value ? result.droitsEligibles : result.droitsNonEligibles

--- a/backend/lib/openfisca/mapping/common.js
+++ b/backend/lib/openfisca/mapping/common.js
@@ -51,7 +51,8 @@ exports.getPeriods = function (dateDeValeur) {
 
 let requestedVariables = {}
 forEach((aide, aideId) => {
-  requestedVariables[aide.internal_flag || aideId] = assign({}, aide)
+  const item = aide.openfisca_eligibility_source || aideId
+  requestedVariables[item] = requestedVariables[item] || assign({}, aide)
   if (aide.uncomputability)
     requestedVariables[aideId + "_non_calculable"] = assign({}, aide, {
       type: "string",
@@ -59,7 +60,7 @@ forEach((aide, aideId) => {
 
   if (aide.extra) {
     aide.extra.forEach(function (extra) {
-      requestedVariables[extra.id] = assign({}, extra)
+      requestedVariables[extra.id] = requestedVariables[extra.id] || assign({}, extra)
     })
   }
 })

--- a/backend/lib/openfisca/mapping/common.js
+++ b/backend/lib/openfisca/mapping/common.js
@@ -60,7 +60,8 @@ forEach((aide, aideId) => {
 
   if (aide.extra) {
     aide.extra.forEach(function (extra) {
-      requestedVariables[extra.id] = requestedVariables[extra.id] || assign({}, extra)
+      requestedVariables[extra.id] =
+        requestedVariables[extra.id] || assign({}, extra)
     })
   }
 })

--- a/backend/lib/openfisca/mapping/common.js
+++ b/backend/lib/openfisca/mapping/common.js
@@ -51,7 +51,7 @@ exports.getPeriods = function (dateDeValeur) {
 
 let requestedVariables = {}
 forEach((aide, aideId) => {
-  requestedVariables[aideId] = assign({}, aide)
+  requestedVariables[aide.internal_flag || aideId] = assign({}, aide)
   if (aide.uncomputability)
     requestedVariables[aideId + "_non_calculable"] = assign({}, aide, {
       type: "string",

--- a/data/benefits/crous_logement_eligibilite.yml
+++ b/data/benefits/crous_logement_eligibilite.yml
@@ -9,4 +9,4 @@ prefix: un
 type: bool
 top: 2
 entity: individus
-internal_flag: bourse_criteres_sociaux
+openfisca_eligibility_source: bourse_criteres_sociaux

--- a/data/benefits/crous_logement_eligibilite.yml
+++ b/data/benefits/crous_logement_eligibilite.yml
@@ -9,3 +9,4 @@ prefix: un
 type: bool
 top: 2
 entity: individus
+internal_flag: bourse_criteres_sociaux

--- a/src/store.js
+++ b/src/store.js
@@ -501,10 +501,8 @@ const store = new Vuex.Store({
         .then((variableNames) => {
           let missingBenefits = []
           Institution.forEachBenefit((benefit, benefitId) => {
-            if (
-              !benefit.test &&
-              variableNames.indexOf(benefit.openfisca_eligibility_source || benefitId) < 0
-            ) {
+            const source = benefit.openfisca_eligibility_source || benefitId
+            if (!benefit.test && variableNames.indexOf(source) < 0) {
               missingBenefits.push(benefitId)
             }
           })

--- a/src/store.js
+++ b/src/store.js
@@ -501,7 +501,10 @@ const store = new Vuex.Store({
         .then((variableNames) => {
           let missingBenefits = []
           Institution.forEachBenefit((benefit, benefitId) => {
-            if (!benefit.test && variableNames.indexOf(benefitId) < 0) {
+            if (
+              !benefit.test &&
+              variableNames.indexOf(benefit.internal_flag || benefitId) < 0
+            ) {
               missingBenefits.push(benefitId)
             }
           })

--- a/src/store.js
+++ b/src/store.js
@@ -503,7 +503,7 @@ const store = new Vuex.Store({
           Institution.forEachBenefit((benefit, benefitId) => {
             if (
               !benefit.test &&
-              variableNames.indexOf(benefit.internal_flag || benefitId) < 0
+              variableNames.indexOf(benefit.openfisca_eligibility_source || benefitId) < 0
             ) {
               missingBenefits.push(benefitId)
             }


### PR DESCRIPTION
L'estimation de l'éligibilité au logement CROUS n'a pas vocation à [être ajouté à OpenFisca](https://github.com/openfisca/openfisca-france/pull/1493). Comme nous souhaitons le présenter dans le simulateur, il faut mettre en place une logique élémentaire de calculs du côté du front.

La logique implémentée côté front est sciemment simple/limitée. C'est pour éviter de normaliser cette pratique qui aurait pour conséquence négative de ne pas alimenter OpenFisca et de faire des calculs uniquement dans le front.

J'aurais pu reprendre [le hack qui est fait pour la complémentaire santé solidaire](https://github.com/betagouv/aides-jeunes/blob/master/app/js/constants/benefits/index.js#L51-L59) mais comme l'ambition est de passer les informations textuelles du fichier JS à des fichiers YAML j'ai choisi cette approche.