### PR TITLE
[657] Certaines régions sont manquantes dans l'outil de contribution

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -67,12 +67,24 @@ fields:
             value: "53"
           - label: Centre-Val de Loire
             value: "24"
+          - label: Corse
+            value: "94"
           - label: Grand Est
             value: "44"
+          - label: Guadeloupe
+            value: "01"
+          - label: Guyane
+            value: "03"
           - label: Hauts-de-France
             value: "32"
           - label: Île-de-France
             value: "11"
+          - label: La Réunion
+            value: "04"
+          - label: Martinique
+            value: "02"
+          - label: Mayotte
+            value: "06"
           - label: Normandie
             value: "28"
           - label: Nouvelle-Aquitaine


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/9iMonilx/657-certaines-r%C3%A9gions-sont-manquantes-dans-loutil-de-contribution)

## Détails

Lors de l'ajout d'une "Conditions générale à satisfaire simultanément" de type "régions", il manquait la région Corse ainsi que les régions d'Outre-mer