### PR TITLE
Ajoute un event dans l'analytics pour les ctas

### DIFF
--- a/src/components/benefit-cta-link.vue
+++ b/src/components/benefit-cta-link.vue
@@ -17,6 +17,7 @@
 
 <script>
 import StatisticsMixin from "@/mixins/statistics"
+import ResultatsMixin from "@/mixins/resultats"
 
 let typeLabels = {
   teleservice: "Faire une demande en ligne",
@@ -33,7 +34,7 @@ let longLabels = {
 export default {
   name: "BenefitCtaLink",
   components: {},
-  mixins: [StatisticsMixin],
+  mixins: [ResultatsMixin, StatisticsMixin],
   props: {
     analyticsName: String,
     benefit: Object,
@@ -63,6 +64,7 @@ export default {
       return link
     },
     onClick: function (link) {
+      this.sendStatistics(this.droits, this.type, this.benefit.id)
       if (typeof link === "object") {
         window.localStorage.setItem(
           "trampoline",


### PR DESCRIPTION
En complément de cette PR une modification des events sont nécessaires
 "si l'on regarde le schéma mongo on n'accepte que les évènements show (page de résultat affichée) et showDetails (un utilisateur affiche les détails d'une aide depuis la page de résultat)." : https://github.com/betagouv/aides-jeunes/pull/2303#discussion_r782038979