### PR TITLE
[483] Correction de commune des parents invalide

### DIFF
--- a/src/views/Simulation/Individu/_BourseCriteresSociauxCommuneDomicileFamilial.vue
+++ b/src/views/Simulation/Individu/_BourseCriteresSociauxCommuneDomicileFamilial.vue
@@ -67,10 +67,17 @@ export default {
   },
   watch: {
     codePostal: function (cp) {
-      if (cp && cp.length == 5) {
+      this.nomCommune = null
+      this.communes = []
+      if (cp?.length == 5) {
         this.fetchCommune()
       }
     },
+  },
+  beforeMount() {
+    if (this.codePostal && this.codePostal.length == 5) {
+      this.fetchCommune()
+    }
   },
   methods: {
     onSubmit: function () {


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/pbKmiSqy/483-correction-de-commune-des-parents-invalide)
[Erreur Sentry](https://sentry.io/organizations/betagouv-f7/issues/2886792390/?project=5709078&query=is%3Aunresolved)

## Détails

L'enregistrement de la commune des parents pouvait ne pas se faire correctement, ce qui rendait l'accès au sommaire impossible par la suite.

Lié indirectement à la PR https://github.com/betagouv/aides-jeunes/pull/2284, avec le fait que la ville n'était pas automatiquement chargée lors de la répétition de cette étape (ex: après un retour en arrière)