### PR TITLE
Met à jour la légende du `livret_epargne_populaire_taux`

### DIFF
--- a/app/js/constants/benefits/index.js
+++ b/app/js/constants/benefits/index.js
@@ -408,7 +408,7 @@ var droitsDescription = {
             "Effectuer chaque année votre déclaration auprès des impôts.",
             "Présenter à l’établissement bancaire votre avis d’imposition indiquant votre revenu fiscal.",
           ],
-          legend: "au lieu de 0,75%",
+          legend: "au lieu de 0,50%",
           link: "https://www.service-public.fr/particuliers/vosdroits/F2367",
           entity: "individus", // default entity is familles
           isBaseRessourcesYearMinusTwo: true,


### PR DESCRIPTION
Le taux de la légende fait référence au livret A qui est à 0.50% : https://www.service-public.fr/particuliers/vosdroits/F2365