### PR TITLE
Ajoute un filtre par categorie pour la page résultat en mode debug

### DIFF
--- a/src/lib/BenefitsCategories.js
+++ b/src/lib/BenefitsCategories.js
@@ -1,0 +1,15 @@
+export default {
+  aide_permis: [
+    "aide_financement_permis_apprenti",
+    "aide_permis_demandeur_emploi",
+    "aide_permis_pro_btp",
+    "cambrai_aide_mobilite_permis_b",
+    "haut_de_france_aide_permis",
+    "iwuy_aide_mobilite_permis",
+    "le_cateau_aide_mobilite_permis",
+    "les_rues_des_vignes_aide_mobilite_permis",
+    "loire_atlantique_aide_mobilite_permis_am",
+    "loire_atlantique_aide_mobilite_permis_b",
+    "pret_formation_permis_eligibilite",
+  ],
+}

--- a/src/lib/Institution.js
+++ b/src/lib/Institution.js
@@ -1,11 +1,15 @@
 import jamstack from "jamstack-loader!./../../contribuer/public/admin/config.yml"
 import * as droitsDescription from "@/../app/js/constants/benefits"
+import BenefitsCategories from "@/lib/BenefitsCategories"
 
 const Institution = droitsDescription.generate(jamstack)
 Institution.forEachBenefit = Institution.forEach
 
 Institution.mockResults = function (sublist) {
-  sublist = sublist ? sublist.split(",") : null
+  let filterSublist
+  if (sublist) {
+    filterSublist = BenefitsCategories[sublist] || sublist.split(",")
+  }
   const list = []
 
   const defaults = {
@@ -22,7 +26,7 @@ Institution.mockResults = function (sublist) {
       mock: true,
     })
 
-    if (!sublist || sublist.indexOf(aideId) !== -1) {
+    if (!filterSublist || filterSublist.includes(aideId)) {
       list.push(addition)
     }
   })


### PR DESCRIPTION
Pour visualiser les aides par categorie il suffit d'accéder à l'url suivante :
`/simulation/resultats?debug=aide_permis`