### PR TITLE
Config/parallel ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,26 +26,9 @@ install_virtualenv: &install_virtualenv
       python3 get-pip.py
       pip3 install virtualenv
 
-start_openfisca: &start_openfisca
-  run:
-    name: Start OpenFisca
-    requires: install_virtualenv
-    command: |
-      source .venv/bin/activate
-      gunicorn api --chdir openfisca/ --config openfisca/config.py --preload --log-level debug --log-file=-
-      deactivate
-    background: true
-
-wait_for_openfisca: &wait_for_openfisca
-  run:
-    name: Wait for OpenFisca
-    requires: install_virtualenv
-    command: wget --retry-connrefused --waitretry=2 --output-document=/dev/null http://localhost:2000/variable/parisien
-
 start_mes_aides: &start_mes_aides
   run:
     name: Start Mes Aides
-    requires: wait_for_openfisca
     command: |
       cp backend/config/continuous_integration.js backend/config/production.js
       npm start
@@ -54,32 +37,9 @@ start_mes_aides: &start_mes_aides
 wait_for_mes_aides: &wait_for_mes_aides
   run:
     name: Wait for Mes Aides
-    requires: start_mes_aides
     command: wget --retry-connrefused --no-check-certificate -T 30 http://localhost:8080
 
-start_xvfb: &start_xvfb
-  run:
-    name: Start Xvfb
-    requires: wait_for_mes_aides
-    command: |
-      Xvfb :99
-    background: true
-
 version: 2.1
-commands:
-  cypress:
-    description: "Commande pour exécuter un fichier de test cypress et sauvegarder la vidéo."
-    parameters:
-      title:
-        type: string
-      path:
-        type: string
-    steps:
-      - run:
-          title: "<< parameters.title >>"
-          requires: start_xvfb
-          command: 'npm run cypress -- --spec "cypress/integration/<< parameters.path >>"'
-
 jobs:
   install:
     <<: *defaults
@@ -163,37 +123,43 @@ jobs:
           command: npm run test
   test_e2e:
     <<: *defaults
-    parallelism: 4
     steps:
       - checkout
       - attach_workspace:
-          requires: checkout
           at: ~/mes-aides-ui
       - *install_virtualenv
-      - *start_openfisca
-      - *wait_for_openfisca
+      - run:
+          name: Start OpenFisca
+          command: |
+            source .venv/bin/activate
+            gunicorn api --chdir openfisca/ --config openfisca/config.py --preload --log-level debug --log-file=-
+            deactivate
+          background: true
+      - run:
+          name: Wait for OpenFisca
+          command: wget --retry-connrefused --waitretry=2 --output-document=/dev/null http://localhost:2000/variable/parisien
       - *start_mes_aides
       - *wait_for_mes_aides
       - restore_cache:
           name: Restoring node_modules
-          requires: wait_for_mes_aides
           keys:
             - v12.1.4-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
-      - *start_xvfb
+      - run:
+          name: Start Xvfb
+          command: |
+            Xvfb :99
+          background: true
       - run:
           name: Run Cypress tests
-          requires: start_xvfb
           command: |
             set -e
             TEST_FILES=$(circleci tests glob "cypress/integration/**/*.spec.js" | circleci tests split --split-by=timings)
             mkdir -p test-results
             npm run cypress -- --spec "$TEST_FILES"
       - store_artifacts:
-          requires: cypress
           path: cypress/videos
       - run:
           name: Stop Xvfb
-          requires: store_artifacts
           command: |
             pkill Xvfb
   test_openfisca_test_generation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,18 +180,14 @@ jobs:
           keys:
             - v12.1.4-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - *start_xvfb
-      - cypress:
-          title: "Test un scénario simple"
-          path: "base.spec.js"
-      - cypress:
-          title: "Test un scénario d'une personne en situation de handicap"
-          path: "handicap.spec.js"
-      - cypress:
-          title: "Test un scénario familial"
-          path: "family.spec.js"
-      - cypress:
-          title: "Test un scénario d'une personne étudiante"
-          path: "student.spec.js"
+      - run:
+          name: Run Cypress tests
+          requires: start_xvfb
+          command: |
+            set -e
+            TEST_FILES=$(circleci tests glob "cypress/integration/**/*.spec.js" | circleci tests split --split-by=timings)
+            mkdir -p test-results
+            npm run cypress -- --spec "$TEST_FILES"
       - store_artifacts:
           requires: cypress
           path: cypress/videos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,7 @@ jobs:
           path: cypress/videos
       - run:
           name: Stop Xvfb
