### PR TITLE
Fix possible null parameters

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -59,6 +59,7 @@ function defaultStore() {
     inIframe: false,
     iframeOrigin: null,
     saveSituationError: null,
+    openFiscaParameters: {},
   }
 }
 


### PR DESCRIPTION
The store seems managed a bit differently in firefox, so when you refresh the page, you are calculating the journey before receiving the parameters from open fisca. Defaulting them to {} has no impact since you are already on a given page and it will be recomputed after your answer