### PR TITLE
fix: corrige les problèmes d'iframe sur webkit

### DIFF
--- a/backend/controllers/answers.js
+++ b/backend/controllers/answers.js
@@ -28,6 +28,8 @@ exports.attachAccessCookie = function (req, res) {
   res.cookie(req.answers.cookieName, req.answers.token, {
     maxAge,
     httpOnly: true,
+    sameSite: "none",
+    secure: true,
   })
   res.cookie("lastestSituation", req.answers._id.toString(), { maxAge })
 }


### PR DESCRIPTION
## Description

[Tâche Trello](corriger les cors ou autres pour l'intégration en iframe)

## Détails

Deux paramètres sont ajoutés au cookie de session :
```
SameSite: None
Secure: true
```

Depuis Chrome 80 les cookies sans paramètres `SameSite` ont par valeur la défaut `lax`, ce qui, dans notre cas, les rend incompatibles avec les iframes.

À noter également que pour fonctionner il faut que la cible de l'iframe passe par https.