### PR TITLE
[511] Ajouter le niveau d'accessibilité dans le footer

### DIFF
--- a/src/components/footer-1j1s.vue
+++ b/src/components/footer-1j1s.vue
@@ -75,7 +75,7 @@ export default {
               route: "/confidentialite",
             },
             {
-              label: "Accessibilité",
+              label: "Accessibilité (non conforme)",
               route: "/accessibilite",
             },
             {


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/e73LpK7o/511-ajouter-le-niveau-daccessibilit%C3%A9-dans-le-footer)

Après un passage sur [dashlord](https://dashlord.incubateur.net/#/url/https:%2F%2Fmes-aides.1jeune1solution.beta.gouv.fr) et un check de notre site il y a bien déjà un lien vers la déclaration d'accessibilité présent mais il faut que celui indique explicitement si l'accessibilité est conforme ou non.

Par exemple sur [dashlord pour beta.gouv.fr](https://dashlord.incubateur.net/#/url/https:%2F%2Fbeta.gouv.fr) on peut que l'accessibilité est présente mais non valide) (on trouve bien la mention ` Accessibilité : non conforme` dans le footer de beta.gouv.fr)