### PR TITLE
Simplifie pour accélérer le chargement des infos de communes

### DIFF
--- a/backend/controllers/outils.js
+++ b/backend/controllers/outils.js
@@ -2,36 +2,47 @@ const communes = require("@etalab/decoupage-administratif/data/communes.json")
 const communeCode98 = require("./communeCode98.json")
 const epci = require("@etalab/decoupage-administratif/data/epci.json")
 
-const index = {}
-let communeEpci
+const communesActuelles = communes.filter((c) => c.type === "commune-actuelle")
+const communeMap = {}
+const indexCodesPostaux = {}
 
-communes.forEach(function (commune) {
+communesActuelles.forEach(function (commune) {
+  communeMap[commune.code] = commune
+
   if (!commune.codesPostaux) {
     return
   }
 
-  communeEpci = epci.find((value) =>
-    value.membres.some((membre) => membre.code === commune.code)
-  )
   // Backward compatibility
   commune.codeCommune = commune.code
   commune.nomCommune = commune.nom
-  commune.epci = communeEpci?.code
-  commune.epciType = communeEpci?.type
 
   const codesPostauxUniques = new Set(commune.codesPostaux)
   codesPostauxUniques.forEach(function (codePostal) {
-    if (!(codePostal in index)) {
-      index[codePostal] = []
+    if (!(codePostal in indexCodesPostaux)) {
+      indexCodesPostaux[codePostal] = []
     }
 
-    index[codePostal].push(commune)
+    indexCodesPostaux[codePostal].push(commune)
+  })
+})
+
+epci.forEach(function (epci) {
+  epci.membres.forEach((communeMembre) => {
+    // commune déléguée
+    if (!communeMap[communeMembre.code]) {
+      return
+    }
+    communeMap[communeMembre.code].epci = epci.code
+    communeMap[communeMembre.code].epciType = epci.type
   })
 })
 
 function find(postalCode) {
-  return index[postalCode] || communeCode98[postalCode] || []
+  return indexCodesPostaux[postalCode] || communeCode98[postalCode] || []
 }
+
+exports.find = find
 
 exports.communes = function (req, res) {
   res.send(find(req.params.codePostal))


### PR DESCRIPTION
Limite les itérations imbriquées pour diminuer le temps de lancement du serveur. Grosso modo 12s -> 3s

Avant 
![Capture d’écran de 2022-02-28 10-29-29](https://user-images.githubusercontent.com/1410356/155958926-7adf6b14-e7b8-4abf-afdf-d406ee44d66d.png)

Après

![Capture d’écran de 2022-02-28 10-30-25](https://user-images.githubusercontent.com/1410356/155966023-15a26acf-d0d7-4824-9d2d-5083b62b5757.png)

