### PR TITLE
Corrige la contrainte de date d'obtention du dernier diplôme

### DIFF
--- a/src/lib/State/blocks.js
+++ b/src/lib/State/blocks.js
@@ -177,8 +177,8 @@ function individuBlockFactory(id) {
                     r("plus_haut_diplome_date_obtention"),
                     {
                       isActive: (subject) =>
-                        subject.plus_haut_diplome_date_obtention <
-                        new Date("2021-01-01 00:00:00"),
+                        subject.plus_haut_diplome_date_obtention >=
+                        new Date("2019-12-31 00:00:00"),
                       steps: [
                         r("_boursier_derniere_annee_etudes"),
                         {


### PR DESCRIPTION
Les diplômé.e.s de 2020 et 2021 sont éligibles à l'aide jeune diplômé ancien boursier et il faut donc leur poser des questions supplémentaires.