### PR TITLE
Remplace le i de en savoir plus par un svg

### DIFF
--- a/src/components/en-savoir-plus.vue
+++ b/src/components/en-savoir-plus.vue
@@ -5,8 +5,19 @@
       :data-text="text"
       class="aj-help-popup aj-tooltip a-unstyled"
     >
-      <div class="aj-help-icon"> i </div>
-      en savoir plus
+      <svg
+        class="aj-help-icon"
+        fill="#FFFFFF"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 50 50"
+        width="20px"
+        height="20px"
+      >
+        <path
+          d="M25,2C12.297,2,2,12.297,2,25s10.297,23,23,23s23-10.297,23-23S37.703,2,25,2z M25,11c1.657,0,3,1.343,3,3s-1.343,3-3,3 s-3-1.343-3-3S23.343,11,25,11z M29,38h-2h-4h-2v-2h2V23h-2v-2h2h4v2v13h2V38z"
+        />
+      </svg>
+      <span>en savoir plus</span>
     </router-link>
   </div>
 </template>

--- a/src/styles/partials/desktop/_ui-kit.scss
+++ b/src/styles/partials/desktop/_ui-kit.scss
@@ -194,15 +194,9 @@ html {
         }
 
         .aj-help-icon {
-          background-color: var(--white);
-          color: var(--theme-primary);
-          border-radius: 50%;
           width: 20px;
           height: 20px;
-          text-align: center;
-          display: inline-block;
           margin-right: 5px;
-          line-height: 22px;
         }
       }
 


### PR DESCRIPTION
Lorsque l'on change la font on modifie aussi l'icone ce qui rend l'affichage plus ou moins jolie.
Pour simplifier ça je propose de le remplacer par un svg qui ne sera pas affecté par le changement de font.
Résultat :
![image](https://user-images.githubusercontent.com/65901733/154473689-be28fe49-003d-475e-a4ac-c5fa3be81f74.png)