+          requires: store_artifacts
           command: |
             pkill Xvfb
   test_openfisca_test_generation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,7 @@ jobs:
           command: npm run test
   test_e2e:
     <<: *defaults
+    parallelism: 4
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,26 @@ install_virtualenv: &install_virtualenv
       python3 get-pip.py
       pip3 install virtualenv
 
+start_openfisca: &start_openfisca
+  run:
+    name: Start OpenFisca
+    requires: install_virtualenv
+    command: |
+      source .venv/bin/activate
+      gunicorn api --chdir openfisca/ --config openfisca/config.py --preload --log-level debug --log-file=-
+      deactivate
+    background: true
+
+wait_for_openfisca: &wait_for_openfisca
+  run:
+    name: Wait for OpenFisca
+    requires: install_virtualenv
+    command: wget --retry-connrefused --waitretry=2 --output-document=/dev/null http://localhost:2000/variable/parisien
+
 start_mes_aides: &start_mes_aides
   run:
     name: Start Mes Aides
+    requires: wait_for_openfisca
     command: |
       cp backend/config/continuous_integration.js backend/config/production.js
       npm start
@@ -37,7 +54,16 @@ start_mes_aides: &start_mes_aides
 wait_for_mes_aides: &wait_for_mes_aides
   run:
     name: Wait for Mes Aides
+    requires: start_mes_aides
     command: wget --retry-connrefused --no-check-certificate -T 30 http://localhost:8080
+
+start_xvfb: &start_xvfb
+  run:
+    name: Start Xvfb
+    requires: wait_for_mes_aides
+    command: |
+      Xvfb :99
+    background: true
 
 version: 2.1
 commands:
@@ -51,9 +77,8 @@ commands:
     steps:
       - run:
           title: "<< parameters.title >>"
+          requires: start_xvfb
           command: 'npm run cypress -- --spec "cypress/integration/<< parameters.path >>"'
-      - store_artifacts:
-          path: cypress/videos
 
 jobs:
   install:
@@ -138,32 +163,23 @@ jobs:
           command: npm run test
   test_e2e:
     <<: *defaults
+    parallelism: 4
     steps:
       - checkout
       - attach_workspace:
+          requires: checkout
           at: ~/mes-aides-ui
       - *install_virtualenv
-      - run:
-          name: Start OpenFisca
-          command: |
-            source .venv/bin/activate
-            gunicorn api --chdir openfisca/ --config openfisca/config.py --preload --log-level debug --log-file=-
-            deactivate
-          background: true
-      - run:
-          name: Wait for OpenFisca
-          command: wget --retry-connrefused --waitretry=2 --output-document=/dev/null http://localhost:2000/variable/parisien
+      - *start_openfisca
+      - *wait_for_openfisca
       - *start_mes_aides
       - *wait_for_mes_aides
       - restore_cache:
           name: Restoring node_modules
+          requires: wait_for_mes_aides
           keys:
             - v12.1.4-dependencies-{{ .Branch }}-{{ checksum "package-lock.json" }}
-      - run:
-          name: Start Xvfb
-          command: |
-            Xvfb :99
-          background: true
+      - *start_xvfb
       - cypress:
           title: "Test un scénario simple"
           path: "base.spec.js"
@@ -176,6 +192,9 @@ jobs:
       - cypress:
           title: "Test un scénario d'une personne étudiante"
           path: "student.spec.js"
+      - store_artifacts:
+          requires: cypress
+          path: cypress/videos
       - run:
           name: Stop Xvfb
           command: |


### PR DESCRIPTION
## Description 

[Tâche Trello](https://trello.com/c/1tIMYozC/438-parall%C3%A9liser-la-ci)

## Tâches
- [x] Paralléliser les tests end-to-end

## Notes

Cette PR modifie la logique d'exécution de la CI avec les implications suivantes :
- chaque étape de la section de test end to end est exécutée dans 4 containers parallèles
- la distribution des tests entre les containers est faite automatiquement par Circle-CI. Ainsi si l'on rajoute d'autres tests ils seront dispatchés au mieux entre les containers. 
- on peut augmenter jusqu'à 16 le nombre de run parallèles
- aujourd'hui on ne voit plus immédiatement les noms des tests qui se sont exécutés ou qui ont échoués. On peut toujours consulter le résultat des tests depuis l'interface de Circle-CI en 2 clics (chaque tests est contenu dans un container)

Le dernier point est probablement améliorable en y passant davantage de temps.

