### PR TITLE
[500] Mettre à jour les différents package présentant des CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8631,9 +8631,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",
@@ -24629,9 +24629,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "font-awesome": {
       "version": "4.7.0",


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/RWFBVb3Y/500-mettre-%C3%A0-jour-les-diff%C3%A9rents-package-pr%C3%A9sentant-des-cve)

## Détails

Le package mis à jour par cette PR est le suivant : 
- `follow-redirects` : passage de la version `1.14.5` à la version `1.14.7`

Différent package sont affectés mais ne peuvent/nécessitent pas d'être mis à jour  :
- `chalk/ansi-regex` ([CVE-2021-3807](https://github.com/advisories/GHSA-93q8-gq69-wqmw)). Utilisé par `vue-cli-service`. Après investigation la CVE n'a aucun impact tant que l'on ne laisse pas des utilisateurs éditer le code librement, changer la configuration de webpack ou toute autre contribution active au code du projet.
- `postcss` ([CVE-2021-23382](https://github.com/advisories/GHSA-566m-qj78-rww5)). Utilisé par `vue-cli-service`. Après invesigation la CVE n'a aucun impact, tant que l'on ne laisse par des utilisateurs ajouter du CSS (qui serait malicieux) au code du projet. Si c'était le cas, seul le build serait impacté.

Il n'existe pas encore de nouvelle version de `@vue/cli-service` n'utilisant pas les 2 packages nommés ci-dessus. La version précédente sans ces 2 packages est la  `3.3.1` (la version actuelle étant la version `5.0.0`), mais celle-ci embarque d'autres vulnérabilités non corrigées.

## Notes

```bash
# npm audit report

ansi-regex  >2.1.1 <5.0.1
Severity: moderate
 Inefficient Regular Expression Complexity in chalk/ansi-regex - https://github.com/advisories/GHSA-93q8-gq69-wqmw
fix available via `npm audit fix --force`
Will install @vue/cli-service@3.3.1, which is a breaking change
node_modules/log-update/node_modules/ansi-regex
  strip-ansi  4.0.0 - 5.2.0
  Depends on vulnerable versions of ansi-regex
  node_modules/log-update/node_modules/strip-ansi
    string-width  2.1.0 - 4.1.0
    Depends on vulnerable versions of strip-ansi
    node_modules/log-update/node_modules/string-width
      wrap-ansi  3.0.0 - 6.1.0
      Depends on vulnerable versions of string-width
      Depends on vulnerable versions of strip-ansi
      node_modules/log-update/node_modules/wrap-ansi
        log-update  2.1.0 - 3.4.0
        Depends on vulnerable versions of wrap-ansi
        node_modules/log-update
          progress-webpack-plugin  *
          Depends on vulnerable versions of log-update
          node_modules/progress-webpack-plugin
            @vue/cli-service  *
            Depends on vulnerable versions of @vue/component-compiler-utils
            Depends on vulnerable versions of progress-webpack-plugin
            Depends on vulnerable versions of vue-loader
            node_modules/@vue/cli-service

postcss  <8.2.13
Severity: moderate
Regular Expression Denial of Service in postcss - https://github.com/advisories/GHSA-566m-qj78-rww5
fix available via `npm audit fix --force`
Will install @vue/cli-service@3.3.1, which is a breaking change
node_modules/@vue/component-compiler-utils/node_modules/postcss
  @vue/component-compiler-utils  *
  Depends on vulnerable versions of postcss
  node_modules/@vue/component-compiler-utils
    @vue/cli-service  *
    Depends on vulnerable versions of @vue/component-compiler-utils
    Depends on vulnerable versions of progress-webpack-plugin
    Depends on vulnerable versions of vue-loader
    node_modules/@vue/cli-service
    vue-loader  15.0.0-beta.1 - 15.9.8
    Depends on vulnerable versions of @vue/component-compiler-utils
    node_modules/@vue/vue-loader-v15

10 moderate severity vulnerabilities
```

