### PR TITLE
Ajoute l'id de l'institution dans l'affichage NetlifyCMS des aides

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -478,6 +478,7 @@ collections:
     editor:
       preview: true
     slug: "{{label}}"
+    summary: "{{label}} ({{fields.institution}})"
     extension: yml
     fields:
       - *field_nom_aide


### PR DESCRIPTION
J'ai tenté de remplacer l'identifiant de l'institution via `fields.institution.fields.name` sans succès. Je pense que l'identifiant est (pour le moment :thinking: ) suffisant.

J'ai pas pu tester sur la vue « flux », uniquement dans le listing des aides mais j'imagine que c'est le même champs qui est utilisé.