### PR TITLE
fix: laisse les champs vides à undefined

### DIFF
--- a/contribuer/public/admin/description.js
+++ b/contribuer/public/admin/description.js
@@ -5,7 +5,9 @@ class DescriptionControl extends Text.control {
     return value.trim().replace(/ +(?= )/g, "")
   }
   isValid = () => {
-    this.props.onChange(this.format(this.props.value))
+    if (this.props.value?.length > 0) {
+      this.props.onChange(this.format(this.props.value))
+    }
     const p = document.createElement("p")
     p.innerHTML = this.props.value
     const innerText = p.textContent

--- a/contribuer/public/admin/formatter.js
+++ b/contribuer/public/admin/formatter.js
@@ -11,7 +11,9 @@ class CustomStringControl extends StringControl {
     return value.trim().replace(/ +(?= )/g, "")
   }
   isValid = () => {
-    this.props.onChange(this.format(this.props.value))
+    if (this.props.value?.length > 0) {
+      this.props.onChange(this.format(this.props.value))
+    }
     return (
       !this.props.field.get("required", true) || this.props.value.length > 0
     )


### PR DESCRIPTION
## Description

La PR #2395 induisait un bug remplaçant la valeur `undefined` de champ vide en une string vide `""`, créant des entrées inutiles dans des fichiers yaml et causant des erreurs de CI