### PR TITLE
Revert "[656] Lors de la création d'une institution, le code insee est optionnel dans l'interface mais obligatoire dans les tests"

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -720,6 +720,7 @@ collections:
         hint: Pour les communes, départements, régions
         name: code_insee
         widget: string
+        required: false
       - label: Code SIREN
         hint: En l'absence de code INSEE
         name: code_siren


### PR DESCRIPTION
Reverts betagouv/aides-jeunes#2582