### PR TITLE
Permet de cliquer sur le bouton entrée dans le champ date

### DIFF
--- a/src/components/input-date.vue
+++ b/src/components/input-date.vue
@@ -1,5 +1,5 @@
 <template>
-  <form class="aj-input-date">
+  <div class="aj-input-date">
     <div v-if="showDay" class="aj-input-date-component day">
       <label class="aj-date-label">jour</label>
       <input
@@ -47,7 +47,7 @@
         min="1900"
       />
     </div>
-  </form>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Après investigation le changement est causé par le passage en form du composant input-date lors de la PR https://github.com/betagouv/aides-jeunes/pull/2444

Repasser en div ne semble pas supprimer les vérifications ajoutés lors de la PR 2444.

[Tâche Trello 611](https://trello.com/c/fAdY95Mv/611-etude-fix-y-a-t-il-eu-un-r%C3%A9gression-sur-le-passage-%C3%A0-la-page-suivante-avec-un-entr%C3%A9e-sur-la-page-date-de-naissance)