### PR TITLE
[601] Corrige un bug lors du retour vers le listing des aides

### DIFF
--- a/src/views/aide.vue
+++ b/src/views/aide.vue
@@ -70,7 +70,7 @@ export default {
       if (window?.history.length > 2) {
         history.back()
       } else {
-        this.$router.push("/simulation/aides")
+        this.$router.push("/aides")
       }
     },
   },


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/fDhlExo0/601-bug-lors-que-lon-acc%C3%A8de-directement-%C3%A0-une-page-donnant-d%C3%A9tails-sur-une-aide-le-bouton-retour-ne-fonctionne-pas-correctement)

