### PR TITLE
Corrige le bouton recapitulatif en mode tablette

### DIFF
--- a/src/styles/partials/desktop/_ui-kit.scss
+++ b/src/styles/partials/desktop/_ui-kit.scss
@@ -168,7 +168,45 @@ html {
       }
 
       .aj-category-title-button-mobile {
+        $menu-button-size: 40px;
+
         display: none;
+
+        align-items: center;
+        justify-content: center;
+        position: relative;
+
+        .menu-button {
+          flex-shrink: 0;
+          border: 1px solid var(--light-grey);
+
+          svg {
+            width: 15px;
+            fill: var(--theme-primary);
+          }
+
+          &:focus,
+          &:active {
+            border: 1px solid var(--theme-primary);
+
+            svg {
+              fill: white;
+            }
+          }
+        }
+
+        .menu-button,
+        .menu-button:focus,
+        .menu-button:active {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: $menu-button-size;
+          width: $menu-button-size;
+          margin-top: 0;
+          margin-right: 10px;
+          padding: 0;
+        }
       }
 
       .aj-help-popup {

--- a/src/styles/partials/mobile/_ui-kit.scss
+++ b/src/styles/partials/mobile/_ui-kit.scss
@@ -6,56 +6,6 @@ html {
         padding: 16px 0;
       }
 
-      .aj-category-title {
-        flex-direction: row-reverse;
-        justify-content: center;
-        h1 {
-          font-size: 2em;
-          line-height: 1.125em;
-        }
-      }
-
-      .aj-category-title-button-mobile {
-        $menu-button-size: 40px;
-
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        position: relative;
-
-        .menu-button {
-          flex-shrink: 0;
-          border: 1px solid var(--light-grey);
-
-          svg {
-            width: 15px;
-            fill: var(--theme-primary);
-          }
-
-          &:focus,
-          &:active {
-            border: 1px solid var(--theme-primary);
-
-            svg {
-              fill: white;
-            }
-          }
-        }
-
-        .menu-button,
-        .menu-button:focus,
-        .menu-button:active {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          height: $menu-button-size;
-          width: $menu-button-size;
-          margin-top: 0;
-          margin-right: 10px;
-          padding: 0;
-        }
-      }
-
       .aj-box-wrapper {
         margin-bottom: 0;
         & > div:not(.aj-unbox),

--- a/src/styles/partials/tablet/_ui-kit.scss
+++ b/src/styles/partials/tablet/_ui-kit.scss
@@ -14,6 +14,19 @@ html {
       .aj-box-wrapper {
         margin-bottom: 78px;
       }
+
+      .aj-category-title {
+        flex-direction: row-reverse;
+        justify-content: center;
+        h1 {
+          font-size: 2em;
+          line-height: 1.125em;
+        }
+      }
+
+      .aj-category-title-button-mobile {
+        display: flex;
+      }
     }
   }
 }


### PR DESCRIPTION
Le bouton pour accéder au récapitulatif n'était pas disponible en affiche tablette. Ce correctif change la position du titre en mode tablette et affiche le bouton pour accéder au récapitulatif.
Résultat : 
![image](https://user-images.githubusercontent.com/65901733/156217152-9b55132e-a83b-4e33-b76c-335d5b99f403.png)

[Carte Trello](https://trello.com/c/AyXRkhv1/605-afficher-le-bouton-r%C3%A9cap-en-mode-tablette-%C3%A0-cot%C3%A9-du-titre)
