### PR TITLE
[464] Utiliser une image Docker en CI avec Node v16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/mes-aides-ui
   docker:
     # https://circleci.com/docs/2.0/circleci-images/#language-image-variants
-    - image: ghcr.io/betagouv/mes-aides-dockerfiles@sha256:92fbe169cc07e6e7ab785676ac294bf296bd27f96a224521035d7db959e45db7
+    - image: ghcr.io/betagouv/mes-aides-dockerfiles@sha256:0480cc271969a3a6ebe2856b107a5ccf19260f7bfacbfef6b0ec55cf8ecb87c6
     # FIXME
     # mongo 2.4.9 is not available on Docker Hub
     # https://stackoverflow.com/questions/48233357/install-older-version-of-mongodb-with-docker
@@ -37,7 +37,7 @@ start_mes_aides: &start_mes_aides
 wait_for_mes_aides: &wait_for_mes_aides
   run:
     name: Wait for Mes Aides
-    command: wget --retry-connrefused --no-check-certificate -T 30 http://localhost:8080
+    command: wget --retry-connrefused --no-check-certificate -T 60 http://localhost:8080
 
 version: 2.1
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/mes-aides-ui
   docker:
     # https://circleci.com/docs/2.0/circleci-images/#language-image-variants
-    - image: docker pull ghcr.io/betagouv/mes-aides-dockerfiles:1.0
+    - image: docker pull ghcr.io/betagouv/mes-aides-dockerfiles@sha256:b131ffeb027ce301143127f5eb5ad0f8c1864b4a1f5da4831eae3c44440c4c16
     # FIXME
     # mongo 2.4.9 is not available on Docker Hub
     # https://stackoverflow.com/questions/48233357/install-older-version-of-mongodb-with-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/mes-aides-ui
   docker:
     # https://circleci.com/docs/2.0/circleci-images/#language-image-variants
-    - image: ghcr.io/betagouv/mes-aides-dockerfiles@sha256:b131ffeb027ce301143127f5eb5ad0f8c1864b4a1f5da4831eae3c44440c4c16
+    - image: ghcr.io/betagouv/mes-aides-dockerfiles@sha256:220458ec85d8a9b4748183426cb481ef05c504a639142db4aeb50857190aa1f9
     # FIXME
     # mongo 2.4.9 is not available on Docker Hub
     # https://stackoverflow.com/questions/48233357/install-older-version-of-mongodb-with-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/mes-aides-ui
   docker:
     # https://circleci.com/docs/2.0/circleci-images/#language-image-variants
-    - image: ghcr.io/betagouv/mes-aides-dockerfiles@sha256:220458ec85d8a9b4748183426cb481ef05c504a639142db4aeb50857190aa1f9
+    - image: ghcr.io/betagouv/mes-aides-dockerfiles@sha256:92fbe169cc07e6e7ab785676ac294bf296bd27f96a224521035d7db959e45db7
     # FIXME
     # mongo 2.4.9 is not available on Docker Hub
     # https://stackoverflow.com/questions/48233357/install-older-version-of-mongodb-with-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/mes-aides-ui
   docker:
     # https://circleci.com/docs/2.0/circleci-images/#language-image-variants
-    - image: ghcr.io/betagouv/mes-aides-dockerfiles@sha256:0480cc271969a3a6ebe2856b107a5ccf19260f7bfacbfef6b0ec55cf8ecb87c6
+    - image: ghcr.io/betagouv/mes-aides-dockerfiles:node16-python3.7
     # FIXME
     # mongo 2.4.9 is not available on Docker Hub
     # https://stackoverflow.com/questions/48233357/install-older-version-of-mongodb-with-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/mes-aides-ui
   docker:
     # https://circleci.com/docs/2.0/circleci-images/#language-image-variants
