### PR TITLE
[647] empêche le changement de valeur de champs number en cas de scroll

### DIFF
--- a/src/components/input-number.vue
+++ b/src/components/input-number.vue
@@ -11,6 +11,7 @@
       :max="max"
       :step="step"
       :data-type="dataType"
+      :onWheel="(e) => e.target.blur()"
     />
     <div v-if="error" class="text-red input-number-error">
       Ce champ n'est pas valide.

--- a/src/components/input-number.vue
+++ b/src/components/input-number.vue
@@ -11,7 +11,7 @@
       :max="max"
       :step="step"
       :data-type="dataType"
-      :onWheel="(e) => e.target.blur()"
+      :onWheel="(e) => e.preventDefault()"
     />
     <div v-if="error" class="text-red input-number-error">
       Ce champ n'est pas valide.


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/QrahWibm/647-sur-le-simulateur-le-scroll-sur-un-champ-number-change-la-valeur)

## Détails

La solution ici est d'enlever le focus au champ `number` sélectionné par l'utilisateur ; l'inconvénient étant que cela change le comportement par défaut du navigateur.

Une autre solution serait de faire un `e.preventDefault()` avec comme inconvénient majeur que cela empêcherait de scroll sur la page si jamais un input number a le focus.

=> À noter que dans tous les cas chrome empêche le scroll si un input number est sélectionné et le curseur au dessus de celui-ci.