### PR TITLE
Affiche les aides vélos si une commune contient `_departement` et `_region`

### DIFF
--- a/lib/benefits/compute-aides-velo.js
+++ b/lib/benefits/compute-aides-velo.js
@@ -10,7 +10,7 @@ const veloTypes = {
   velo_motorisation: "motorisation",
 }
 
-function showBikeBenefits(situation) {
+function canComputeAidesVeloBenefits(situation) {
   return [
     situation.menage.depcom,
     situation.menage._departement,
@@ -24,7 +24,7 @@ function computeAidesVeloBenefits(
   situation,
   openfiscaResponse
 ) {
-  if (!showBikeBenefits(situation)) {
+  if (!canComputeAidesVeloBenefits(situation)) {
     return
   }
 

--- a/lib/benefits/compute-aides-velo.js
+++ b/lib/benefits/compute-aides-velo.js
@@ -10,6 +10,14 @@ const veloTypes = {
   velo_motorisation: "motorisation",
 }
 
+function showBikeBenefits(situation) {
+  return [
+    situation.menage.depcom,
+    situation.menage._departement,
+    situation.menage._region,
+  ].every((value) => Boolean(value))
+}
+
 function computeAidesVeloBenefits(
   aidesVeloBenefitList,
   resultHolder,
@@ -17,6 +25,10 @@ function computeAidesVeloBenefits(
   openfiscaResponse
 ) {
   const periods = generator(situation.dateDeValeur)
+
+  if (!showBikeBenefits(situation)) {
+    return
+  }
 
   const eligibleBenefitsMap = {}
   for (let type of situation.demandeur._interetsAidesVelo) {
@@ -54,4 +66,7 @@ function computeAidesVeloBenefits(
     })
 }
 
-exports.computeAidesVeloBenefits = computeAidesVeloBenefits
+module.exports = {
+  computeAidesVeloBenefits,
+  showBikeBenefits,
+}

--- a/lib/benefits/compute-aides-velo.js
+++ b/lib/benefits/compute-aides-velo.js
@@ -24,11 +24,11 @@ function computeAidesVeloBenefits(
   situation,
   openfiscaResponse
 ) {
-  const periods = generator(situation.dateDeValeur)
-
   if (!showBikeBenefits(situation)) {
     return
   }
+
+  const periods = generator(situation.dateDeValeur)
 
   const eligibleBenefitsMap = {}
   for (let type of situation.demandeur._interetsAidesVelo) {
@@ -66,7 +66,4 @@ function computeAidesVeloBenefits(
     })
 }
 
-module.exports = {
-  computeAidesVeloBenefits,
-  showBikeBenefits,
-}
+exports.computeAidesVeloBenefits = computeAidesVeloBenefits

--- a/src/lib/State/blocks.js
+++ b/src/lib/State/blocks.js
@@ -3,7 +3,6 @@ const { ACTIVITES_ACTIF } = require("../../../lib/activite")
 const Ressource = require("@/../lib/ressource")
 const { datesGenerator } = require("../../../lib/benefits/compute")
 const { Step, ComplexStep } = require("./steps")
-const { showBikeBenefits } = require("../../../lib/benefits/compute-aides-velo")
 
 function individuBlockFactory(id, chapter) {
   const r = (variable, chapter) =>
@@ -225,10 +224,7 @@ function extraBlock() {
       situation.enfants?.find((enfant) => enfant.id === id) ||
       {},
     steps: [
-      {
-        isActive: (_, situation) => showBikeBenefits(situation),
-        steps: [s("_interetsAidesVelo", "projets")],
-      },
+      s("_interetsAidesVelo", "projets"),
       s("_interetBafa", "projets"),
       s("_interetPermisDeConduire", "projets"),
       {

--- a/src/lib/State/blocks.js
+++ b/src/lib/State/blocks.js
@@ -3,6 +3,7 @@ const { ACTIVITES_ACTIF } = require("../../../lib/activite")
 const Ressource = require("@/../lib/ressource")
 const { datesGenerator } = require("../../../lib/benefits/compute")
 const { Step, ComplexStep } = require("./steps")
+const { showBikeBenefits } = require("../../../lib/benefits/compute-aides-velo")
 
 function individuBlockFactory(id, chapter) {
   const r = (variable, chapter) =>
@@ -224,7 +225,10 @@ function extraBlock() {
       situation.enfants?.find((enfant) => enfant.id === id) ||
       {},
     steps: [
-      s("_interetsAidesVelo", "projets"),
+      {
+        isActive: (_, situation) => showBikeBenefits(situation),
+        steps: [s("_interetsAidesVelo", "projets")],
+      },
       s("_interetBafa", "projets"),
       s("_interetPermisDeConduire", "projets"),
       {


### PR DESCRIPTION
Comment reproduire le bug :
Faire une simulation avec le code postal 97150 avec un intéret pour les aides vélos.
Raison : 
Les aides vélos nécessitent `_depcom`, `_departement`, `_region` sinon le moteur d'aide ne fonctionne pas.

Autre point, sur le site https://mesaidesvelo.fr/ nous ne pouvons pas renseigner le code postal 97150.
 
 J'ai donc fait le choix de ne pas afficher les aides pour les zone n'ayant pas de _departement ni de _region
