### PR TITLE
Corrige le chemin des logos d'aides dans l'outil de contribution

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -196,6 +196,7 @@ fields:
     widget: image
     allow_multiple: false
     required: false
+    public_folder: "img/benefits"
     media_folder: "/public/img/benefits"
     hint: Utile si vous voulez afficher le logo de l'aide à la place de l'image de l'institution.
   field_nom_aide: &field_nom_aide


### PR DESCRIPTION
Le chemin généré par l'aide n'était pas bon, il commencait par `/public/`. ex : https://github.com/betagouv/aides-jeunes/pull/2620/files
Ce correctif permet de changer de faire commencer le changement par `img/`
