### PR TITLE
[TEST] Fix/ratio image home

### DIFF
--- a/src/styles/partials/desktop/_home.scss
+++ b/src/styles/partials/desktop/_home.scss
@@ -55,21 +55,37 @@ html {
     }
 
     .aj-home-illustration {
-      width: 40%;
       display: flex;
       align-items: flex-end;
-      img {
-        height: 87%;
-      }
     }
   }
 }
 
-@media screen and (max-width: 2100px) {
+@media screen and (min-width: 557px) and (orientation: portrait) {
   .aj-home-illustration {
     justify-content: center;
     img {
       max-width: 100%;
+    }
+  }
+}
+
+@media screen and (max-width: 2100px) and (orientation: landscape) {
+  .aj-home-illustration {
+    width: 40%;
+    justify-content: center;
+    img {
+      max-width: 100%;
+      height: 87%;
+    }
+  }
+}
+
+@media screen and (min-width: 2100px) and (orientation: landscape) {
+  .aj-home-illustration {
+    width: 40%;
+    img {
+      height: 87%;
     }
   }
 }

--- a/src/styles/partials/desktop/_home.scss
+++ b/src/styles/partials/desktop/_home.scss
@@ -20,7 +20,7 @@ html {
     height: 100%;
 
     .aj-home-hero {
-      width: 60%;
+      width: 65%;
       display: flex;
       align-items: center;
       flex-wrap: wrap;
@@ -56,36 +56,14 @@ html {
 
     .aj-home-illustration {
       display: flex;
-      align-items: flex-end;
-    }
-  }
-}
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: flex-start;
 
-@media screen and (min-width: 557px) and (orientation: portrait) {
-  .aj-home-illustration {
-    justify-content: center;
-    img {
-      max-width: 100%;
-    }
-  }
-}
-
-@media screen and (max-width: 2100px) and (orientation: landscape) {
-  .aj-home-illustration {
-    width: 40%;
-    justify-content: center;
-    img {
-      max-width: 100%;
-      height: 87%;
-    }
-  }
-}
-
-@media screen and (min-width: 2100px) and (orientation: landscape) {
-  .aj-home-illustration {
-    width: 40%;
-    img {
-      height: 87%;
+      img {
+        max-height: 87%;
+        flex-grow: 2;
+      }
     }
   }
 }

--- a/src/styles/partials/desktop/_home.scss
+++ b/src/styles/partials/desktop/_home.scss
@@ -57,13 +57,19 @@ html {
     .aj-home-illustration {
       width: 40%;
       display: flex;
-      justify-content: center;
       align-items: flex-end;
-
       img {
-        max-width: 100%;
         height: 87%;
       }
+    }
+  }
+}
+
+@media screen and (max-width: 2100px) {
+  .aj-home-illustration {
+    justify-content: center;
+    img {
+      max-width: 100%;
     }
   }
 }

--- a/src/styles/partials/desktop/_home.scss
+++ b/src/styles/partials/desktop/_home.scss
@@ -20,7 +20,7 @@ html {
     height: 100%;
 
     .aj-home-hero {
-      width: 65%;
+      width: 55%;
       display: flex;
       align-items: center;
       flex-wrap: wrap;
@@ -58,10 +58,20 @@ html {
       display: flex;
       flex-direction: column;
       justify-content: flex-end;
-      align-items: flex-start;
+      align-items: stretch;
+      flex-grow: 2;
+
+      div {
+        display: flex;
+        align-items: flex-end;
+        max-height: 87%;
+        flex-grow: 2;
+      }
 
       img {
-        max-height: 87%;
+        max-height: 100%;
+        max-width: 100%;
+        object-fit: contain;
         flex-grow: 2;
       }
     }

--- a/src/styles/partials/desktop/_home.scss
+++ b/src/styles/partials/desktop/_home.scss
@@ -55,25 +55,10 @@ html {
     }
 
     .aj-home-illustration {
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-      align-items: stretch;
       flex-grow: 2;
-
-      div {
-        display: flex;
-        align-items: flex-end;
-        max-height: 87%;
-        flex-grow: 2;
-      }
-
-      img {
-        max-height: 100%;
-        max-width: 100%;
-        object-fit: contain;
-        flex-grow: 2;
-      }
+      background: transparent url("~@/assets/images/home_illustration.png")
+        center bottom / 87% no-repeat;
+      min-height: 700px;
     }
   }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -31,7 +31,7 @@
           </div>
         </div>
       </div>
-      <div class="aj-home-illustration" alt="Portrait jeune"> </div>
+      <div class="aj-home-illustration" role="img" alt="Portrait jeune"> </div>
     </div>
   </div>
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -32,7 +32,12 @@
         </div>
       </div>
       <div class="aj-home-illustration">
-        <img src="@/assets/images/home_illustration.png" alt="Portrait jeune" />
+        <div>
+          <img
+            src="@/assets/images/home_illustration.png"
+            alt="Portrait jeune"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -31,14 +31,7 @@
           </div>
         </div>
       </div>
-      <div class="aj-home-illustration">
-        <div>
-          <img
-            src="@/assets/images/home_illustration.png"
-            alt="Portrait jeune"
-          />
-        </div>
-      </div>
+      <div class="aj-home-illustration" alt="Portrait jeune"> </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Description

Ma version de la PR #2275. 

## Questions / réponses
- Pourquoi mettre la valeur `min-height` de `.aj-home-illustration` à 700px ?
  - Parce qu'on pourrait théoriquement hériter de la hauteur `100%` depuis les balises `html` et `body` mais ça rajouterait du code et que le rendu actuel est au plus proche de la PR #2275 
- Pourquoi mettre un `alt="Portrait jeune"` et un `role="img"` directement sur le `div``
  - Pour améliorer l'accessibilité, cf la [doc w3](https://www.w3.org/TR/wai-aria-1.1/#img)