### PR TITLE
Repasse aux id de droits dans le suivi via matomo

### DIFF
--- a/src/views/simulation/resultats-detail.vue
+++ b/src/views/simulation/resultats-detail.vue
@@ -88,7 +88,7 @@ export default {
         return droit.id === droitId
       })
 
-      droit && this.$matomo?.trackEvent("General", "showDetails", droit.label)
+      droit && this.$matomo?.trackEvent("General", "showDetails", droit.id)
 
       this.sendStatistics(this.droits, "showDetails", droitId)
     }

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -137,7 +137,7 @@ export default {
       switch (type) {
         case "setResults": {
           calculs.resultats.droitsEligibles.forEach(function (d) {
-            vm.$matomo?.trackEvent("General", "show", d.label)
+            vm.$matomo?.trackEvent("General", "show", d.id)
           })
           this.sendStatistics(this.droits, "show")
           break


### PR DESCRIPTION
## Détails

Aujourd'hui seul le label d'un droit est enregistré dans matomo lors de la consultation de la page de résultats ou la page de détail d'une aide.

Or il existe plusieurs droits différents avec un label identique (ex `Aide au BAFA pour une session d'approfondissement` qui est un label pour 6 aides différentes), d'où le fait de repasser à l'id dans cette PR pour obtenir une entrée par aide