### PR TITLE
Supprime l'erreur navigation cancelled

### DIFF
--- a/src/plugins/StateService.js
+++ b/src/plugins/StateService.js
@@ -13,11 +13,18 @@ const StateService = {
       const nextStep = next(this.$route, this.$store.getters.getAllSteps)
       this.$router.push(nextStep.path).catch((failure) => {
         if (
-          !VueRouter.isNavigationFailure(
+          VueRouter.isNavigationFailure(
             failure,
             VueRouter.NavigationFailureType.cancelled
           )
         ) {
+          this.$matomo &&
+            this.$matomo.trackEvent(
+              "Parcours",
+              "Navigation cancelled",
+              failure.toString()
+            )
+        } else {
           throw new Error(failure)
         }
       })

--- a/src/plugins/StateService.js
+++ b/src/plugins/StateService.js
@@ -1,4 +1,5 @@
 import { next, current, chapters } from "@/lib/State"
+import VueRouter from "vue-router"
 
 const StateService = {
   install(Vue) {
@@ -11,7 +12,14 @@ const StateService = {
     Vue.prototype.$push = function () {
       const nextStep = next(this.$route, this.$store.getters.getAllSteps)
       this.$router.push(nextStep.path).catch((failure) => {
-        throw new Error(failure)
+        if (
+          !VueRouter.isNavigationFailure(
+            failure,
+            VueRouter.NavigationFailureType.cancelled
+          )
+        ) {
+          throw new Error(failure)
+        }
       })
     }
   },


### PR DESCRIPTION
Le problème vient du fait que l'utilisateur a le temps de cliquer plusieurs fois sur le bouton push et que l'utilisateur charge les prochaines steps (Webpack).
Le router vue écrase la route qui est en cours de chargement et raise une erreur.
Étant donné que le problème, il ne gêne pas le parcours utilisateur, je pense qu'on peut le considérer comme un faux problème, et éviter de faire des modifications qui peuvent créer de réels problèmes.