### PR TITLE
[651] Les units tests échouent lorsqu'une image est spécifiée pour une aide

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -184,7 +184,7 @@ fields:
     widget: image
     allow_multiple: false
     required: false
-    media_folder: "/public/img/benefits"
+    media_folder: "public/img/benefits"
     hint: Utile si vous voulez afficher le logo de l'aide à la place de l'image de l'institution.
   field_nom_aide: &field_nom_aide
     label: Nom de l'aide

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -184,7 +184,7 @@ fields:
     widget: image
     allow_multiple: false
     required: false
-    media_folder: "public/img/benefits"
+    media_folder: "/public/img/benefits"
     hint: Utile si vous voulez afficher le logo de l'aide à la place de l'image de l'institution.
   field_nom_aide: &field_nom_aide
     label: Nom de l'aide

--- a/tests/unit/benefits-description.spec.js
+++ b/tests/unit/benefits-description.spec.js
@@ -48,7 +48,7 @@ describe("benefit descriptions", function () {
 
           if (benefit.imgSrc) {
             it("should refer to a img file that exists", function () {
-              const path = `${__dirname}/../../public/${benefit.imgSrc}`
+              const path = `${__dirname}/../../${benefit.imgSrc}`
               expect(fs.existsSync(path)).toBe(true)
             })
           }


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/cKcf6UXl/651-les-units-tests-%C3%A9chouent-lorsquune-image-est-sp%C3%A9cifi%C3%A9e-pour-une-aide)

