### PR TITLE
Sécurise les cookies en fonction de l'environnement

### DIFF
--- a/backend/controllers/answers.js
+++ b/backend/controllers/answers.js
@@ -25,13 +25,14 @@ exports.answers = function (req, res, next, answersId) {
 
 exports.attachAccessCookie = function (req, res) {
   const maxAge = 7 * 24 * 3600 * 1000
-  res.cookie(req.answers.cookieName, req.answers.token, {
+  const cookiesParameters = {
     maxAge,
     httpOnly: true,
-    sameSite: "none",
-    secure: true,
-  })
-  res.cookie("lastestSituation", req.answers._id.toString(), { maxAge })
+    sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
+    secure: process.env.NODE_ENV === "production",
+  }
+  res.cookie(req.answers.cookieName, req.answers.token, cookiesParameters)
+  res.cookie("lastestSituation", req.answers._id.toString(), cookiesParameters)
 }
 
 exports.validateAccess = function (req, res, next) {

--- a/backend/controllers/answers.js
+++ b/backend/controllers/answers.js
@@ -24,9 +24,8 @@ exports.answers = function (req, res, next, answersId) {
 }
 
 exports.attachAccessCookie = function (req, res) {
-  const maxAge = 7 * 24 * 3600 * 1000
   const cookiesParameters = {
-    maxAge,
+    maxAge: 7 * 24 * 3600 * 1000,
     httpOnly: true,
     sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
     secure: process.env.NODE_ENV === "production",

--- a/backend/controllers/answers.js
+++ b/backend/controllers/answers.js
@@ -26,7 +26,6 @@ exports.answers = function (req, res, next, answersId) {
 exports.attachAccessCookie = function (req, res) {
   const cookiesParameters = {
     maxAge: 7 * 24 * 3600 * 1000,
-    httpOnly: true,
     sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
     secure: process.env.NODE_ENV === "production",
   }


### PR DESCRIPTION
## Description

Pour que le simulateur fonctionne dans une iframe il faut que les différentes cookies soient envoyés avec les attributs `sameSite = none` et `secure = true`. Cependant en local l'attribut `secure` doit être à `false` pour pouvoir fonctionner en http