### PR TITLE
Corrige les champs dépréciés suite à la montée de version de Netlify

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -37,9 +37,9 @@ collections:
         name: institution
         widget: relation
         collection: institutions
-        valueField: "{{slug}}"
-        displayFields: ["{{name}}"]
-        searchFields: [slug, displayFields]
+        value_field: "{{slug}}"
+        display_fields: ["{{name}}"]
+        search_fields: [slug, displayFields]
         allow_multiple: false
       - label: Courte description
         name: description


### PR DESCRIPTION
Depuis la montée de version, certains champs de la configuration de Netlify sont indiqués comme dépréciés dans la console. 