### PR TITLE
[656] Lors de la création d'une institution, le code insee est optionnel dans l'interface mais obligatoire dans les tests

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -708,7 +708,6 @@ collections:
         hint: Pour les communes, départements, régions
         name: code_insee
         widget: string
-        required: false
       - label: Code SIREN
         hint: En l'absence de code INSEE
         name: code_siren


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/eUEpi4eb/656-lors-de-la-cr%C3%A9ation-dune-institution-le-code-insee-est-optionnel-dans-linterface-mais-obligatoire-dans-les-tests)

## Détails

Le code insee n'est pas obligatoire dans l'outil de contribution mais est requis dans les tests unitaires.

**Checker les cas où le code insee n'existe pas (ex: caf etc)**