### PR TITLE
Cache le bouton récapitulatif en mode mobile

### DIFF
--- a/src/components/TitreChapitre.vue
+++ b/src/components/TitreChapitre.vue
@@ -28,7 +28,7 @@ export default {
       return this.getTitleByRoute(this.$route)
     },
     showMenuButton() {
-      return this.$route.name !== "sommaire"
+      return this.$route.name !== "recapitulatif"
     },
   },
   methods: {


### PR DESCRIPTION
En mobile le bouton récapitulatif ne disparait pas lorsque l'on clique dessus et créer l'erreur suivante :
![image](https://user-images.githubusercontent.com/65901733/135881862-cf399f49-772a-4bd8-a9df-2178ae637d73.png)
