### PR TITLE
fix: supprime vuelidate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3132,36 +3132,6 @@
       "integrity": "sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA==",
       "dev": true
     },
-    "@vuelidate/core": {
-      "version": "2.0.0-alpha.32",
-      "resolved": "https://registry.npmjs.org/@vuelidate/core/-/core-2.0.0-alpha.32.tgz",
-      "integrity": "sha512-bB5YJzorKZyRm+R4d3svGChwpHjPw+ECOLwlKfvKJIuyC+y25Wf7NGbr/9odZggoGTi/rKPUYXhpbp5RXb4ssw==",
-      "requires": {
-        "vue-demi": "^0.12.0"
-      },
-      "dependencies": {
-        "vue-demi": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.1.tgz",
-          "integrity": "sha512-QL3ny+wX8c6Xm1/EZylbgzdoDolye+VpCXRhI2hug9dJTP3OUJ3lmiKN3CsVV3mOJKwFi0nsstbgob0vG7aoIw=="
-        }
-      }
-    },
-    "@vuelidate/validators": {
-      "version": "2.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@vuelidate/validators/-/validators-2.0.0-alpha.25.tgz",
-      "integrity": "sha512-+Cz9itIlPbloXE8hWmTWCS/EXYdgZ0y/mH76v9Ou0ILirVUjErTtgEx/jCfkijbFJAttBTdwJmxaWakwQuA0qA==",
-      "requires": {
-        "vue-demi": "^0.12.0"
-      },
-      "dependencies": {
-        "vue-demi": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.1.tgz",
-          "integrity": "sha512-QL3ny+wX8c6Xm1/EZylbgzdoDolye+VpCXRhI2hug9dJTP3OUJ3lmiKN3CsVV3mOJKwFi0nsstbgob0vG7aoIw=="
-        }
-      }
-    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
     "@sentry/node": "^6.14.0",
     "@sentry/vue": "^6.14.0",
     "@vue/compiler-sfc": "^3.2.23",
-    "@vuelidate/core": "^2.0.0-alpha.32",
-    "@vuelidate/validators": "^2.0.0-alpha.25",
     "axios": "^0.24.0",
     "body-parser": "^1.19.0",
     "communes-lonlat": "^1.1.0",

--- a/src/components/OfflineResults.vue
+++ b/src/components/OfflineResults.vue
@@ -44,11 +44,12 @@
           submitResult &&
           !(submitResult.ok || submitResult.waiting || submitResult.error)
         "
+        ref="form"
       >
         <label for="email" class="form__group">Votre email</label>
-        <input id="email" v-model="email" type="text" name="email" />
-        <p v-if="v$ && v$.email.$error" class="notification warning">
-          Un email doit être indiqué.
+        <input id="email" v-model="email" type="email" name="email" required />
+        <p v-if="errorMessage" class="notification warning">
+          Une adresse email valide doit être indiquée.
         </p>
         <div class="aj-feedback-buttons">
           <button
@@ -73,8 +74,6 @@
 
 <script>
 import axios from "axios"
-import useVuelidate from "@vuelidate/core"
-import { required, email } from "@vuelidate/validators"
 
 import Modal from "@/components/Modal"
 
@@ -86,9 +85,6 @@ export default {
   props: {
     id: String,
   },
-  setup() {
-    return { v$: useVuelidate() }
-  },
   data: function () {
     return {
       email: undefined,
@@ -97,6 +93,7 @@ export default {
         waiting: undefined,
         error: undefined,
       },
+      errorMessage: undefined,
     }
   },
   methods: {
@@ -108,8 +105,8 @@ export default {
       }
     },
     getRecap: function (surveyOptin) {
-      this.v$.$touch()
-      if (this.v$.$invalid) {
+      if (!this.$refs.form.checkValidity()) {
+        this.errorMessage = true
         this.$matomo &&
           this.$matomo.trackEvent(
             "General",
@@ -140,9 +137,6 @@ export default {
           this.submitResult.waiting = false
         })
     },
-  },
-  validations: {
-    email: { required, email },
   },
 }
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,6 @@ import ScrollService from "./plugins/ScrollService"
 import StateService from "./plugins/StateService"
 
 import * as Sentry from "@sentry/vue"
-import useVuelidate from "@vuelidate/core"
 import VueMatomo from "vue-matomo"
 
 import "template.data.gouv.fr/dist/main.css"
@@ -48,7 +47,6 @@ if (process.env.NODE_ENV === "production") {
 app.use(Resizer)
 app.use(ScrollService)
 app.use(StateService)
-app.use(useVuelidate)
 
 app.use(VueMatomo, {
   host: "https://stats.data.gouv.fr",

--- a/src/styles/partials/desktop/_inputs.scss
+++ b/src/styles/partials/desktop/_inputs.scss
@@ -131,6 +131,7 @@ html {
       }
 
       input[type="text"],
+      input[type="email"],
       input[type="number"],
       input[data-type="number"],
       select {


### PR DESCRIPTION
## Description

La version actuelle du package `@vuelidate/validators` comporte une CVE de niveau élévé (score de `7.5`).
En l'état le code exploitable n'est pas présent sur aides-jeunes, 2 conditions devraient être remplies pour que ça soit le cas :
- utiliser la fonction de validation d'url de `@vuelidate/validators`
- exposer des utilisateurs à des données soumises par un tiers mal intentionné (ex: message utilisateur contenant une url)

## Détails

Par principe de précaution ce correctif supprime l'utilisation du package `vuelidate` du code.
Le package était utilisé sur la page d'envoi d'email pour :
- vérifier qu'une adresse email est valide
- vérifier que le formulaire associé est valide

L'utilisation de [form-validation](https://caniuse.com/form-validation) est tout aussi fonctionnelle et permet de ne pas utiliser le package `vuelidate`

## Tâches
- [x] Suppression de `@vuelidate/core` et `@vuelidate/validators`
- [x] Utilisation de `form-validation` pour valider l'adresse email
- [x] Utilisation de `form-validation` pour valider le formulaire