### PR TITLE
Ajout de fonctionnalités à la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ env:
   LANG: C.UTF-8
   PYTHON_VERSION: 3.7
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   install:
     name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,4 +247,4 @@ jobs:
         env:
           CONTEXT: ${{ toJSON(needs) }}
         run: |
-          curl -i -X POST -H 'Content-Type: application/json' -d '{"text": "[THIS IS A TEST, DO NOT TAKE INTO ACCOUNT] :icon-danger: La CI a rencontré un problème sur la branche master"}' ${{ secrets.MATTERMOST_POST_URL }}
+          curl -i -X POST -H 'Content-Type: application/json' -d '{"text": ":icon-danger: La CI a rencontré un problème sur la branche master ([lien](https://github.com/betagouv/aides-jeunes/actions/workflows/ci.yml?query=branch%3Amaster+is%3Afailure))"}' ${{ secrets.MATTERMOST_POST_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,5 @@ jobs:
     steps:
       - name: Send CI failed message
         shell: bash
-        env:
-          CONTEXT: ${{ toJSON(needs) }}
         run: |
           curl -i -X POST -H 'Content-Type: application/json' -d '{"text": ":icon-danger: La CI a rencontré un problème sur la branche master ([lien](https://github.com/betagouv/aides-jeunes/actions/workflows/ci.yml?query=branch%3Amaster+is%3Afailure))"}' ${{ secrets.MATTERMOST_POST_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
           path: cypress/videos
           retention-days: 10
   ci_failed:
-    name: Continuous Integration Failed
+    name: Detect failure
     runs-on: ubuntu-20.04
     needs:
       [
@@ -244,4 +244,6 @@ jobs:
         shell: bash
         env:
           CONTEXT: ${{ toJSON(needs) }}
-        run: echo "Continuous Integration failed during step $CONTEXT"
+        run: |
+          echo "Continuous Integration failed during step $CONTEXT"
+          curl -i -X POST -H 'Content-Type: application/json' -d '{"text": "[THIS IS A TEST, DO NOT TAKE INTO ACCOUNT] :x: Echec de la CI sur la branche master"}' ${{ secrets.MATTERMOST_POST_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Install dependencies
         if: steps.restore-dependencies.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit
+      - name: Trigger ci error
+        run: exit 1
   install_openfisca:
     name: Install OpenFisca
     runs-on: ubuntu-20.04
@@ -223,3 +225,23 @@ jobs:
           name: cypress-${{matrix.test}}
           path: cypress/videos
           retention-days: 10
+  ci_failed:
+    name: Continuous Integration Failed
+    runs-on: ubuntu-20.04
+    needs:
+      [
+        install,
+        install_openfisca,
+        lint,
+        unit_tests,
+        build,
+        openfisca_test_generation,
+        test_e2e,
+      ]
+    if: always() && (needs.install.result == 'failure' || needs.install_openfisca.result == 'failure' || needs.lint.result == 'failure' || needs.unit_tests.result == 'failure' || needs.build.result == 'failure' || needs.openfisca_test_generation.result == 'failure' || needs.test_e2e.result == 'failure')
+    steps:
+      - name: Send CI failed message
+        shell: bash
+        env:
+          CONTEXT: ${{ toJSON(needs) }}
+        run: echo "Continuous Integration failed during step $CONTEXT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,4 +246,4 @@ jobs:
           CONTEXT: ${{ toJSON(needs) }}
         run: |
           echo "Continuous Integration failed during step $CONTEXT"
-          curl -i -X POST -H 'Content-Type: application/json' -d '{"text": "[THIS IS A TEST, DO NOT TAKE INTO ACCOUNT] :x: Echec de la CI sur la branche master"}' ${{ secrets.MATTERMOST_POST_URL }}
+          curl -i -X POST -H 'Content-Type: application/json' -d '{"text": "[THIS IS A TEST, DO NOT TAKE INTO ACCOUNT] :icon-danger: La CI a rencontré un problème sur la branche master"}' ${{ secrets.MATTERMOST_POST_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
       - name: Install dependencies
         if: steps.restore-dependencies.outputs.cache-hit != 'true'
         run: npm ci --prefer-offline --no-audit
-      - name: Trigger ci error
-        run: exit 1
   install_openfisca:
     name: Install OpenFisca
     runs-on: ubuntu-20.04
@@ -238,12 +236,11 @@ jobs:
         openfisca_test_generation,
         test_e2e,
       ]
-    if: always() && (needs.install.result == 'failure' || needs.install_openfisca.result == 'failure' || needs.lint.result == 'failure' || needs.unit_tests.result == 'failure' || needs.build.result == 'failure' || needs.openfisca_test_generation.result == 'failure' || needs.test_e2e.result == 'failure')
+    if: always() && github.ref == 'refs/heads/master' && (needs.install.result == 'failure' || needs.install_openfisca.result == 'failure' || needs.lint.result == 'failure' || needs.unit_tests.result == 'failure' || needs.build.result == 'failure' || needs.openfisca_test_generation.result == 'failure' || needs.test_e2e.result == 'failure')
     steps:
       - name: Send CI failed message
         shell: bash
         env:
           CONTEXT: ${{ toJSON(needs) }}
         run: |
-          echo "Continuous Integration failed during step $CONTEXT"
           curl -i -X POST -H 'Content-Type: application/json' -d '{"text": "[THIS IS A TEST, DO NOT TAKE INTO ACCOUNT] :icon-danger: La CI a rencontré un problème sur la branche master"}' ${{ secrets.MATTERMOST_POST_URL }}


### PR DESCRIPTION
## Description

Deux ajouts au workflow de la CI :
- si un problème est détecté lors d'une exécution de la CI après un merge sur `master`, un message sera envoyé automatiquement sur mattermost pour alerter l'équipe
- ajouter un commit sur une branche/PR annule l'exécution du précédent run de CI. Cela permet de ne pas avoir plusieurs run de CI en parallèle pour une même branche suite à l'envoi de plusieurs commits consécutifs, laissant un maximum de runners disponible.

A noter que ces éléments ne s'appliquent **que  à la CI** et pas à la CD.