### PR TITLE
Ajoute la réponse "pas concerné" pour la question `enceinte`

### DIFF
--- a/backend/lib/definitions.js
+++ b/backend/lib/definitions.js
@@ -89,7 +89,10 @@ const individuBase = {
   date_naissance: Date,
   _dureeMoisEtudesEtranger: Number,
   duree_possession_titre_sejour: Number,
-  enceinte: Boolean,
+  enceinte: {
+    type: String,
+    enum: ["enceinte", "pas_enceinte", "pas_concerne"],
+  },
   enfant_a_charge: Object,
   enfant_place: Boolean,
   _firstName: String,

--- a/backend/lib/migrations/to-v9.js
+++ b/backend/lib/migrations/to-v9.js
@@ -1,0 +1,31 @@
+/*
+ * Migre enceinte
+ */
+
+const VERSION = 9
+
+function isEnceinteAnswer(answer) {
+  return answer.entityName === "individu" && answer.fieldName === "enceinte"
+}
+
+function updateEnceinte(answers) {
+  const enceinteAnswerIds = answers.reduce((accum, answer, index) => {
+    return accum.concat(isEnceinteAnswer(answer) ? index : [])
+  }, [])
+
+  enceinteAnswerIds.forEach((enceinteAnswerId) => {
+    const newValue = answers[enceinteAnswerId].value
+      ? "enceinte"
+      : "pas_enceinte"
+    answers[enceinteAnswerId].set("value", newValue, { strict: false })
+  })
+}
+
+module.exports = {
+  function: function (simulation) {
+    updateEnceinte(simulation.answers.all)
+    updateEnceinte(simulation.answers.current)
+    return simulation
+  },
+  version: VERSION,
+}

--- a/backend/lib/openfisca/mapping/individu/index.js
+++ b/backend/lib/openfisca/mapping/individu/index.js
@@ -88,6 +88,12 @@ const individuSchema = {
       return moment(situation.dateDeValeur).format("YYYY-MM-DD")
     },
   },
+  enceinte: {
+    src: "enceinte",
+    fn: function (enceinte) {
+      return enceinte === "enceinte"
+    },
+  },
   fin_etudes_etranger: {
     src: "_dureeMoisEtudesEtranger",
     fn: function (_dureeMoisEtudesEtranger, _, situation) {

--- a/cypress/utils/profil.js
+++ b/cypress/utils/profil.js
@@ -105,7 +105,7 @@ const defaultIndivu = () => {
   fill_activite("salarie")
   fill__nombreMoisDebutContratDeTravail(2)
   fillHandicap(false)
-  fill_enceinte(false)
+  fill_enceinte("pas_enceinte")
 }
 
 const handicaped = () => {
@@ -114,7 +114,7 @@ const handicaped = () => {
   fill_activite("salarie")
   fill__nombreMoisDebutContratDeTravail(2)
   fillHandicap({ taux_incapacite: 0.65, aah: true })
-  fill_enceinte(false)
+  fill_enceinte("pas_enceinte")
 }
 
 const publicStudent = () => {
@@ -130,7 +130,7 @@ const publicStudent = () => {
   fillHandicap(false)
   fill_enfant_a_charge(false)
   fill_regime_securite_sociale("regime_general")
-  fill_enceinte(false)
+  fill_enceinte("pas_enceinte")
 }
 
 const defaultChildren = () => {
@@ -149,7 +149,7 @@ const defaultConjoint = () => {
   fill_statut_marital("marie")
   fill_conjoint_activite("salarie")
   fillHandicap(false)
-  fill_enceinte(false)
+  fill_enceinte("pas_enceinte")
 }
 
 export default {

--- a/src/lib/individu-properties.js
+++ b/src/lib/individu-properties.js
@@ -257,6 +257,23 @@ const STEPS = {
           : "Votre conjointe est-elle"
       } enceinte ?`
     },
+    questionType: "enum",
+    items: () => {
+      return [
+        {
+          label: "Oui",
+          value: "enceinte",
+        },
+        {
+          label: "Non",
+          value: "pas_enceinte",
+        },
+        {
+          label: "Pas concerné",
+          value: "pas_concerne",
+        },
+      ]
+    },
   },
 
   enfant_a_charge: {

--- a/src/store.js
+++ b/src/store.js
@@ -39,7 +39,7 @@ function defaultStore() {
         current: [],
       },
       dateDeValeur: new Date(),
-      version: 8,
+      version: 9,
     },
     message: {
       text: null,


### PR DESCRIPTION
- [x] Permet la réponse "non concerné"
- [x] Migre `enceinte` dans les anciennes simulations


script à lancer :
```
bash backend/lib/migrations/looper.sh
```


Ce changement neccessite une migration possible après le passage de la PR : https://github.com/betagouv/aides-jeunes/pull/2346