### PR TITLE
Ajoute l'id de l'institution dans le nom de fichier par défaut d'une aide JS

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -477,7 +477,7 @@ collections:
     delete: false
     editor:
       preview: true
-    slug: "{{label}}"
+    slug: "{{fields.institution}}-{{label}}"
     summary: "{{label}} ({{fields.institution}})"
     extension: yml
     fields:


### PR DESCRIPTION
J'ai mis l'id au début du nom du fichier mais ça peut tout à fait aller à la fin, j'ai cru que c'était ce qui était fait pour le moment.