### PR TITLE
Répare les problèmes de distance pour les DOMTOM

### DIFF
--- a/backend/lib/mes-aides/distance.js
+++ b/backend/lib/mes-aides/distance.js
@@ -16,7 +16,7 @@ const processArrondissements = (inseeCode) => {
 }
 
 function computeDistanceCommunes(origin, destination) {
-  if (origin && destination) {
+  if (origin && origin.centre && destination && destination.centre) {
     return haversine(
       origin.centre.coordinates,
       destination.centre.coordinates,


### PR DESCRIPTION
Problème technique rencontré par un usager lors du calcul de la distance entre le foyer de ses parents et le sien. Le problème provient du fichier `communes.json` qui répertorie uniquement les communes en France métropolitaine et non dans les DOM-TOM.

Plus d'information mail 14/09 18h49.