### PR TITLE
[621] Vérifier NODE_ENV en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         id: restore-build
         with:
           path: dist
-          key: ${{ runner.os }}-cache-build-${{ hashFiles('.') }}
+          key: ${{ runner.os }}-cache-build-${{ "$GITHUB_SHA" }}
       - name: Build assets
         run: |
           cp backend/config/continuous-integration.js backend/config/production.js
@@ -191,7 +191,7 @@ jobs:
         id: restore-build
         with:
           path: dist
-          key: ${{ runner.os }}-cache-build-${{ hashFiles('.') }}
+          key: ${{ runner.os }}-cache-build-${{ "$GITHUB_SHA" }}
       - name: Start OpenFisca
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
         with:
           browser: chrome
           config-file: false
-          start: npm run start
+          start: npm run ci
           wait-on: "http://localhost:8080, http://localhost:2000/variable/parisien, http://127.0.0.1:27017"
           install: false
           spec: cypress/integration/${{matrix.test}}.spec.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         id: restore-build
         with:
           path: dist
-          key: ${{ runner.os }}-cache-build-${{ echo "$GITHUB_SHA" }}
+          key: ${{ runner.os }}-cache-build-${{ github.sha }}
       - name: Build assets
         run: |
           cp backend/config/continuous-integration.js backend/config/production.js
@@ -191,7 +191,7 @@ jobs:
         id: restore-build
         with:
           path: dist
-          key: ${{ runner.os }}-cache-build-${{ echo "$GITHUB_SHA" }}
+          key: ${{ runner.os }}-cache-build-${{ github.sha }}
       - name: Start OpenFisca
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,6 @@ jobs:
         shell: bash
         run: |
           cp backend/config/continuous-integration.js backend/config/production.js
-          NODE_ENV=production
           nohup Xvfb :99 &
       - name: Cypress install
         uses: cypress-io/github-action@v2
@@ -216,7 +215,7 @@ jobs:
         with:
           browser: chrome
           config-file: false
-          start: node server.js
+          start: npm run start
           wait-on: "http://localhost:8080, http://localhost:2000/variable/parisien, http://127.0.0.1:27017"
           install: false
           spec: cypress/integration/${{matrix.test}}.spec.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         id: restore-build
         with:
           path: dist
-          key: ${{ runner.os }}-cache-build-${{ hashFiles('**/dist') }}
+          key: ${{ runner.os }}-cache-build-${{ hashFiles('.') }}
       - name: Build assets
         run: |
           cp backend/config/continuous-integration.js backend/config/production.js
@@ -191,7 +191,7 @@ jobs:
         id: restore-build
         with:
           path: dist
-          key: ${{ runner.os }}-cache-build-${{ hashFiles('**/dist') }}
+          key: ${{ runner.os }}-cache-build-${{ hashFiles('.') }}
       - name: Start OpenFisca
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         id: restore-build
         with:
           path: dist
-          key: ${{ runner.os }}-cache-build-${{ "$GITHUB_SHA" }}
+          key: ${{ runner.os }}-cache-build-${{ echo "$GITHUB_SHA" }}
       - name: Build assets
         run: |
           cp backend/config/continuous-integration.js backend/config/production.js
@@ -191,7 +191,7 @@ jobs:
         id: restore-build
         with:
           path: dist
-          key: ${{ runner.os }}-cache-build-${{ "$GITHUB_SHA" }}
+          key: ${{ runner.os }}-cache-build-${{ echo "$GITHUB_SHA" }}
       - name: Start OpenFisca
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         id: restore-build
         with:
           path: dist
-          key: ${{ runner.os }}-cache-build-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-cache-build-${{ hashFiles('**/dist') }}
       - name: Build assets
         run: |
           cp backend/config/continuous-integration.js backend/config/production.js
@@ -191,7 +191,7 @@ jobs:
         id: restore-build
         with:
           path: dist
-          key: ${{ runner.os }}-cache-build-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-cache-build-${{ hashFiles('**/dist') }}
       - name: Start OpenFisca
         shell: bash
         run: |

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "predb": "mkdir -p db",
     "prestart": "npm run build && npm run stats",
     "start": "NODE_ENV=production node server.js",
+    "ci": "npm run stats && NODE_ENV=production node server.js",
     "stats": "node backend/lib/stats",
     "serve-mail": "node tools/mjml.js",
     "test": "NODE_PATH=. jest --testTimeout=20000",


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/mANed7Ga/621-v%C3%A9rifier-nodeenv-en-ci)

## Détails

La variable d'environnement `NODE_ENV` était set à `production` dans un autre shell que celui de cypress lançant le serveur, ce qui avait pour conséquence de lancer ce dernier en mode `development`