### PR TITLE
Vérifie que matomo existe avant d'utiliser la fonction trackEvent

### DIFF
--- a/src/components/DroitsDetails.vue
+++ b/src/components/DroitsDetails.vue
@@ -181,11 +181,12 @@ export default {
     alertBrokenLink() {
       this.brokenLinkButtonState = "showThanksMessage"
       setTimeout(() => (this.brokenLinkButtonState = null), 5000)
-      this.$matomo.trackEvent(
-        "General",
-        "Erreur lien aide invalide",
-        this.droit.label
-      )
+      this.$matomo &&
+        this.$matomo.trackEvent(
+          "General",
+          "Erreur lien aide invalide",
+          this.droit.label
+        )
     },
   },
 }


### PR DESCRIPTION
Correction du ticket : https://sentry.io/organizations/betagouv-f7/issues/2556503117/?project=5709078&query=is%3Aunresolved