### PR TITLE
[467] Réparer la récupération des paramètres OpenFisca en mode npm run front

### DIFF
--- a/backend/lib/openfisca/parameters.js
+++ b/backend/lib/openfisca/parameters.js
@@ -47,6 +47,8 @@ const computeParameter = (parameter, date) => {
   return parametersList[parameter]
 }
 
+module.exports.parametersList = parametersList
+
 module.exports.getParameter = (parameter, date) => {
   return computeParameter(parameter, date)
 }

--- a/mock.js
+++ b/mock.js
@@ -65,6 +65,16 @@ function mock({ app }) {
     res.send([])
   })
 
+  app.get("/api/openfisca/parameters/:timestamp", function (req, res) {
+    res.send({
+      "prestations.carte_des_metiers.age_maximal": 26,
+      "prestations.minima_sociaux.aah.taux_incapacite": 0.8,
+      "epargne.livret_a.taux": 0.005,
+      "marche_travail.salaire_minimum.smic_h_b": 10.48,
+      "marche_travail.salaire_minimum.nb_heure_travail_mensuel": 151.67,
+    })
+  })
+
   app.get("/api/followups/surveys/:id", function (req, res) {
     res.send({
       benefits: [

--- a/mock.js
+++ b/mock.js
@@ -2,6 +2,7 @@ const bodyParser = require("body-parser")
 const axios = require("axios")
 const outils = require("./backend/controllers/outils")
 const mapping = require("./backend/lib/openfisca/mapping")
+const openfiscaParameters = require("./backend/lib/openfisca/parameters.js")
 
 const openfiscaRoot = "https://openfisca.mes-aides.1jeune1solution.beta.gouv.fr"
 const buildOpenFiscaRequest = mapping.buildOpenFiscaRequest
@@ -66,13 +67,7 @@ function mock({ app }) {
   })
 
   app.get("/api/openfisca/parameters/:timestamp", function (req, res) {
-    res.send({
-      "prestations.carte_des_metiers.age_maximal": 26,
-      "prestations.minima_sociaux.aah.taux_incapacite": 0.8,
-      "epargne.livret_a.taux": 0.005,
-      "marche_travail.salaire_minimum.smic_h_b": 10.48,
-      "marche_travail.salaire_minimum.nb_heure_travail_mensuel": 151.67,
-    })
+    res.send(openfiscaParameters.parametersList)
   })
 
   app.get("/api/followups/surveys/:id", function (req, res) {


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/LgXZCg0N/467-r%C3%A9parer-la-r%C3%A9cup%C3%A9ration-des-param%C3%A8tres-openfisca-en-mode-npm-run-front)

## Détails

Lors de l'exécution de `npm run front`, les appels API sont mockés dans le fichier `mock.js`. Or les requêtes du type `/api/openfisca/parameters/:timestamp` n'avait pas de mock.