### PR TITLE
[468] Corriger la corruption potentielle des infos de commune

### DIFF
--- a/src/views/Simulation/Menage/Depcom.vue
+++ b/src/views/Simulation/Menage/Depcom.vue
@@ -69,7 +69,9 @@ export default {
   },
   watch: {
     codePostal: function (cp) {
-      if (cp && cp.length == 5) {
+      this.nomCommune = null
+      this.communes = []
+      if (cp?.length == 5) {
         this.fetchCommune()
       }
     },


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/yhE3oeST/468-corriger-la-corruption-potentielle-des-infos-de-commune)

## Détails
- [x] empêche de valider le formulaire si la liste des communes est en train d'être récupéré
- [x] n'impacte pas un utilisateur ayant déjà rentré son code postal + commune et étant revenu à cette étape