### PR TITLE
Évite la redirection lorsque ?debug est utilisé

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -428,7 +428,8 @@ router.beforeEach((to, from, next) => {
       ["resultats", "resultatsDetails", "resultatsLieuxGeneriques"].indexOf(
         to.name
       ) === -1 &&
-      !store.getters.passSanityCheck
+      !store.getters.passSanityCheck &&
+      to.query.debug === undefined
     ) {
       return store.dispatch("redirection", (route) => next(route))
     }


### PR DESCRIPTION
C'est en particulier pour permettre le partage d'une page avec des partenaires ou collègues dans le cas de demande d'aide par exemple.

En l'occurrence, j'aimerais partager avec des designers la page sur la situation parentale `/simulation/parents/_situation?debug` et avoir leur retours sur les différentes possibilités et en particulier l'absence de « célibataire » (cf email 11/10/2021 à 00:05).