### PR TITLE
Répare le déploiement de /contribuer

### DIFF
--- a/contribuer/pages/_document.js
+++ b/contribuer/pages/_document.js
@@ -36,7 +36,7 @@ class MyDocument extends Document {
               </a>
               .
             </p>
-            <p>L’équipe du simulateur d'aides pour les jeunes</p>
+            <p>L’équipe du simulateur d’aides pour les jeunes</p>
           </footer>
         </body>
       </Html>


### PR DESCRIPTION
Le linter de `next` n'accepte pas certaines apostrophes.
