### PR TITLE
Corrige une erreur dans la configuration de Netlify

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -113,8 +113,8 @@ collections:
             value: "%"
           - label: séances
             value: séances
-      - label: Légende pour le résultat
-        hint: "Il s'agit d'ajouter des informations complémentaires au résultat. Exemple: X% de réduction."
+      - label: Légende asssociée au montant
+        hint: Cette légende permet d'ajouter des informations complémentaires sur le montant. Cette légende correspond à « séances » dans l'affichage « N séances » et à « au lieu x de 0,5% dans « 1% au lieu de 0,5% ».
         name: legend
         widget: string
         required: false
@@ -178,11 +178,6 @@ collections:
             value: annuelle
           - label: Autre
             value: autre
-      - label: Légende asssociée au montant
-        hint: Cette légende permet d'ajouter des informations complémentaires sur le montant. Cette légende correspond à « séances » dans l'affichage « N séances » et à « au lieu x de 0,5% dans « 1% au lieu de 0,5% ».
-        name: legend
-        widget: string
-        required: false
       - label: Régions
         name: regions
         required: false


### PR DESCRIPTION
Cette PR corrige une erreur qui s'est produite durant un merge. Le field "legend" a été dupliqué dans la configuration des "fields" de Netlify CMS.