### PR TITLE
[629] Ajouter un lien vers l'outil de contribution sur chaque page dédiée d'aide /aides/:slug

### DIFF
--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -21,6 +21,7 @@ const all = {
     apiKey: process.env.SEND_IN_BLUE_PRIVATE_KEY || "privateKey",
   },
   github: {
+    repository_url: "https://github.com/betagouv/aides-jeunes",
     access_token_url: "https://github.com/login/oauth/access_token",
     authenticated_url: "https://api.github.com/user",
     authorize_url: "https://github.com/login/oauth/authorize",

--- a/src/components/droits-contributions.vue
+++ b/src/components/droits-contributions.vue
@@ -1,0 +1,64 @@
+<template>
+  <p class="is-align-vertically-center">
+    <a
+      v-if="brokenLinkButtonState === 'show'"
+      class="text-center"
+      @click="alertBrokenLink()"
+      >Lien invalide ?</a
+    >
+    <span
+      v-else-if="brokenLinkButtonState === 'showThanksMessage'"
+      class="text-center"
+      >Merci pour votre aide ! Nous réglerons ce problème très
+      prochainement.</span
+    >
+    <span v-if="showContributionLinks && isEditableBenefit()"
+      > -
+      <a :href="repositoryBenefitUrl()" target="_blank" rel="noreferrer"
+        >Code source de l'aide</a
+      >
+      -
+      <a :href="netlifyContributionUrl()" target="_blank" rel="noreferrer"
+        >Proposer une modification</a
+      ></span
+    >
+  </p>
+</template>
+
+<script>
+export default {
+  name: "DroitsContributions",
+  props: {
+    droit: Object,
+    showContributionLinks: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      brokenLinkButtonState: "show",
+    }
+  },
+  methods: {
+    isEditableBenefit() {
+      return ["javascript", "openfisca"].includes(this.droit.source)
+    },
+    repositoryBenefitUrl() {
+      return `${process.env.VUE_APP_BENEFIT_URL}/${this.droit.source}/${this.droit.id}.yml`
+    },
+    netlifyContributionUrl() {
+      return `${process.env.VUE_APP_NETLIFY_CONTRIBUTION_URL}/admin/#/collections/benefits_${this.droit.source}/entries/${this.droit.id}`
+    },
+    alertBrokenLink() {
+      this.brokenLinkButtonState = "showThanksMessage"
+      setTimeout(() => (this.brokenLinkButtonState = null), 5000)
+      this.$matomo?.trackEvent(
+        "General",
+        "Erreur lien aide invalide",
+        this.droit.label
+      )
+    },
+  },
+}
+</script>

--- a/src/components/droits-details.vue
+++ b/src/components/droits-details.vue
@@ -117,34 +117,6 @@
             <img src="@/assets/images/doigt.svg" /> Démarches pour les
             professions agricoles
           </a>
-
-          <div class="is-align-vertically-center">
-            <a
-              v-if="brokenLinkButtonState === 'show'"
-              class="text-center"
-              @click="alertBrokenLink()"
-              >Lien invalide ?</a
-            >
-            <span
-              v-else-if="brokenLinkButtonState === 'showThanksMessage'"
-              class="text-center"
-              >Merci pour votre aide ! Nous réglerons ce problème très
-              prochainement.</span
-            >
-            <span v-if="showContributionLinks && isEditableBenefit()"
-              > -
-              <a :href="repositoryBenefitUrl()" target="_blank" rel="noreferrer"
-                >Code source de l'aide</a
-              >
-              -
-              <a
-                :href="netlifyContributionUrl()"
-                target="_blank"
-                rel="noreferrer"
-                >Proposer une modification</a
-              ></span
-            >
-          </div>
         </div>
       </div>
     </div>
@@ -173,39 +145,10 @@ export default {
     droits: Array,
     patrimoineCaptured: Boolean,
     ressourcesYearMinusTwoCaptured: Boolean,
-    showContributionLinks: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  data() {
-    return {
-      brokenLinkButtonState: "show",
-    }
   },
   computed: {
     aCharge() {
       return Situation.aCharge(this.$store.getters.situation)
-    },
-  },
-  methods: {
-    isEditableBenefit() {
-      return ["javascript", "openfisca"].includes(this.droit.source)
-    },
-    repositoryBenefitUrl() {
-      return `${process.env.VUE_APP_BENEFIT_URL}/${this.droit.source}/${this.droit.id}.yml`
-    },
-    netlifyContributionUrl() {
-      return `${process.env.VUE_APP_NETLIFY_CONTRIBUTION_URL}/admin/#/collections/benefits_${this.droit.source}/entries/${this.droit.id}`
-    },
-    alertBrokenLink() {
-      this.brokenLinkButtonState = "showThanksMessage"
-      setTimeout(() => (this.brokenLinkButtonState = null), 5000)
-      this.$matomo?.trackEvent(
-        "General",
-        "Erreur lien aide invalide",
-        this.droit.label
-      )
     },
   },
 }

--- a/src/components/droits-details.vue
+++ b/src/components/droits-details.vue
@@ -131,6 +131,19 @@
               >Merci pour votre aide ! Nous réglerons ce problème très
               prochainement.</span
             >
