### PR TITLE
[473] Corrige un bug lors de l'accès à la page de suivi

### DIFF
--- a/src/views/Suivi.vue
+++ b/src/views/Suivi.vue
@@ -184,9 +184,12 @@ export default {
     isNumber: (val) => typeof val === "number",
     isNegative,
     prefix: function (droit) {
-      return `${droit.prefix}${
-        droit.prefix[droit.prefix.length - 1] == "’" ? "" : " "
-      }`
+      if (droit.prefix) {
+        return `${droit.prefix}${
+          droit.prefix[droit.prefix.length - 1] == "’" ? "" : " "
+        }`
+      }
+      return ""
     },
     submit: function () {
       let answers = this.droits.map((droit) => ({


### PR DESCRIPTION
## Description

Lors de l'accès à la page de suivi, les aides auxquelles ils manquaient un préfixe ("Le", "La", L'" etc) empêchaient l'affichage d'information