### PR TITLE
Améliore la gestion d'affichage en iframe

### DIFF
--- a/backend/config/front-only.js
+++ b/backend/config/front-only.js
@@ -1,0 +1,14 @@
+"use strict"
+
+module.exports = {
+  baseURL: "http://localhost:8080",
+  teleserviceAccessTokens: {
+    loiret_APA_test: "token",
+    loiret_APA: "token",
+    PNDS: "token",
+  },
+  matomo: {
+    id: 170,
+  },
+  statistics: {},
+}

--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -6,7 +6,9 @@ const all = {
   animation: {
     delay: process.env.ANIMATION_DELAY || 300,
   },
-  baseURL: "https://mes-aides.1jeune1solution.beta.gouv.fr",
+  baseURL:
+    process.env.MES_AIDES_ROOT_URL ||
+    "https://mes-aides.1jeune1solution.beta.gouv.fr",
   openfiscaURL: process.env.OPENFISCA_URL || "http://localhost:2000",
   openfiscaAxeURL: "https://betagouv.github.io/mes-aides-changent",
   openfiscaPublicURL:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "fast-install": "PUPPETEER_SKIP_DOWNLOAD=1 npm ci",
-    "front": "NODE_ENV=front_only npm run serve",
+    "front": "NODE_ENV=front-only npm run serve",
     "install-openfisca": "pip install --upgrade -r openfisca/requirements.txt",
     "openfisca": "OPENFISCA_WORKERS=1 gunicorn openfisca.api --config openfisca/config.py",
     "predb": "mkdir -p db",

--- a/src/components/iframe-layout.vue
+++ b/src/components/iframe-layout.vue
@@ -1,37 +1,16 @@
 <template>
-  <div>
-    <nav>
-      <router-link :to="link">
-        {{ label }}
-      </router-link>
-    </nav>
-    <slot />
-  </div>
+  <slot />
 </template>
 
 <script>
 export default {
   name: "IFrameLayout",
-  computed: {
-    label: function () {
-      return this.$store.state.iframeOrigin ? "Précédent" : "À propos"
-    },
-    link: function () {
-      return this.$store.state.iframeOrigin || "/a-propos-integre"
-    },
-  },
 }
 </script>
 
-<style scoped lang="scss">
-nav {
-  position: absolute;
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-}
-
-nav a {
-  margin: 1em;
+<style>
+html,
+body {
+  height: unset !important;
 }
 </style>

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -34,6 +34,12 @@ const routes = [
     component: () =>
       import(/* webpackChunkName: "stats" */ "@/views/stats.vue"),
   },
+  {
+    path: "/iframe",
+    name: "iframe",
+    component: () =>
+      import(/* webpackChunkName: "iframe" */ "@/views/iframe.vue"),
+  },
 ]
 
 export default {

--- a/src/styles/partials/desktop/_ui-kit.scss
+++ b/src/styles/partials/desktop/_ui-kit.scss
@@ -168,7 +168,45 @@ html {
       }
 
       .aj-category-title-button-mobile {
+        $menu-button-size: 40px;
+
         display: none;
+
+        align-items: center;
+        justify-content: center;
+        position: relative;
+
+        .menu-button {
+          flex-shrink: 0;
+          border: 1px solid var(--light-grey);
+
+          svg {
+            width: 15px;
+            fill: var(--theme-primary);
+          }
+
+          &:focus,
+          &:active {
+            border: 1px solid var(--theme-primary);
+
+            svg {
+              fill: white;
+            }
+          }
+        }
+
+        .menu-button,
+        .menu-button:focus,
+        .menu-button:active {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: $menu-button-size;
+          width: $menu-button-size;
+          margin-top: 0;
+          margin-right: 10px;
+          padding: 0;
+        }
       }
 
       .aj-help-popup {

--- a/src/styles/partials/desktop/_ui-kit.scss
+++ b/src/styles/partials/desktop/_ui-kit.scss
@@ -168,45 +168,7 @@ html {
       }
 
       .aj-category-title-button-mobile {
-        $menu-button-size: 40px;
-
         display: none;
-
-        align-items: center;
-        justify-content: center;
-        position: relative;
-
-        .menu-button {
-          flex-shrink: 0;
-          border: 1px solid var(--light-grey);
-
-          svg {
-            width: 15px;
-            fill: var(--theme-primary);
-          }
-
-          &:focus,
-          &:active {
-            border: 1px solid var(--theme-primary);
-
-            svg {
-              fill: white;
-            }
-          }
-        }
-
-        .menu-button,
-        .menu-button:focus,
-        .menu-button:active {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          height: $menu-button-size;
-          width: $menu-button-size;
-          margin-top: 0;
-          margin-right: 10px;
-          padding: 0;
-        }
       }
 
       .aj-help-popup {

--- a/src/views/iframe.vue
+++ b/src/views/iframe.vue
@@ -1,0 +1,30 @@
+<template>
+  <iframe
+    id="iframe"
+    :src="`/?iframe`"
+    scrolling="no"
+    @load="iframeLoaded"
+  ></iframe>
+</template>
+
+<script>
+import { iframeResize } from "iframe-resizer"
+
+export default {
+  name: "IFrame",
+  methods: {
+    iframeLoaded() {
+      iframeResize({ log: false }, "#iframe")
+    },
+  },
+}
+</script>
+
+<style scoped>
+#iframe {
+  margin: 0 auto;
+  width: 100%;
+  border: none;
+  min-height: 700px;
+}
+</style>

--- a/src/views/stats.vue
+++ b/src/views/stats.vue
@@ -50,13 +50,13 @@
 </template>
 
 <script>
-import iFrameResize from "iframe-resizer/js/iframeResizer"
+import iframeResize from "iframe-resizer/js/iframeResizer"
 
 export default {
   name: "Stats",
   methods: {
     iframeLoaded() {
-      iFrameResize({ log: false }, "#iframe")
+      iframeResize({ log: false }, "#iframe")
     },
   },
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -4,7 +4,7 @@ const { animation, baseURL, matomo, statistics } = require("./backend/config")
 const configureAPI = require("./configure")
 const mock = require("./mock")
 const webpack = require("webpack")
-const before = process.env.NODE_ENV === "front_only" ? mock : configureAPI
+const before = process.env.NODE_ENV === "front-only" ? mock : configureAPI
 const parseArgs = require("minimist")
 const benefits = require("./data/all")
 


### PR DESCRIPTION
Les contraintes d'affichage `height: 100%` appliquées à `html` et `body` empêche le bon redimensionnement de l'iframe via `https://github.com/davidjbradshaw/iframe-resizer`.
Cette PR améliore la situation mais ne corrige pas encore l'affichage en mobile qui ne peut pas fonctionner en l'état avec les boutons précédent et suivant « collés » en bas et donc forcément avec une contrainte d'affichage à 100%.

Preneur de vos retours sur cette implémentation et d'aide pour un correctif sur la gestion en mobile.

J'ai ajouté une page /iframe en mode _inception_, qui contient l'application dans un iframe.