+            <span v-if="showContributionLinks && isEditableBenefit()"
+              > -
+              <a :href="repositoryBenefitUrl()" target="_blank" rel="noreferrer"
+                >Code source de l'aide</a
+              >
+              -
+              <a
+                :href="netlifyContributionUrl()"
+                target="_blank"
+                rel="noreferrer"
+                >Proposer une modification</a
+              ></span
+            >
           </div>
         </div>
       </div>
@@ -160,6 +173,10 @@ export default {
     droits: Array,
     patrimoineCaptured: Boolean,
     ressourcesYearMinusTwoCaptured: Boolean,
+    showContributionLinks: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -172,6 +189,15 @@ export default {
     },
   },
   methods: {
+    isEditableBenefit() {
+      return ["javascript", "openfisca"].includes(this.droit.source)
+    },
+    repositoryBenefitUrl() {
+      return `${process.env.VUE_APP_BENEFIT_URL}/${this.droit.source}/${this.droit.id}.yml`
+    },
+    netlifyContributionUrl() {
+      return `${process.env.VUE_APP_NETLIFY_CONTRIBUTION_URL}/admin/#/collections/benefits_${this.droit.source}/entries/${this.droit.id}`
+    },
     alertBrokenLink() {
       this.brokenLinkButtonState = "showThanksMessage"
       setTimeout(() => (this.brokenLinkButtonState = null), 5000)

--- a/src/views/aide.vue
+++ b/src/views/aide.vue
@@ -35,6 +35,7 @@
               :city="'75056'"
               :patrimoine-captured="true"
               :ressources-year-minus-two-captured="true"
+              :show-contribution-links="true"
             />
           </div>
         </div>

--- a/src/views/aide.vue
+++ b/src/views/aide.vue
@@ -35,9 +35,12 @@
               :city="'75056'"
               :patrimoine-captured="true"
               :ressources-year-minus-two-captured="true"
-              :show-contribution-links="true"
             />
           </div>
+          <DroitsContributions
+            :droit="benefit"
+            :show-contribution-links="true"
+          />
         </div>
       </div>
     </article>
@@ -47,11 +50,13 @@
 <script>
 import Institution from "@/lib/institution"
 import DroitsDetails from "@/components/droits-details.vue"
+import DroitsContributions from "@/components/droits-contributions.vue"
 
 export default {
   name: "AideDetails",
   components: {
     DroitsDetails,
+    DroitsContributions,
   },
   data() {
     return {}

--- a/src/views/simulation/resultats-detail.vue
+++ b/src/views/simulation/resultats-detail.vue
@@ -37,7 +37,9 @@
         :patrimoine-captured="patrimoineCaptured"
         :ressources-year-minus-two-captured="ressourcesYearMinusTwoCaptured"
       />
+      <DroitsContributions v-if="droit" :droit="droit" />
     </div>
+
     <div class="aj-box normal-padding-bottom aj-results-details-feedback-box">
       <Feedback />
     </div>
@@ -46,6 +48,7 @@
 
 <script>
 import DroitsDetails from "../../components/droits-details.vue"
+import DroitsContributions from "../../components/droits-contributions.vue"
 import Feedback from "@/components/feedback"
 import LoadingModal from "@/components/loading-modal"
 import ResultatsMixin from "@/mixins/resultats"
@@ -55,6 +58,7 @@ export default {
   name: "SimulationResultatsDetail",
   components: {
     DroitsDetails,
+    DroitsContributions,
     Feedback,
     LoadingModal,
   },

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,13 @@
 const HtmlWebpackPlugin = require("html-webpack-plugin")
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer")
-const { animation, baseURL, matomo, statistics } = require("./backend/config")
+const {
+  animation,
+  baseURL,
+  github,
+  matomo,
+  netlifyContributionURL,
+  statistics,
+} = require("./backend/config")
 const configureAPI = require("./configure")
 const mock = require("./mock")
 const webpack = require("webpack")
@@ -16,6 +23,8 @@ process.env.VUE_APP_CONTEXT_NAME = "1jeune1solution"
 process.env.VUE_APP_BASE_URL = baseURL
 process.env.VUE_APP_CONTEXT = process.env.CONTEXT
 process.env.VUE_APP_PR_URL = `${process.env.REPOSITORY_URL}/pull/${process.env.REVIEW_ID}`
+process.env.VUE_APP_BENEFIT_URL = `${github.repository_url}/blob/master/data/benefits`
+process.env.VUE_APP_NETLIFY_CONTRIBUTION_URL = `${netlifyContributionURL}`
 process.env.VUE_APP_STATS_URL = statistics?.url ? statistics.url : ""
 process.env.VUE_APP_STATS_VERSION = statistics?.version ? statistics.version : 2
 process.env.VUE_APP_NETLIFY_PR = process.env.BRANCH


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/t7DwU7mU/629-ajouter-un-lien-vers-loutil-de-contribution-sur-chaque-page-d%C3%A9di%C3%A9e-daide-aides-slug)

## Remarques

Pour les aides vélos il n'y a pas de lien affiché puisque la gestion de ces aides ne se fait pas sur netlify et qu'elles ne sont pas présentes sur notre repository