### PR TITLE
[530] Ajoute un champ participation aux aides

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -251,7 +251,7 @@ fields:
         name: periodicite
         widget: select
         required: false
-        options: [Annuel, Trimestrielle, Mensuel, Unique, Autre]
+        options: [Annuelle, Trimestrielle, Mensuelle, Unique, Autre]
 
   field_lien_plus_informations: &field_lien_plus_informations
     label: Lien vers la page d'informations de référence

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -223,6 +223,36 @@ fields:
           '\.$',
           "La condition doit commencer par un verbe à l'infinitif et se terminer par un point",
         ]
+  field_participation: &field_participation
+    label: Coûts d'accès à l'aide
+    label_singular: Coût d'accès à l'aide
+    hint: |
+      Certaines aides et avantages peuvent avoir un coût d'acquisition (ex: carte de réduction)
+    name: field_participation
+    widget: list
+    collapsed: false
+    required: false
+    fields:
+      - label: Légende
+        name: legende
+        widget: string
+        required: false
+      - label: Coût en euros
+        name: cout
+        widget: number
+        required: false
+        step: -1
+      - label: Type
+        name: type
+        widget: select
+        required: false
+        options: [Fixe, Variable]
+      - label: Périodicité
+        name: periodicite
+        widget: select
+        required: false
+        options: [Annuel, Trimestrielle, Mensuel, Unique, Autre]
+
   field_lien_plus_informations: &field_lien_plus_informations
     label: Lien vers la page d'informations de référence
     hint: Vers un site institutionnel de préférence (par exemple, pour les aides nationales il s'agit souvent de service-public.fr)
@@ -630,6 +660,7 @@ collections:
       - *field_legende_montant
       - *field_montant_maximal_aide
       - *field_interet_particulier
+      - *field_participation
       - *field_references
   - name: benefits_openfisca
     label: Aides complexes
@@ -658,6 +689,7 @@ collections:
       - *field_legende_montant
       - *field_fiabilite_montant
       - *field_interet_particulier
+      - *field_participation
       - *field_entite_rattachement_openfisca
   - name: institutions
     label: Institutions

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -251,7 +251,17 @@ fields:
         name: periodicite
         widget: select
         required: false
-        options: [Annuelle, Trimestrielle, Mensuelle, Unique, Autre]
+        options:
+          - label: Annuelle
+            value: an
+          - label: Trimestrielle
+            value: trimestre
+          - label: Mensuelle
+            value: mois
+          - label: Unique
+            value: unique
+          - label: Autre
+            value: autre
   field_lien_plus_informations: &field_lien_plus_informations
     label: Lien vers la page d'informations de référence
     hint: Vers un site institutionnel de préférence (par exemple, pour les aides nationales il s'agit souvent de service-public.fr)

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -228,9 +228,9 @@ fields:
     label_singular: Coût d'accès à l'aide
     hint: |
       Certaines aides et avantages peuvent avoir un coût d'acquisition (ex: carte de réduction)
-    name: field_participation
-    widget: list
-    collapsed: false
+    name: participation
+    widget: object
+    collapsed: true
     required: false
     fields:
       - label: Légende
@@ -252,7 +252,6 @@ fields:
         widget: select
         required: false
         options: [Annuelle, Trimestrielle, Mensuelle, Unique, Autre]
-
   field_lien_plus_informations: &field_lien_plus_informations
     label: Lien vers la page d'informations de référence
     hint: Vers un site institutionnel de préférence (par exemple, pour les aides nationales il s'agit souvent de service-public.fr)

--- a/contribuer/public/admin/main.js
+++ b/contribuer/public/admin/main.js
@@ -27,7 +27,16 @@ const Conditions = ({ conditions, participation }) => {
 
 const Participation = ({ participation }) => {
   if (participation && participation.legende) {
-    return <li>{participation.legende}</li>
+    const legend = participation.legende
+    const period = !["unique", "autre"].includes(participation.periodicite)
+      ? ` / ${participation.periodicite}`
+      : ""
+    const cost = participation.cout ? `(${participation.cout}€${period})` : ""
+    return (
+      <li>
+        {participation.legende} {cost}
+      </li>
+    )
   }
 }
 

--- a/contribuer/public/admin/main.js
+++ b/contribuer/public/admin/main.js
@@ -4,7 +4,7 @@ const LEGENDE_PERIODICITE_AIDE_ENUM = {
   annuelle: "/ an",
 }
 
-const Conditions = ({ conditions }) => {
+const Conditions = ({ conditions, participation }) => {
   if (!conditions || !conditions.length) {
     return <div></div>
   }
@@ -17,9 +17,18 @@ const Conditions = ({ conditions }) => {
       <p className="aj-content-conditions-title">
         Pour en bénéficier, vous devez également :
       </p>
-      <ul className="list-unstyled">{conditionsList}</ul>
+      <ul className="list-unstyled">
+        {conditionsList}
+        {Participation({ participation })}
+      </ul>
     </div>
   )
+}
+
+const Participation = ({ participation }) => {
+  if (participation && participation.legende) {
+    return <li>{participation.legende}</li>
+  }
 }
 
 const Description = ({ description, link }) => {
@@ -124,7 +133,10 @@ const DroitPreviewTemplate = ({ entry }) => {
               <Description description={droit.description} link={droit.link} />
             </div>
             <div className="aj-droit-conditions">
-              <Conditions conditions={droit.conditions} />
+              <Conditions
+                conditions={droit.conditions}
+                participation={droit.participation}
+              />
             </div>
             <div className="aj-droit-content-buttons-cta">
               <CTA droit={droit} />

--- a/src/components/droits-details.vue
+++ b/src/components/droits-details.vue
@@ -32,7 +32,7 @@
               </li>
               <li v-if="droit.participation">
                 <img src="@/assets/images/doigt.svg" />
-                <span>{{ droit.participation.legende }}</span>
+                <span>{{ formatParticipation(droit.participation) }}</span>
               </li>
             </ul>
           </div>

--- a/src/components/droits-details.vue
+++ b/src/components/droits-details.vue
@@ -30,6 +30,10 @@
                 <img src="@/assets/images/doigt.svg" />
                 <span v-html="condition" />
               </li>
+              <li v-if="droit.participation">
+                <img src="@/assets/images/doigt.svg" />
+                <span>{{ droit.participation.legende }}</span>
+              </li>
             </ul>
           </div>
         </div>

--- a/src/mixins/droit-mixin.js
+++ b/src/mixins/droit-mixin.js
@@ -7,5 +7,13 @@ export default {
     isEmpty: (array) => array.length === 0,
     isNumber: (val) => typeof val === "number",
     isString: (val) => typeof val === "string",
+    formatParticipation: (participation) => {
+      const legend = participation.legende
+      const period = !["unique", "autre"].includes(participation.periodicite)
+        ? ` / ${participation.periodicite}`
+        : ""
+      const cost = participation.cout ? `(${participation.cout}€${period})` : ""
+      return `${participation.legende} ${cost}`
+    },
   },
 }

--- a/src/mixins/droit-mixin.js
+++ b/src/mixins/droit-mixin.js
@@ -8,12 +8,15 @@ export default {
     isNumber: (val) => typeof val === "number",
     isString: (val) => typeof val === "string",
     formatParticipation: (participation) => {
-      const legend = participation.legende
-      const period = !["unique", "autre"].includes(participation.periodicite)
-        ? ` / ${participation.periodicite}`
-        : ""
-      const cost = participation.cout ? `(${participation.cout}€${period})` : ""
-      return `${participation.legende} ${cost}`
+      if (participation.legende) {
+        const period = !["unique", "autre"].includes(participation.periodicite)
+          ? ` / ${participation.periodicite}`
+          : ""
+        const cost = participation.cout
+          ? `(${participation.cout}€${period})`
+          : ""
+        return `${participation.legende} ${cost}`
+      }
     },
   },
 }


### PR DESCRIPTION
## Description

Cette PR ajoute un champ de participation à l'outil de contribution permettant de spécifier le coût d'accès à une aide (par exemple une carte jeune donnant droit à des réductions avec un coût à l'achat de XX€).

## Tâches restantes

- [ ] Définir en terme d'UI/UX l'apparence des coûts d'une aide (encart spécifique etc)
- [ ] Mettre à jour les aides existantes demandant déjà une contribution
- [ ] Ajouter des tests unitaires liés aux contributions