### PR TITLE
fix: corrige un bug des champs mensuels

### DIFF
--- a/src/components/InputNumber.vue
+++ b/src/components/InputNumber.vue
@@ -3,7 +3,7 @@
     <input
       :id="id"
       ref="result"
-      v-model="model"
+      v-model.number="model"
       v-select-on-click
       type="number"
       :name="name"
@@ -26,7 +26,7 @@ export default {
     min: Number,
     max: Number,
     step: String,
-    modelValue: Number,
+    modelValue: [Number, String],
     emit: { type: Boolean, default: true },
   },
   emits: ["update:modelValue"],
@@ -42,8 +42,12 @@ export default {
         return this.modelValue
       },
       set(value) {
-        if (this.emit) {
+        if (value || value === 0) {
+          this.error = false
           this.$emit("update:modelValue", value)
+        } else {
+          this.error = true
+          this.$emit("update:modelValue", undefined)
         }
       },
     },

--- a/src/components/InputNumber.vue
+++ b/src/components/InputNumber.vue
@@ -42,7 +42,7 @@ export default {
         return this.modelValue
       },
       set(value) {
-        if (this.emit && !isNaN(value) && parseFloat(value)) {
+        if (this.emit) {
           this.$emit("update:modelValue", value)
         }
       },

--- a/src/components/InputNumber.vue
+++ b/src/components/InputNumber.vue
@@ -25,11 +25,12 @@ export default {
     name: String,
     min: Number,
     max: Number,
-    step: String,
-    modelValue: [Number, String],
+    value: { type: [Number, String] },
+    modelValue: { type: [Number, String] },
+    step: { type: String, default: "any" },
     emit: { type: Boolean, default: true },
   },
-  emits: ["update:modelValue"],
+  emits: ["input", "update:modelValue"],
   data: function () {
     return {
       result: this.result,
@@ -39,14 +40,15 @@ export default {
   computed: {
     model: {
       get() {
-        return this.modelValue
+        return this.value || this.modelValue
       },
       set(value) {
         if (value || value === 0) {
-          this.error = false
+          this.$emit("input", value)
           this.$emit("update:modelValue", value)
         } else {
           this.error = true
+          this.$emit("input", undefined)
           this.$emit("update:modelValue", undefined)
         }
       },

--- a/src/components/InputNumber.vue
+++ b/src/components/InputNumber.vue
@@ -44,6 +44,7 @@ export default {
       },
       set(value) {
         if (value || value === 0) {
+          this.error = false
           this.$emit("input", value)
           this.$emit("update:modelValue", value)
         } else {

--- a/src/components/Ressource/AutoEntreprise.vue
+++ b/src/components/Ressource/AutoEntreprise.vue
@@ -7,11 +7,8 @@
       >
       <InputNumber
         id="autoAmount"
-        :modelValue="ressource.amounts[$store.state.dates.lastYear.id]"
-        :emit="false"
-        @input="
-          updateFloat($store.state.dates.lastYear.id, $event.target.value)
-        "
+        :value="ressource.amounts[$store.state.dates.lastYear.id]"
+        @input="updateFloat($store.state.dates.lastYear.id, $event)"
       />
     </div>
 
@@ -22,11 +19,8 @@
       >
       <InputNumber
         id="autoAmountLastMonth"
-        :modelValue="ressource.amounts[$store.state.dates.thisMonth.id]"
-        :emit="false"
-        @input="
-          updateFloat($store.state.dates.thisMonth.id, $event.target.value)
-        "
+        :value="ressource.amounts[$store.state.dates.thisMonth.id]"
+        @input="updateFloat($store.state.dates.thisMonth.id, $event)"
       />
     </div>
     <div
@@ -39,9 +33,8 @@
       </label>
       <InputNumber
         :id="'autoAmount' + month.label"
-        :modelValue="ressource.amounts[month.id]"
-        :emit="false"
-        @input="updateFloat(month.id, $event.target.value)"
+        :value="ressource.amounts[month.id]"
+        @input="updateFloat(month.id, $event)"
       />
     </div>
   </div>

--- a/src/components/Ressource/AutoEntreprise.vue
+++ b/src/components/Ressource/AutoEntreprise.vue
@@ -8,7 +8,7 @@
       <InputNumber
         id="autoAmount"
         :value="ressource.amounts[$store.state.dates.lastYear.id]"
-        @input="updateFloat($store.state.dates.lastYear.id, $event)"
+        @input="update($store.state.dates.lastYear.id, $event)"
       />
     </div>
 
@@ -20,7 +20,7 @@
       <InputNumber
         id="autoAmountLastMonth"
         :value="ressource.amounts[$store.state.dates.thisMonth.id]"
-        @input="updateFloat($store.state.dates.thisMonth.id, $event)"
+        @input="update($store.state.dates.thisMonth.id, $event)"
       />
     </div>
     <div
@@ -34,7 +34,7 @@
       <InputNumber
         :id="'autoAmount' + month.label"
         :value="ressource.amounts[month.id]"
-        @input="updateFloat(month.id, $event)"
+        @input="update(month.id, $event)"
       />
     </div>
   </div>

--- a/src/components/Ressource/ExploitantAgricole.vue
+++ b/src/components/Ressource/ExploitantAgricole.vue
@@ -7,11 +7,8 @@
       >
       <InputNumber
         id="agriBenef"
-        :modelValue="ressource.amounts[$store.state.dates.lastYear.id]"
-        :emit="false"
-        @input="
-          updateFloat($store.state.dates.lastYear.id, $event.target.value)
-        "
+        :value="ressource.amounts[$store.state.dates.lastYear.id]"
+        @input="updateFloat($store.state.dates.lastYear.id, $event)"
       />
     </div>
   </div>

--- a/src/components/Ressource/ExploitantAgricole.vue
+++ b/src/components/Ressource/ExploitantAgricole.vue
@@ -8,7 +8,7 @@
       <InputNumber
         id="agriBenef"
         :value="ressource.amounts[$store.state.dates.lastYear.id]"
-        @input="updateFloat($store.state.dates.lastYear.id, $event)"
+        @input="update($store.state.dates.lastYear.id, $event)"
       />
     </div>
   </div>

--- a/src/components/Ressource/MicroEntreprise.vue
+++ b/src/components/Ressource/MicroEntreprise.vue
@@ -8,7 +8,7 @@
       <InputNumber
         id="microAmount"
         :value="ressource.amounts[$store.state.dates.lastYear.id]"
-        @input="updateFloat($store.state.dates.lastYear.id, $event)"
+        @input="update($store.state.dates.lastYear.id, $event)"
       />
     </div>
   </div>

--- a/src/components/Ressource/MicroEntreprise.vue
+++ b/src/components/Ressource/MicroEntreprise.vue
@@ -7,11 +7,8 @@
       >
       <InputNumber
         id="microAmount"
-        :modelValue="ressource.amounts[$store.state.dates.lastYear.id]"
-        :emit="false"
-        @input="
-          updateFloat($store.state.dates.lastYear.id, $event.target.value)
-        "
+        :value="ressource.amounts[$store.state.dates.lastYear.id]"
+        @input="updateFloat($store.state.dates.lastYear.id, $event)"
       />
     </div>
   </div>

--- a/src/components/Ressource/Montants.vue
+++ b/src/components/Ressource/Montants.vue
@@ -17,9 +17,7 @@
     <label v-if="type.displayMonthly === true" class="form__group">
       Indiquez le montant <b>mensuel net</b> :
       <InputNumber
-        step="any"
-        :modelValue="type.amounts[$store.state.dates.thisMonth.id]"
-        :emit="false"
+        :value="type.amounts[$store.state.dates.thisMonth.id]"
         @input="$emit('update', 'singleValue', index, $event)"
       />
     </label>
@@ -33,11 +31,10 @@
         <label>
           <MonthLabel :month="month" />
           <InputNumber
-            :modelValue="type.amounts[month.id]"
-            :emit="false"
+            :value="type.amounts[month.id]"
             @input="
               $emit('update', 'monthUpdate', index, {
-                value: $event.target.value,
+                value: $event,
                 monthIndex,
               })
             "

--- a/src/components/Ressource/Montants.vue
+++ b/src/components/Ressource/Montants.vue
@@ -18,9 +18,9 @@
       Indiquez le montant <b>mensuel net</b> :
       <InputNumber
         step="any"
-        :modelValue="type.amounts[$store.state.dates.thisMonth.id]"
+        :modelValue="parseFloat(type.amounts[$store.state.dates.thisMonth.id])"
         :emit="false"
-        @input="$emit('update', 'singleValue', index, $event)"
+        @input="$emit('update', 'singleValue', index, $event.target.value)"
       />
     </label>
 
@@ -33,11 +33,11 @@
         <label>
           <MonthLabel :month="month" />
           <InputNumber
-            :modelValue="type.amounts[month.id]"
+            :modelValue="parseFloat(type.amounts[month.id])"
             :emit="false"
             @input="
               $emit('update', 'monthUpdate', index, {
-                value: $event,
+                value: $event.target.value,
                 monthIndex,
               })
             "

--- a/src/components/Ressource/Montants.vue
+++ b/src/components/Ressource/Montants.vue
@@ -18,9 +18,9 @@
       Indiquez le montant <b>mensuel net</b> :
       <InputNumber
         step="any"
-        :modelValue="parseFloat(type.amounts[$store.state.dates.thisMonth.id])"
+        :modelValue="type.amounts[$store.state.dates.thisMonth.id]"
         :emit="false"
-        @input="$emit('update', 'singleValue', index, $event.target.value)"
+        @input="$emit('update', 'singleValue', index, $event)"
       />
     </label>
 

--- a/src/components/Ressource/Montants.vue
+++ b/src/components/Ressource/Montants.vue
@@ -33,7 +33,7 @@
         <label>
           <MonthLabel :month="month" />
           <InputNumber
-            :modelValue="parseFloat(type.amounts[month.id])"
+            :modelValue="type.amounts[month.id]"
             :emit="false"
             @input="
               $emit('update', 'monthUpdate', index, {

--- a/src/components/Ressource/ProfessionLiberale.vue
+++ b/src/components/Ressource/ProfessionLiberale.vue
@@ -26,7 +26,7 @@
       <InputNumber
         id="liberaleLastBenef"
         :value="ressource.amounts[$store.state.dates.lastYear.id]"
-        @input="updateFloat($store.state.dates.lastYear.id, $event)"
+        @input="update($store.state.dates.lastYear.id, $event)"
       />
     </div>
   </div>

--- a/src/components/Ressource/ProfessionLiberale.vue
+++ b/src/components/Ressource/ProfessionLiberale.vue
@@ -25,11 +25,8 @@
       >
       <InputNumber
         id="liberaleLastBenef"
-        :modelValue="ressource.amounts[$store.state.dates.lastYear.id]"
-        :emit="false"
-        @input="
-          updateFloat($store.state.dates.lastYear.id, $event.target.value)
-        "
+        :value="ressource.amounts[$store.state.dates.lastYear.id]"
+        @input="updateFloat($store.state.dates.lastYear.id, $event)"
       />
     </div>
   </div>

--- a/src/mixins/RessourceProcessor.js
+++ b/src/mixins/RessourceProcessor.js
@@ -25,9 +25,6 @@ function update(type, newValue, monthIndex, force) {
   }, true)
   const shouldAutofill = valuesAreEqual || force
   if (shouldAutofill) {
-    if (newValue && newValue.target) {
-      newValue = parseFloat(newValue.target.value)
-    }
     nextMonths.forEach((m) => (type.amounts[m.id] = newValue))
   } else {
     type.amounts[type.months[monthIndex].id] = newValue

--- a/src/mixins/TNSRessourceUpdator.js
+++ b/src/mixins/TNSRessourceUpdator.js
@@ -6,9 +6,6 @@ export default {
     update: function (month, value) {
       this.$emit("update", this.ressource, month, value)
     },
-    updateFloat: function (month, value) {
-      this.$emit("update", this.ressource, month, parseFloat(value))
-    },
     updateExtra: function (item, value) {
       this.$emit("updateExtra", this.ressource, item, value)
     },


### PR DESCRIPTION
## Description

Lors de la saisie des derniers salaires mensuels, l'évènement de saisie était sauvé au lieu de la valeur du champs saisi.

## Détails

Plusieurs éléments à noter :
- le fait de repasser `v-model="model"` à `v-model.number="model"` permet de s'assurer que la valeur de modèle soit toujours un `Number`, ce qui évite d'avoir à utiliser des `parseFloat`
- en fonction de l'utilisation du champ `InputNumber` 2 comportements sont possibles :
  - l'utilisation du champ avec `v-model` ; la modification du contenu du champ changera la variable associée
  - l'utilisation du champ avec `value` ; la modification du champ déclenchera la fonction `@input` associée

Le fait d'avoir ces 2 comportements implique d'avoir la possibilité d'envoyer dans `InputNumber` les 2 signaux.

La doc de [v-model pour Vue 3](https://v3.vuejs.org/guide/migration/v-model.html) en référence.