### PR TITLE
Corrige parameters si getParameters n'a pas encore été appelé

### DIFF
--- a/backend/lib/openfisca/parameters.js
+++ b/backend/lib/openfisca/parameters.js
@@ -38,9 +38,11 @@ const computeParameter = (parameter, date) => {
     }
   }
   Sentry.captureMessage("Openfisca parameters are not loaded", (scope) => {
-    scope.setTag("date", date)
-    scope.setTag("parameters", parameters)
-    scope.setTag("parameter", parameter)
+    scope.setContext("parameters", {
+      date,
+      parameter,
+      parameters,
+    })
   })
   return parametersList[parameter]
 }

--- a/backend/lib/openfisca/parameters.js
+++ b/backend/lib/openfisca/parameters.js
@@ -1,3 +1,4 @@
+const Sentry = require("@sentry/browser")
 const openfisca = require("./getter")
 
 const parametersList = {
@@ -36,6 +37,7 @@ const computeParameter = (parameter, date) => {
       return values[closestDate]
     }
   }
+  Sentry.captureMessage("Openfisca parameters are not loaded")
   return parametersList[parameter]
 }
 

--- a/backend/lib/openfisca/parameters.js
+++ b/backend/lib/openfisca/parameters.js
@@ -27,7 +27,7 @@ const computeParameters = async () => {
 }
 
 const computeParameter = (parameter, date) => {
-  const values = parameters[parameter]
+  const values = parameters && parameters[parameter]
   if (values) {
     const closestDate = Object.keys(values).find(
       (valueDate) => new Date(valueDate) < date

--- a/backend/lib/openfisca/parameters.js
+++ b/backend/lib/openfisca/parameters.js
@@ -1,4 +1,4 @@
-const Sentry = require("@sentry/browser")
+const Sentry = require("@sentry/node")
 const openfisca = require("./getter")
 
 const parametersList = {

--- a/backend/lib/openfisca/parameters.js
+++ b/backend/lib/openfisca/parameters.js
@@ -37,7 +37,11 @@ const computeParameter = (parameter, date) => {
       return values[closestDate]
     }
   }
-  Sentry.captureMessage("Openfisca parameters are not loaded")
+  Sentry.captureMessage("Openfisca parameters are not loaded", (scope) => {
+    scope.setTag("date", date)
+    scope.setTag("parameters", parameters)
+    scope.setTag("parameter", parameter)
+  })
   return parametersList[parameter]
 }
 


### PR DESCRIPTION
Investigation de l'erreur : 

```
{
"message": "Cannot read property 'marche_travail.salaire_minimum.nb_heure_travail_mensuel' of undefined",
"name": "TypeError",
"stack": "TypeError: Cannot read property 'marche_travail.salaire_minimum.nb_heure_travail_mensuel' of undefined\n at computeParameter (/home/main/aides-jeunes/backend/lib/openfisca/parameters.js:30:28)\n at module.exports.getParameter (/home/main/aides-jeunes/backend/lib/openfisca/parameters.js:43:10)\n at salaireNetToImposable (/home/main/aides-jeunes/backend/lib/openfisca/mapping/individu/ressources.js:20:19)\n at /home/main/aides-jeunes/backend/lib/openfisca/mapping/individu/ressources.js:76:27\n at /home/main/aides-jeunes/node_modules/lodash/_createBaseFor.js:17:11\n at baseForOwn (/home/main/aides-jeunes/node_modules/lodash/_baseForOwn.js:13:20)\n at /home/main/aides-jeunes/node_modules/lodash/_createBaseEach.js:17:14\n at forEach (/home/main/aides-jeunes/node_modules/lodash/forEach.js:38:10)\n at /home/main/aides-jeunes/backend/lib/openfisca/mapping/individu/ressources.js:74:7\n at arrayEach (/home/main/aides-jeunes/node_modules/lodash/_arrayEach.js:15:9)\n at forEach (/home/main/aides-jeunes/node_modules/lodash/forEach.js:38:10)\n at /home/main/aides-jeunes/backend/lib/openfisca/mapping/individu/ressources.js:66:5\n at /home/main/aides-jeunes/node_modules/lodash/_createBaseFor.js:17:11\n at baseForOwn (/home/main/aides-jeunes/node_modules/lodash/_baseForOwn.js:13:20)\n at /home/main/aides-jeunes/node_modules/lodash/_createBaseEach.js:17:14\n at forEach (/home/main/aides-jeunes/node_modules/lodash/forEach.js:38:10)"
}
```
Mon interprétation de l'erreur est la suivante :
- L'utilisateur a commencé sa simulation normalement et a appelé la fonction getParameters. Il a indiqué être alternant, une information importante pour calculer le salaire imposable
- La mise en prod de la PR https://github.com/betagouv/aides-jeunes/commit/24b477cf8e4ee52dc5b88f12e34930d4b1e2fad3 s'est effectuée et réinitalise parameters
- L'utilisateur interroge le back pour obtenir le résultat de la simulation et obtient l'erreur ci-dessus car parameters n'est pas défini