### PR TITLE
Corrige le test jest

### DIFF
--- a/tests/unit/compute-aides.spec.js
+++ b/tests/unit/compute-aides.spec.js
@@ -67,6 +67,9 @@ describe("computeAides", function () {
           rfr: {
             2012: 42,
           },
+          nbptr: {
+            2012: 2,
+          },
         },
       },
     }


### PR DESCRIPTION
Si aucune condition n'a été stipulé autre que le `quotient_familial`, alors le test plante