### PR TITLE
Répare le lancement du front sans NodeJS

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -32,7 +32,7 @@ const ID = function () {
   return "_" + Math.random().toString(36).substr(2, 9)
 }
 
-function mock(app) {
+function mock({ app }) {
   app.use(bodyParser.json())
 
   let cache = {}


### PR DESCRIPTION
Suite à #1922 `npm run front` n'est plus fonctionnel. Cette PR corrige la situation.