### PR TITLE
Correctifs pour l'outil d'accompagnement

### DIFF
--- a/backend/controllers/followups.js
+++ b/backend/controllers/followups.js
@@ -49,7 +49,10 @@ exports.persist = function (req, res) {
 
 exports.showFromSurvey = function (req, res) {
   Followup.findOne({
-    "surveys._id": req.params.surveyId,
+    $or: [
+      { "surveys._id": req.params.surveyId },
+      { "surveys.accessToken": req.params.surveyId },
+    ],
   }).then((followup) => {
     if (!followup) return res.sendStatus(404)
 
@@ -88,33 +91,20 @@ exports.showSimulation = function (req, res) {
 
 exports.postSurvey = function (req, res) {
   Followup.findOne({
-    "surveys._id": req.params.surveyId,
+    $or: [
+      { "surveys._id": req.params.surveyId },
+      { "surveys.accessToken": req.params.surveyId },
+    ],
   }).then((followup) => {
     if (!followup) return res.sendStatus(404)
-    followup.updateSurvey(req.params.surveyId, req.body).then(() => {
+    const token = followup.surveys.find(
+      (survey) =>
+        survey._id == req.params.surveyId ||
+        survey.accessToken == req.params.surveyId
+    )._id
+    followup.updateSurvey(token, req.body).then(() => {
       res.sendStatus(201)
     })
     pollResult.postPollResult(followup, req.body)
   })
-  /*
-  utils
-    .generateToken()
-    .then(function (followingId) {
-      Followup.findOne({
-        "surveys._id": req.params.surveyId,
-      }).then((followup) => {
-        if (!followup) return res.sendStatus(404)
-        followup
-          .updateSurvey(req.params.surveyId, followingId, req.body)
-          .then(() => {
-            res.sendStatus(201)
-          })
-        pollResult.postPollResult(followup, req.body, followingId)
-      })
-    })
-    .catch((error) => {
-      console.log("error", error)
-      return res.sendStatus(400)
-    })
-  */
 }

--- a/backend/controllers/followups.js
+++ b/backend/controllers/followups.js
@@ -3,7 +3,6 @@ const Followup = require("mongoose").model("Followup")
 
 const situation = require("./answers")
 const pollResult = require("../lib/mattermost-bot/poll-result")
-const utils = require("../lib/utils")
 
 exports.followup = function (req, res, next, id) {
   Followup.findById(id)
@@ -65,7 +64,6 @@ exports.showSurveyResults = function (req, res) {
     surveyOptin: true,
     surveys: { $exists: true, $ne: [] },
     "surveys.repliedAt": { $exists: true },
-    "surveys.surveyId": { $exists: true },
   })
     .skip(0)
     .limit(10)

--- a/backend/controllers/followups.js
+++ b/backend/controllers/followups.js
@@ -4,6 +4,8 @@ const Followup = require("mongoose").model("Followup")
 const situation = require("./answers")
 const pollResult = require("../lib/mattermost-bot/poll-result")
 
+const excludeFields = ["surveys.accessToken"].join(" -").replace(/^/, "-")
+
 exports.followup = function (req, res, next, id) {
   Followup.findById(id)
     .populate("answers")
@@ -53,7 +55,7 @@ exports.showFromSurvey = function (req, res) {
       { "surveys.accessToken": req.params.surveyId },
     ],
   })
-    .select("-surveys.accessToken")
+    .select(excludeFields)
     .then((followup) => {
       if (!followup) return res.sendStatus(404)
 
@@ -70,7 +72,7 @@ exports.showSurveyResults = function (req, res) {
     .skip(0)
     .limit(10)
     .sort({ "surveys.repliedAt": -1 })
-    .select("-surveys.accessToken")
+    .select(excludeFields)
     .then((followup) => {
       res.send(followup)
     })
@@ -80,7 +82,7 @@ exports.showSimulation = function (req, res) {
   Followup.findOne({
     _id: req.params.surveyId,
   })
-    .select("-surveys.accessToken")
+    .select(excludeFields)
     .then((simulation) => {
       if (!simulation) return res.sendStatus(404)
       res.send([simulation])

--- a/backend/controllers/followups.js
+++ b/backend/controllers/followups.js
@@ -52,11 +52,13 @@ exports.showFromSurvey = function (req, res) {
       { "surveys._id": req.params.surveyId },
       { "surveys.accessToken": req.params.surveyId },
     ],
-  }).then((followup) => {
-    if (!followup) return res.sendStatus(404)
-
-    res.send(followup)
   })
+    .select("-surveys.accessToken")
+    .then((followup) => {
+      if (!followup) return res.sendStatus(404)
+
+      res.send(followup)
+    })
 }
 
 exports.showSurveyResults = function (req, res) {
@@ -78,6 +80,7 @@ exports.showSimulation = function (req, res) {
   Followup.findOne({
     _id: req.params.surveyId,
   })
+    .select("-surveys.accessToken")
     .then((simulation) => {
       if (!simulation) return res.sendStatus(404)
       res.send([simulation])

--- a/backend/controllers/followups.js
+++ b/backend/controllers/followups.js
@@ -62,7 +62,7 @@ exports.showSurveyResults = function (req, res) {
     surveyOptin: true,
     surveys: { $exists: true, $ne: [] },
     "surveys.repliedAt": { $exists: true },
-    "surveys.followingId": { $exists: true },
+    "surveys.surveyId": { $exists: true },
   })
     .skip(0)
     .limit(10)
@@ -74,7 +74,7 @@ exports.showSurveyResults = function (req, res) {
 
 exports.showSimulation = function (req, res) {
   Followup.findOne({
-    "surveys.followingId": req.params.followingId,
+    _id: req.params.surveyId,
   })
     .then((simulation) => {
       if (!simulation) return res.sendStatus(404)
@@ -87,6 +87,16 @@ exports.showSimulation = function (req, res) {
 }
 
 exports.postSurvey = function (req, res) {
+  Followup.findOne({
+    "surveys._id": req.params.surveyId,
+  }).then((followup) => {
+    if (!followup) return res.sendStatus(404)
+    followup.updateSurvey(req.params.surveyId, req.body).then(() => {
+      res.sendStatus(201)
+    })
+    pollResult.postPollResult(followup, req.body)
+  })
+  /*
   utils
     .generateToken()
     .then(function (followingId) {
@@ -106,4 +116,5 @@ exports.postSurvey = function (req, res) {
       console.log("error", error)
       return res.sendStatus(400)
     })
+  */
 }

--- a/backend/controllers/followups.js
+++ b/backend/controllers/followups.js
@@ -68,6 +68,7 @@ exports.showSurveyResults = function (req, res) {
     .skip(0)
     .limit(10)
     .sort({ "surveys.repliedAt": -1 })
+    .select("-surveys.accessToken")
     .then((followup) => {
       res.send(followup)
     })

--- a/backend/controllers/followups.js
+++ b/backend/controllers/followups.js
@@ -72,11 +72,18 @@ exports.showSurveyResults = function (req, res) {
 
 exports.showSimulation = function (req, res) {
   Followup.findOne({
-    _id: req.params.simulationId,
-  }).then((simulation) => {
-    if (!simulation) return res.sendStatus(404)
-    res.send([simulation])
+    "surveys.createdAt": {
+      $gte: new Date(req.params.simulationCreationDate),
+    },
   })
+    .then((simulation) => {
+      if (!simulation) return res.sendStatus(404)
+      res.send([simulation])
+    })
+    .catch((error) => {
+      console.error("error", error)
+      return res.sendStatus(400)
+    })
 }
 
 exports.postSurvey = function (req, res) {

--- a/backend/controllers/github.js
+++ b/backend/controllers/github.js
@@ -44,7 +44,6 @@ function validateCookieToken(req) {
 }
 
 exports.access = async (req, res, next) => {
-  return next()
   if (req.cookies && req.cookies["github_token"]) {
     try {
       const result = await validateCookieToken(req)

--- a/backend/controllers/github.js
+++ b/backend/controllers/github.js
@@ -44,6 +44,7 @@ function validateCookieToken(req) {
 }
 
 exports.access = async (req, res, next) => {
+  return next()
   if (req.cookies && req.cookies["github_token"]) {
     try {
       const result = await validateCookieToken(req)

--- a/backend/lib/mattermost-bot/poll-result.js
+++ b/backend/lib/mattermost-bot/poll-result.js
@@ -10,7 +10,7 @@ function parseCurrentDate() {
   })} à ${isoDateTime.toLocaleTimeString("fr-FR")}`
 }
 
-function postPollResult(simulation, answers) {
+function postPollResult(simulation, answers, followingId) {
   if (answers.length == 0) {
     return
   }
@@ -30,11 +30,10 @@ function postPollResult(simulation, answers) {
     answer.amount = benefit.amount
     orderedAnswers.push(answer)
   }
-  const id = simulation.surveys[simulation.surveys.length - 1].createdAt || ""
   const result = [
     `#### Résultat du sondage de suivi d'utilisateur du ${parseCurrentDate()} - [Accéder au suivi](${
       process.env.MES_AIDES_ROOT_URL
-    }/accompagnement/${id})`,
+    }/accompagnement/${followingId})`,
     `${Object.values(score)
       .map((val) => val.join(" "))
       .join("  ")}\n  `,

--- a/backend/lib/mattermost-bot/poll-result.js
+++ b/backend/lib/mattermost-bot/poll-result.js
@@ -10,7 +10,7 @@ function parseCurrentDate() {
   })} à ${isoDateTime.toLocaleTimeString("fr-FR")}`
 }
 
-function postPollResult(simulation, answers, followingId) {
+function postPollResult(simulation, answers) {
   if (answers.length == 0) {
     return
   }
@@ -33,7 +33,7 @@ function postPollResult(simulation, answers, followingId) {
   const result = [
     `#### Résultat du sondage de suivi d'utilisateur du ${parseCurrentDate()} - [Accéder au suivi](${
       process.env.MES_AIDES_ROOT_URL
-    }/accompagnement/${followingId})`,
+    }/accompagnement/${simulation._id})`,
     `${Object.values(score)
       .map((val) => val.join(" "))
       .join("  ")}\n  `,

--- a/backend/lib/mattermost-bot/poll-result.js
+++ b/backend/lib/mattermost-bot/poll-result.js
@@ -30,10 +30,11 @@ function postPollResult(simulation, answers) {
     answer.amount = benefit.amount
     orderedAnswers.push(answer)
   }
+  const id = simulation.surveys[simulation.surveys.length - 1].createdAt || ""
   const result = [
     `#### Résultat du sondage de suivi d'utilisateur du ${parseCurrentDate()} - [Accéder au suivi](${
       process.env.MES_AIDES_ROOT_URL
-    }/accompagnement/${simulation._id})`,
+    }/accompagnement/${id})`,
     `${Object.values(score)
       .map((val) => val.join(" "))
       .join("  ")}\n  `,
@@ -51,7 +52,8 @@ function postPollResult(simulation, answers) {
   }
 
   const json = JSON.stringify({ text: result.join("\n") })
-  Mattermost.post(json)
+  console.log(json)
+  //Mattermost.post(json)
 }
 
 module.exports = {

--- a/backend/lib/mattermost-bot/poll-result.js
+++ b/backend/lib/mattermost-bot/poll-result.js
@@ -52,8 +52,7 @@ function postPollResult(simulation, answers) {
   }
 
   const json = JSON.stringify({ text: result.join("\n") })
-  console.log(json)
-  //Mattermost.post(json)
+  Mattermost.post(json)
 }
 
 module.exports = {

--- a/backend/lib/mattermost-bot/poll-result.js
+++ b/backend/lib/mattermost-bot/poll-result.js
@@ -42,9 +42,11 @@ function postPollResult(simulation, answers) {
     result.push(
       `${score[key.value][0]} [${key.id}](${
         process.env.MES_AIDES_ROOT_URL
-      }/aides/${key.id}) ${key.unit ? `**${key.amount}${key.unit}**` : ""} ${
-        key.comments.length > 0 ? `*(${key.comments})*` : ""
-      }`
+      }/aides/${key.id}) ${
+        key.unit && typeof key.amount === "number"
+          ? `**${key.amount}${key.unit}**`
+          : ""
+      } ${key.comments.length > 0 ? `*(${key.comments})*` : ""}`
     )
   }
 

--- a/backend/models/followup.js
+++ b/backend/models/followup.js
@@ -11,7 +11,7 @@ const renderSurvey = require("../lib/mes-aides/emails/survey").render
 const SurveySchema = new mongoose.Schema(
   {
     _id: { type: String },
-    followingId: { type: String },
+    accessToken: { type: String },
     createdAt: { type: Date, default: Date.now },
     messageId: { type: String },
     repliedAt: { type: Date },
@@ -157,7 +157,7 @@ FollowupSchema.methods.mock = function () {
   })
 }
 
-FollowupSchema.methods.updateSurvey = function (id, followingId, answers) {
+FollowupSchema.methods.updateSurvey = function (id, answers) {
   const surveys = Array.from(this.surveys)
   const survey = find(surveys, function (s) {
     return s._id === id
@@ -165,7 +165,6 @@ FollowupSchema.methods.updateSurvey = function (id, followingId, answers) {
   Object.assign(survey, {
     answers: answers,
     repliedAt: Date.now(),
-    followingId: followingId,
   })
   this.surveys = surveys
   return this.save()

--- a/backend/models/followup.js
+++ b/backend/models/followup.js
@@ -11,6 +11,7 @@ const renderSurvey = require("../lib/mes-aides/emails/survey").render
 const SurveySchema = new mongoose.Schema(
   {
     _id: { type: String },
+    followingId: { type: String },
     createdAt: { type: Date, default: Date.now },
     messageId: { type: String },
     repliedAt: { type: Date },
@@ -156,13 +157,16 @@ FollowupSchema.methods.mock = function () {
   })
 }
 
-FollowupSchema.methods.updateSurvey = function (id, answers) {
+FollowupSchema.methods.updateSurvey = function (id, followingId, answers) {
   const surveys = Array.from(this.surveys)
   const survey = find(surveys, function (s) {
     return s._id === id
   })
-
-  Object.assign(survey, { answers: answers, repliedAt: Date.now() })
+  Object.assign(survey, {
+    answers: answers,
+    repliedAt: Date.now(),
+    followingId: followingId,
+  })
   this.surveys = surveys
   return this.save()
 }

--- a/backend/models/followup.js
+++ b/backend/models/followup.js
@@ -29,7 +29,7 @@ const SurveySchema = new mongoose.Schema(
 )
 
 SurveySchema.virtual("returnPath").get(function () {
-  return "/suivi?token=" + this._id
+  return "/suivi?token=" + this.accessToken
 })
 
 const FollowupSchema = new mongoose.Schema(
@@ -104,10 +104,13 @@ FollowupSchema.methods.renderSurveyEmail = function (survey) {
 
 FollowupSchema.methods.createSurvey = function (type) {
   const followup = this
-  return utils.generateToken().then(function (token) {
-    return followup.surveys.create({
-      _id: token,
-      type: type,
+  return utils.generateToken().then(function (id) {
+    return utils.generateToken().then(function (accessToken) {
+      return followup.surveys.create({
+        _id: id,
+        accessToken: accessToken,
+        type: type,
+      })
     })
   })
 }

--- a/backend/routes/followups.js
+++ b/backend/routes/followups.js
@@ -10,7 +10,7 @@ module.exports = function (api) {
     .get(cookieParser(), githubController.access)
     .get(followups.showSurveyResults)
   api
-    .route("/followups/id/:followingId")
+    .route("/followups/id/:surveyId")
     .get(cookieParser(), githubController.access)
     .get(followups.showSimulation)
 }

--- a/backend/routes/followups.js
+++ b/backend/routes/followups.js
@@ -10,7 +10,7 @@ module.exports = function (api) {
     .get(cookieParser(), githubController.access)
     .get(followups.showSurveyResults)
   api
-    .route("/followups/id/:simulationId")
+    .route("/followups/id/:simulationCreationDate")
     .get(cookieParser(), githubController.access)
     .get(followups.showSimulation)
 }

--- a/backend/routes/followups.js
+++ b/backend/routes/followups.js
@@ -10,7 +10,7 @@ module.exports = function (api) {
     .get(cookieParser(), githubController.access)
     .get(followups.showSurveyResults)
   api
-    .route("/followups/id/:simulationCreationDate")
+    .route("/followups/id/:followingId")
     .get(cookieParser(), githubController.access)
     .get(followups.showSimulation)
 }

--- a/src/router.js
+++ b/src/router.js
@@ -326,7 +326,7 @@ const router = createRouter({
         ),
     },
     {
-      path: "/accompagnement/:followupId",
+      path: "/accompagnement/:simulationCreationDate",
       name: "accompagnement",
       component: () =>
         import(

--- a/src/router.js
+++ b/src/router.js
@@ -326,7 +326,7 @@ const router = createRouter({
         ),
     },
     {
-      path: "/accompagnement/:simulationCreationDate",
+      path: "/accompagnement/:followingId",
       name: "accompagnement",
       component: () =>
         import(

--- a/src/router.js
+++ b/src/router.js
@@ -326,7 +326,7 @@ const router = createRouter({
         ),
     },
     {
-      path: "/accompagnement/:followingId",
+      path: "/accompagnement/:surveyId",
       name: "accompagnement",
       component: () =>
         import(

--- a/src/views/accompagnement/liste.vue
+++ b/src/views/accompagnement/liste.vue
@@ -2,7 +2,7 @@
   <article class="text container aj-text-container">
     <h1>Suivis des utilisateurs</h1>
     <router-link
-      v-if="followupId && loggedIn"
+      v-if="simulationCreationDate && loggedIn"
       to="/accompagnement"
       class="aj-droit-details-back-button button outline small with-icon"
       type="button"
@@ -38,7 +38,11 @@
               >{{ accompagnement.email }} -
               {{ formatDate(survey.repliedAt) }}</div
             >
-            <router-link :to="`/accompagnement/${accompagnement._id}`"
+            <router-link
+              :to="`/accompagnement/${
+                accompagnement.surveys[accompagnement.surveys.length - 1]
+                  .createdAt
+              }`"
               >Permalink</router-link
             >
             <a :href="`mailto:${accompagnement.email}`">Recontacter</a>
@@ -195,8 +199,8 @@ export default {
     }
   },
   computed: {
-    followupId() {
-      return this.$route.params.followupId
+    simulationCreationDate() {
+      return this.$route.params.simulationCreationDate
     },
   },
   watch: {
@@ -223,8 +227,8 @@ export default {
 
     fetchPollResults: async function () {
       this.retrievingCommunes = true
-      const uri = this.$route.params.followupId
-        ? `/api/followups/id/${this.$route.params.followupId}`
+      const uri = this.$route.params.simulationCreationDate
+        ? `/api/followups/id/${this.$route.params.simulationCreationDate}`
         : `/api/followups/surveys`
       try {
         const response = await fetch(uri, {

--- a/src/views/accompagnement/liste.vue
+++ b/src/views/accompagnement/liste.vue
@@ -2,7 +2,7 @@
   <article class="text container aj-text-container">
     <h1>Suivis des utilisateurs</h1>
     <router-link
-      v-if="followingId && loggedIn"
+      v-if="surveyId && loggedIn"
       to="/accompagnement"
       class="aj-droit-details-back-button button outline small with-icon"
       type="button"
@@ -38,11 +38,7 @@
               >{{ accompagnement.email }} -
               {{ formatDate(survey.repliedAt) }}</div
             >
-            <router-link
-              :to="`/accompagnement/${
-                accompagnement.surveys[accompagnement.surveys.length - 1]
-                  .followingId
-              }`"
+            <router-link :to="`/accompagnement/${accompagnement._id}`"
               >Permalink</router-link
             >
             <a :href="`mailto:${accompagnement.email}`">Recontacter</a>
@@ -199,8 +195,8 @@ export default {
     }
   },
   computed: {
-    followingId() {
-      return this.$route.params.followingId
+    surveyId() {
+      return this.$route.params.surveyId
     },
   },
   watch: {
@@ -227,8 +223,8 @@ export default {
 
     fetchPollResults: async function () {
       this.retrievingCommunes = true
-      const uri = this.$route.params.followingId
-        ? `/api/followups/id/${this.$route.params.followingId}`
+      const uri = this.$route.params.surveyId
+        ? `/api/followups/id/${this.$route.params.surveyId}`
         : `/api/followups/surveys`
       try {
         const response = await fetch(uri, {

--- a/src/views/accompagnement/liste.vue
+++ b/src/views/accompagnement/liste.vue
@@ -75,7 +75,6 @@
                     />
                     <path
                       transform="rotate(-90, 42, 68.5)"
-                      id="svg_4"
                       d="m28.23677,81.76322l27.52646,-26.52646"
                       opacity="undefined"
                       stroke-width="10"
@@ -195,17 +194,17 @@ export default {
       loggedIn: true,
     }
   },
-  watch: {
-    $route: {
-      immediate: true,
-      async handler(route) {
-        this.accompagnements = await this.fetchPollResults()
-      },
-    },
-  },
   computed: {
     followupId() {
       return this.$route.params.followupId
+    },
+  },
+  watch: {
+    $route: {
+      immediate: true,
+      async handler() {
+        this.accompagnements = await this.fetchPollResults()
+      },
     },
   },
   methods: {

--- a/src/views/accompagnement/liste.vue
+++ b/src/views/accompagnement/liste.vue
@@ -191,9 +191,17 @@
 export default {
   data: function () {
     return {
-      accompagnements: this.fetchPollResults(),
+      accompagnements: [],
       loggedIn: true,
     }
+  },
+  watch: {
+    $route: {
+      immediate: true,
+      async handler(route) {
+        this.accompagnements = await this.fetchPollResults()
+      },
+    },
   },
   computed: {
     followupId() {

--- a/src/views/accompagnement/liste.vue
+++ b/src/views/accompagnement/liste.vue
@@ -175,7 +175,7 @@
               <a :href="`/aides/${answer.id}`" target="_blank">{{
                 answer.id
               }}</a>
-              <b v-if="answer.unit && !isNaN(answer.amount)"
+              <b v-if="answer.unit && typeof answer.amount === `number`"
                 >({{ answer.amount }}{{ answer.unit }})</b
               >
               <div v-if="answer.comments">{{ answer.comments }}</div>

--- a/src/views/accompagnement/liste.vue
+++ b/src/views/accompagnement/liste.vue
@@ -2,7 +2,7 @@
   <article class="text container aj-text-container">
     <h1>Suivis des utilisateurs</h1>
     <router-link
-      v-if="simulationCreationDate && loggedIn"
+      v-if="followingId && loggedIn"
       to="/accompagnement"
       class="aj-droit-details-back-button button outline small with-icon"
       type="button"
@@ -41,7 +41,7 @@
             <router-link
               :to="`/accompagnement/${
                 accompagnement.surveys[accompagnement.surveys.length - 1]
-                  .createdAt
+                  .followingId
               }`"
               >Permalink</router-link
             >
@@ -199,8 +199,8 @@ export default {
     }
   },
   computed: {
-    simulationCreationDate() {
-      return this.$route.params.simulationCreationDate
+    followingId() {
+      return this.$route.params.followingId
     },
   },
   watch: {
@@ -227,8 +227,8 @@ export default {
 
     fetchPollResults: async function () {
       this.retrievingCommunes = true
-      const uri = this.$route.params.simulationCreationDate
-        ? `/api/followups/id/${this.$route.params.simulationCreationDate}`
+      const uri = this.$route.params.followingId
+        ? `/api/followups/id/${this.$route.params.followingId}`
         : `/api/followups/surveys`
       try {
         const response = await fetch(uri, {


### PR DESCRIPTION
## Description

Correctifs :
- sur l'outil d'accompagnement, n'affiche la valeur numérique d'une aide que si elle est numérique
- via le bot Mattermost, n'affiche la valeur numérique d'une aide que si elle est numérique
- l'id utilisé pour les différentes API de suivi n'est plus l'id de la simulation mais l'id de la `survey`. Les utilisateurs peuvent remplir une enquête en utilisant un paramètre `accessToken`.