### PR TITLE
Ajoute un téléservice pour le PNDS

### DIFF
--- a/backend/config/development.js
+++ b/backend/config/development.js
@@ -8,6 +8,7 @@ module.exports = {
   teleserviceAccessTokens: {
     loiret_APA_test: "token",
     loiret_APA: "token",
+    PNDS: "token",
   },
   matomo: {
     id: 170,

--- a/backend/controllers/teleservices/index.js
+++ b/backend/controllers/teleservices/index.js
@@ -9,6 +9,7 @@ var Loiret = require("../../lib/teleservices/loiret")
 var OpenFiscaAxe = require("../../lib/teleservices/openfisca-axe")
 var OpenFiscaResponse = require("../../lib/teleservices/openfisca-response")
 var OpenFiscaTracer = require("../../lib/teleservices/openfisca-tracer")
+var PNDS = require("../../lib/teleservices/pnds")
 
 moment.locale("fr")
 
@@ -53,6 +54,13 @@ var teleservices = [
     public: true,
     destination: {
       url: "{{&openfiscaAxeURL}}/graphique?source={{&baseURL}}/api/situations/via/{{token}}",
+    },
+  },
+  {
+    name: "PNDS",
+    class: PNDS,
+    destination: {
+      url: "https://www.mesdroitssociaux.gouv.fr?token={{token}}",
     },
   },
 ]

--- a/backend/lib/teleservices/pnds.js
+++ b/backend/lib/teleservices/pnds.js
@@ -1,0 +1,15 @@
+var openfisca = require("../openfisca")
+
+function PNDS(situation) {
+  this.situation = situation
+}
+
+PNDS.prototype.toInternal = function () {
+  return {}
+}
+
+PNDS.prototype.toExternal = function () {
+  return openfisca.buildOpenFiscaRequest(this.situation)
+}
+
+module.exports = PNDS

--- a/src/components/Feedback.vue
+++ b/src/components/Feedback.vue
@@ -79,6 +79,14 @@
               >Analysez l'évolution des aides en fonction des ressources
             </a>
           </li>
+          <li v-if="PNDSURL">
+            <a
+              v-analytics="{ category: 'PNDS' }"
+              target="_blank"
+              :href="PNDSURL"
+              >Transférer les données au PNDS
+            </a>
+          </li>
         </ul>
       </div>
     </small>
@@ -100,6 +108,7 @@ export default {
     return {
       openfiscaTracerURL: false,
       openfiscaAxeURL: false,
+      PNDSURL: false,
       showExpertLinks: false,
     }
   },
@@ -116,6 +125,12 @@ export default {
           .fetchRepresentation("openfisca_axe")
           .then((representation) => {
             this.openfiscaAxeURL = representation.destination.url
+          })
+
+        this.$store.getters
+          .fetchRepresentation("PNDS")
+          .then((representation) => {
+            this.PNDSURL = representation.destination.url
           })
       }
       this.showExpertLinks = !this.showExpertLinks


### PR DESCRIPTION
Nous souhaitons permettre le transfert des informations saisies dans le simulateur vers les organismes qui instruisent les dossiers pour éviter les saisies multiples.


Avec ce téléservice, nous mettons en place la mécanique de transfert.
Les usagers ne sont pas impactés, ce nouveau téléservice n'est accessible qu'à partir des liens pour les partenaires.