### PR TITLE
[457] Réparer la génération des données x/n de la page de résultats

### DIFF
--- a/src/components/DroitsDetails.vue
+++ b/src/components/DroitsDetails.vue
@@ -164,7 +164,6 @@ import BenefitCtaLink from "./BenefitCtaLink"
 import DroitEstime from "./DroitEstime"
 import Situation from "../lib/Situation"
 import DroitMixin from "../mixins/DroitMixin"
-import StatisticsMixin from "../mixins/Statistics"
 
 export default {
   name: "DroitsDetails",
@@ -179,14 +178,11 @@ export default {
     BenefitCtaLink,
     DroitEstime,
   },
-  mixins: [DroitMixin, StatisticsMixin],
+  mixins: [DroitMixin],
   data() {
     return {
       brokenLinkButtonState: "show",
     }
-  },
-  mounted() {
-    this.sendStatistics([this.droit], "showDetails", this.droits.length)
   },
   computed: {
     aCharge() {

--- a/src/mixins/Statistics.js
+++ b/src/mixins/Statistics.js
@@ -2,11 +2,17 @@ const uuid = `uid_${Math.random().toString(12).slice(2)}`
 
 export default {
   methods: {
-    sendStatistics: function (benefits, event = "show", benefitsTotal) {
+    sendStatistics: function (
+      benefits,
+      event = "show",
+      benefitIndex,
+      benefitsTotal
+    ) {
       if (
         window.navigator.doNotTrack !== "1" &&
         document.cookie.indexOf("piwik_ignore") < 0 &&
         process.env.VUE_APP_STATS_URL &&
+        process.env.VUE_APP_STATS_URL.length &&
         benefits &&
         benefits.length
       ) {
@@ -17,7 +23,7 @@ export default {
           benefitsStats.push({
             benefit_id: benefit.id,
             hash_id: id,
-            benefit_index: i + 1,
+            benefit_index: benefitIndex || i + 1,
             page_total: benefitsTotal || totalResults,
             event_type: event,
           })

--- a/src/mixins/Statistics.js
+++ b/src/mixins/Statistics.js
@@ -2,12 +2,7 @@ const uuid = `uid_${Math.random().toString(12).slice(2)}`
 
 export default {
   methods: {
-    sendStatistics: function (
-      benefits,
-      event = "show",
-      benefitIndex,
-      benefitsTotal
-    ) {
+    sendStatistics: function (benefits, event = "show", benefitId) {
       if (
         window.navigator.doNotTrack !== "1" &&
         document.cookie.indexOf("piwik_ignore") < 0 &&
@@ -20,13 +15,15 @@ export default {
         const benefitsStats = []
         const totalResults = benefits.length
         benefits.forEach(function (benefit, i) {
-          benefitsStats.push({
-            benefit_id: benefit.id,
-            hash_id: id,
-            benefit_index: benefitIndex || i + 1,
-            page_total: benefitsTotal || totalResults,
-            event_type: event,
-          })
+          if (!benefitId || benefitId == benefit.id) {
+            benefitsStats.push({
+              benefit_id: benefit.id,
+              hash_id: id,
+              benefit_index: i + 1,
+              page_total: totalResults,
+              event_type: event,
+            })
+          }
         })
         fetch(process.env.VUE_APP_STATS_URL, {
           method: "POST",

--- a/src/views/Simulation/ResultatsDetail.vue
+++ b/src/views/Simulation/ResultatsDetail.vue
@@ -73,6 +73,13 @@ export default {
       droit &&
         this.$matomo &&
         this.$matomo.trackEvent("General", "showDetails", droit.label)
+
+      this.sendStatistics(
+        [droit],
+        "showDetails",
+        this.droits.findIndex((droit) => droit.id === droitId) + 1,
+        this.droits.length
+      )
     }
   },
   computed: {

--- a/src/views/Simulation/ResultatsDetail.vue
+++ b/src/views/Simulation/ResultatsDetail.vue
@@ -74,12 +74,7 @@ export default {
         this.$matomo &&
         this.$matomo.trackEvent("General", "showDetails", droit.label)
 
-      this.sendStatistics(
-        [droit],
-        "showDetails",
-        this.droits.findIndex((droit) => droit.id === droitId) + 1,
-        this.droits.length
-      )
+      this.sendStatistics(this.droits, "showDetails", droitId)
     }
   },
   computed: {

--- a/vue.config.js
+++ b/vue.config.js
@@ -14,7 +14,8 @@ process.env.VUE_APP_VALIDATION_DELAY = (animation && animation.delay) || 0
 process.env.VUE_APP_BASE_URL = baseURL
 process.env.VUE_APP_CONTEXT = process.env.CONTEXT
 process.env.VUE_APP_PR_URL = `${process.env.REPOSITORY_URL}/pull/${process.env.REVIEW_ID}`
-process.env.VUE_APP_STATS_URL = statistics.url
+process.env.VUE_APP_STATS_URL =
+  statistics && statistics.url ? statistics.url : ""
 
 module.exports = {
   configureWebpack: (config) => {


### PR DESCRIPTION
## Description

[Lien Trello](https://trello.com/c/n2csqudY/457-r%C3%A9parer-la-g%C3%A9n%C3%A9ration-des-donn%C3%A9es-x-n-de-la-page-de-r%C3%A9sultats)

## Détails

- [x] Correction de la valeur de l'index retournée `1/x` en `x/n`
- [x] Correction d'un bug où l'url de stats était une string non nulle valant `"undefined"`