### PR TITLE
[562] Ajouter des fonctions de linting de certains champs de l'outil de contribution

### DIFF
--- a/contribuer/public/admin/description.js
+++ b/contribuer/public/admin/description.js
@@ -1,7 +1,11 @@
 const Text = CMS.getWidget("text")
 
 class DescriptionControl extends Text.control {
+  format = (value) => {
+    return value.trim().replace(/ +(?= )/g, "")
+  }
   isValid = () => {
+    this.props.onChange(this.format(this.props.value))
     const p = document.createElement("p")
     p.innerHTML = this.props.value
     const innerText = p.textContent

--- a/contribuer/public/admin/formatter.js
+++ b/contribuer/public/admin/formatter.js
@@ -1,0 +1,20 @@
+const StringControl = CMS.getWidget("string").control
+
+class CustomStringControl extends StringControl {
+  constructor(props) {
+    super(props)
+    this.state = {
+      value: this.props.value,
+    }
+  }
+  format = (value) => {
+    return value.trim().replace(/ +(?= )/g, "")
+  }
+  isValid = () => {
+    this.props.onChange(this.format(this.props.value))
+    return (
+      !this.props.field.get("required", true) || this.props.value.length > 0
+    )
+  }
+}
+CMS.registerWidget("string", CustomStringControl)

--- a/contribuer/public/admin/index.html
+++ b/contribuer/public/admin/index.html
@@ -14,6 +14,7 @@
     <script src="main.js" type="text/babel"></script>
     <script src="description.js"></script>
     <script src="institution.js"></script>
+    <script src="formatter.js"></script>
 
     <script>
       CMS.registerPreviewStyle("/css/style.css")


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/GuoXcbtd/562-ajouter-des-fonctions-de-linting-de-certains-champs-de-loutil-de-contribution)

## Détails

Le but de cette tâche est de diminuer les aller-retours lors de l'ajout d'aide en s'assurant que la CI ne puisse pas échouer si les champs de texte ("string") de l'outil de contribution contiennent plusieurs espaces à la suite ou des espaces en début et fin de chaines de caractères.