### PR TITLE
Ajoute un id aux institutions pour y associer leur identifiant officiel

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -667,7 +667,7 @@ collections:
         options: *field_geographical_type
       - label: Identifiant
         hint: Code INSEE pour les communes, départements, régions et code SIREN pour les autres
-        name: publicId
+        name: id
         widget: string
         required: false
   - name: contribution-pages

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -665,6 +665,11 @@ collections:
         name: type
         widget: select
         options: *field_geographical_type
+      - label: Identifiant
+        hint: Code INSEE pour les communes, départements, régions et code SIREN pour les autres
+        name: publicId
+        widget: string
+        required: false
   - name: contribution-pages
     label: Pages
     label_singular: page

--- a/data/index.js
+++ b/data/index.js
@@ -5,7 +5,8 @@ const customBenefits = require("./benefits/custom/index")
 function transformInstitutions(collection) {
   return collection.reduce((result, data) => {
     const item = {
-      id: data.slug,
+      slug: data.slug,
+      id: data.id || data.slug,
       label: data.name,
       imgSrc: data.imgSrc && data.imgSrc.slice("img/".length),
       benefitsIds: [],

--- a/src/views/liste-aides.vue
+++ b/src/views/liste-aides.vue
@@ -54,12 +54,12 @@ export default {
         })
 
         const institutions = benefits.reduce((accum, benefit) => {
-          const institution = accum[benefit.institution.id] || {
-            ...institutionsMap[benefit.institution.id],
+          const institution = accum[benefit.institution.slug] || {
+            ...institutionsMap[benefit.institution.slug],
             benefits: [],
           }
           institution.benefits.push(benefit)
-          accum[institution.id] = institution
+          accum[institution.slug] = institution
 
           return accum
         }, {})

--- a/tests/unit/benefitsGenerate.spec.js
+++ b/tests/unit/benefitsGenerate.spec.js
@@ -6,7 +6,10 @@ describe("benefit descriptions", function () {
   it("exists", function () {
     const collections = {
       institutions: {
-        items: [{ slug: "etat", national: true }, { slug: "region" }],
+        items: [
+          { slug: "etat", national: true },
+          { slug: "region", id: "region_id" },
+        ],
       },
       benefits_javascript: {
         items: [
@@ -32,7 +35,7 @@ describe("benefit descriptions", function () {
     expect(
       result.institutionsMap.region.benefitsIds.includes("region_benefit")
     ).toBeTruthy()
-    expect(result.benefitsMap.region_benefit.institution.id).toBe("region")
+    expect(result.benefitsMap.region_benefit.institution.id).toBe("region_id")
     expect(result.all.length).toBe(3)
   })
 })


### PR DESCRIPTION
Avec cette PR
L'attribut existant `id` s'appelle désormais `slug`.
L'attribut `id` contient désormais un code identifiant officiel (code INSEE, SIREN, etc.) 