-    - image: betagouv/mes-aides-docker:node16-python3.7-cy
+    - image: docker pull ghcr.io/betagouv/mes-aides-dockerfiles:1.0
     # FIXME
     # mongo 2.4.9 is not available on Docker Hub
     # https://stackoverflow.com/questions/48233357/install-older-version-of-mongodb-with-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/mes-aides-ui
   docker:
     # https://circleci.com/docs/2.0/circleci-images/#language-image-variants
-    - image: docker pull ghcr.io/betagouv/mes-aides-dockerfiles@sha256:b131ffeb027ce301143127f5eb5ad0f8c1864b4a1f5da4831eae3c44440c4c16
+    - image: ghcr.io/betagouv/mes-aides-dockerfiles@sha256:b131ffeb027ce301143127f5eb5ad0f8c1864b4a1f5da4831eae3c44440c4c16
     # FIXME
     # mongo 2.4.9 is not available on Docker Hub
     # https://stackoverflow.com/questions/48233357/install-older-version-of-mongodb-with-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
   working_directory: ~/mes-aides-ui
   docker:
     # https://circleci.com/docs/2.0/circleci-images/#language-image-variants
-    - image: betagouv/mes-aides-docker:node14-python3.7-cy
+    - image: betagouv/mes-aides-docker:node16-python3.7-cy
     # FIXME
     # mongo 2.4.9 is not available on Docker Hub
     # https://stackoverflow.com/questions/48233357/install-older-version-of-mongodb-with-docker


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/bnc8lqIv/464-utiliser-une-image-docker-en-ci-avec-la-future-version-de-node)

## Notes

### Versions
- pour l’image Debian je serais d’avis de rester sur la version buster (10) au lieu de passer à bulleye (11+). Même si l’image est stable elle a été release pour la première fois le 14/08/2021, avec la dernière release (11.2) distribuée le 18 décembre 2021
- pour le variant de l’image, étant donné que c'est pour un usage limité je suis d'avis de partir sur l'image Buster avec Node 16 proposée par le repo [docker-node](https://github.com/nodejs/docker-node/blob/6f740b0ca772e978b44c11d194f369e554c54a14/16/buster/Dockerfile) officiel de NodeJS. L'image permet de toujours avoir la dernière version de Node (cf point suivant). Ça permet également de ne pas utiliser nvm / nodesource / le [package n](https://www.npmjs.com/package/n) ou une installation manuelle comme précédemment
- pour Node, je propose de partir sur la version LTS (16.13.1 avec NPM 8.1.2). plutôt que la current (17.3.0 avec NPM 8.3.0)
- pour Python je propose de partir sur la version 3.7.10 qui reste compatible avec nos usages tout en ayant des patchs de sécurité supplémentaires par rapport à 3.7.3

### Points d'attention
- l'image utilise toujours `wget` / `curl` là où la bonne pratique d'un Dockerfile voudrait qu'on utilise que l'un des deux
- je n'ai pas touché aux versions des navigateurs pour la CI ;  de mon point de vue ça n'est pas un risque de sécu et ça permet d'être sûr de ne pas intégrer de features supportées que par des navigateurs très récents (< 2 ans)
- j'ai réuni les `apt install` que j'exécute d'ailleurs dans la même boucle `RUN` que l'apt update pour éviter des problèmes de cache (cf [Best Practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get)
- j'ai légèrement augmenté le timeout (30 secondes à 60 secondes) de la CI sur l'étape `Wait for Mes Aides`. On a eu pas mal d'échecs sur la partie des tests end-to-end parce que la webapp mettait un peu trop longtemps pour être dispo. C'est possible d'optimiser certaines étapes en amont pour réduire le temps de CI mais il faudrait y passer du temps. Là ça permettra d'éviter des erreurs de CI sans raison


J'ai également créé le [package associé](https://github.com/betagouv/mes-aides-dockerfiles/pkgs/container/mes-aides-dockerfiles) dans Github Container Registry et mis à jour le [README.md](https://github.com/betagouv/mes-aides-dockerfiles) du repository associé pour expliquer la démarche pour ajouter une image.