### PR TITLE
[574] Éviter le crash de l'app en npm run front quand on essaie de récupérer le payload openfisca d'une simulation qui n'existe pas

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -50,21 +50,29 @@ function mock({ app }) {
   })
 
   app.get("/api/answers/:id/openfisca-response", function (req, res, next) {
-    const simulation = cache[req.params.id]
-    const situation = generateSituation(simulation)
-    sendToOpenfisca(situation, function (err, result) {
-      if (err) {
-        return next(err)
-      }
+    try {
+      const simulation = cache[req.params.id]
+      const situation = generateSituation(simulation)
+      sendToOpenfisca(situation, function (err, result) {
+        if (err) {
+          return next(err)
+        }
 
-      res.send(Object.assign({ _id: cache[req.params.id]._id }, result))
-    })
+        res.send(Object.assign({ _id: cache[req.params.id]._id }, result))
+      })
+    } catch (e) {
+      res.sendStatus(404)
+    }
   })
 
   app.get("/api/answers/:id/openfisca-request", function (req, res) {
-    const simulation = cache[req.params.id]
-    const situation = generateSituation(simulation)
-    res.send(buildOpenFiscaRequest(situation))
+    try {
+      const simulation = cache[req.params.id]
+      const situation = generateSituation(simulation)
+      res.send(buildOpenFiscaRequest(situation))
+    } catch (e) {
+      res.sendStatus(404)
+    }
   })
 
   app.get("/api/openfisca/missingbenefits", function (req, res) {

--- a/mock.js
+++ b/mock.js
@@ -60,7 +60,7 @@ function mock({ app }) {
 
         res.send(Object.assign({ _id: cache[req.params.id]._id }, result))
       })
-    } catch (e) {
+    } catch {
       res.sendStatus(404)
     }
   })
@@ -70,7 +70,7 @@ function mock({ app }) {
       const simulation = cache[req.params.id]
       const situation = generateSituation(simulation)
       res.send(buildOpenFiscaRequest(situation))
-    } catch (e) {
+    } catch {
       res.sendStatus(404)
     }
   })


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/TdvryJid/574-%C3%A9viter-le-crash-de-lapp-en-npm-run-front-quand-on-essaie-de-r%C3%A9cup%C3%A9rer-le-payload-openfisca-dune-simulation-qui-nexiste-pas)

## Notes

L'utilisation de `try {} catch {}` n'est pas une solution viable pour de la prob mais je pense que ça peut faire l'affaire pour `npm run front`.

A noter qu'une autre solution serait de renvoyer un réponse fixe (e.g ; comme pour `/api/followups/surveys/:id`)