### PR TITLE
Ajoute une authentification à github

### DIFF
--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -18,6 +18,12 @@ const all = {
   sendInBlue: {
     apiKey: process.env.SEND_IN_BLUE_PRIVATE_KEY || "privateKey",
   },
+  github: {
+    access_token_url: "https://github.com/login/oauth/access_token",
+    authenticated_url: "https://api.github.com/user",
+    client_secret: process.env.GITHUB_CLIENT_SECRET || "",
+    client_id: process.env.GITHUB_CLIENT_ID || "",
+  },
   matomo: {
     id: 165,
   },

--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -23,6 +23,14 @@ const all = {
     authenticated_url: "https://api.github.com/user",
     client_secret: process.env.GITHUB_CLIENT_SECRET || "",
     client_id: process.env.GITHUB_CLIENT_ID || "",
+    authorized_users: [
+      "guillett",
+      "Cugniere",
+      "charlottelecuit",
+      "Vanessa-D",
+      "clembiffaud",
+      "Kout95",
+    ],
   },
   matomo: {
     id: 165,

--- a/backend/controllers/github.js
+++ b/backend/controllers/github.js
@@ -1,0 +1,45 @@
+const axios = require("axios")
+const config = require("../config")
+
+exports.callbackGithub = async (req, res) => {
+  const code = req.query.code
+  if (code) {
+    const result = await axios.post(
+      config.github.access_token_url,
+      {
+        client_id: config.github.client_id,
+        client_secret: config.github.client_secret,
+        code: code,
+      },
+      {
+        headers: { Accept: "application/json" },
+      }
+    )
+    if (result.status === 200 && result.data.access_token) {
+      res.cookie("github_token", result.data)
+      return res.redirect("/")
+    }
+  }
+  return res.redirect("/")
+}
+
+exports.isLogged = async (req, res, next) => {
+  const cookie = req.cookies["github_token"]
+  if (cookie) {
+    try {
+      await axios.get(config.github.authenticated_url, {
+        headers: {
+          Accept: "application/json",
+          Authorization: `token ${cookie.access_token}`,
+        },
+      })
+      return next()
+    } catch (e) {
+      console.log(e)
+    }
+  }
+  return res.send({
+    msg: "Not authorized",
+    statusCode: 401,
+  })
+}

--- a/backend/controllers/github.js
+++ b/backend/controllers/github.js
@@ -23,17 +23,19 @@ exports.callbackGithub = async (req, res) => {
   return res.redirect("/")
 }
 
-exports.isLogged = async (req, res, next) => {
+exports.isAuthorized = async (req, res, next) => {
   const cookie = req.cookies["github_token"]
   if (cookie) {
     try {
-      await axios.get(config.github.authenticated_url, {
+      const result = await axios.get(config.github.authenticated_url, {
         headers: {
           Accept: "application/json",
           Authorization: `token ${cookie.access_token}`,
         },
       })
-      return next()
+      if (config.github.authorized_users.includes(result.data.login)) {
+        return next()
+      }
     } catch (e) {
       console.log(e)
     }

--- a/backend/routes/github.js
+++ b/backend/routes/github.js
@@ -1,0 +1,5 @@
+const githubController = require("../controllers/github")
+
+module.exports = function (api) {
+  api.route("/user/signin/callback").get(githubController.callbackGithub)
+}


### PR DESCRIPTION
Ajoute l'authentification via github et un middleware pour vérifier les droits.

Pour Mettre en place la connexion : 

1. Ajouter l'app sur github https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app
Infos :
Homepage URL : https://mes-aides.1jeune1solution.beta.gouv.fr
Authorization callback URL : https://mes-aides.1jeune1solution.beta.gouv.fr/api/user/signin/callback
2. Ajouter le `client_id` et `client_secret` de l'app en production
3. Ajouter un bouton de connexion redirigeant vers l'url : https://github.com/login/oauth/authorize?client_id=<client_id>&redirect_uri=<redirect_uri>
4. Ajouter le middleware sur les routes nécessitant une connexion à github


Pour ajouter une nouvelle personne il faut ajouter son id github dans : `config.github.authorized_users`