### PR TITLE
Supprime une ligne de test dans les tests e2e

### DIFF
--- a/cypress/utils/results.js
+++ b/cypress/utils/results.js
@@ -2,7 +2,6 @@ import { submit } from "./form"
 
 const wait = () => {
   cy.wait("@results")
-  cy.get("#print-disclaimer").invoke("text").should("contain", "engagement")
 }
 
 const getBenefitSummary = (id) => cy.get(`@${id}-summary`)


### PR DESCRIPTION
La ligne de test ne me parait pas nécessaire : test si le disclaimer existe en vérifiant que le mot `engagement` est utilisé dans le disclaimer.
Cette ligne est bloquante pour le fonctionnement des tests e2e lorsque l'on modifie la structure ou les textes associés.
Je propose de la supprimer car je ne vois pas trop l'intéret de vérifier si le disclaimer est présent ou non, sachant que l'on vérifie ensuite si les aides sont affichés et que ces aides dépendent des mêmes conditions d'affichages.