### PR TITLE
fix: corrige la page En Savoir Plus

### DIFF
--- a/src/components/EnSavoirPlusContent.vue
+++ b/src/components/EnSavoirPlusContent.vue
@@ -55,7 +55,7 @@ export default {
   },
   computed: {
     attribute: function () {
-      return this.$route.params.parent.split("/").pop()
+      return this.$route.params.parent.pop()
     },
     source: function () {
       return this.$route.params.parent

--- a/src/components/EnSavoirPlusContent.vue
+++ b/src/components/EnSavoirPlusContent.vue
@@ -55,7 +55,7 @@ export default {
   },
   computed: {
     attribute: function () {
-      return this.$route.params.parent.slice(-1)[0]
+      return this.source[this.source.length - 1]
     },
     source: function () {
       return this.$route.params.parent

--- a/src/components/EnSavoirPlusContent.vue
+++ b/src/components/EnSavoirPlusContent.vue
@@ -55,7 +55,7 @@ export default {
   },
   computed: {
     attribute: function () {
-      return this.$route.params.parent.pop()
+      return this.$route.params.parent.slice(-1)[0]
     },
     source: function () {
       return this.$route.params.parent


### PR DESCRIPTION
## Description

Le bouton "En savoir plus" redirigeait vers une page vide suite à une erreur dans le format de `this.$route.params.parent` (string attendu, array donné).