### PR TITLE
Correctif/cleaning pour l'outil d'accompagnement

### DIFF
--- a/backend/controllers/followups.js
+++ b/backend/controllers/followups.js
@@ -70,6 +70,20 @@ exports.showFromSurvey = function (req, res) {
   })
 }
 
+exports.showSurveyResult = function (req, res) {
+  Followup.findOne({
+    _id: req.params.surveyId,
+  })
+    .then((simulation) => {
+      if (!simulation) return res.sendStatus(404)
+      res.send([simulation])
+    })
+    .catch((error) => {
+      console.error("error", error)
+      return res.sendStatus(400)
+    })
+}
+
 exports.showSurveyResults = function (req, res) {
   Followup.find({
     surveyOptin: true,

--- a/backend/routes/followups.js
+++ b/backend/routes/followups.js
@@ -12,5 +12,5 @@ module.exports = function (api) {
   api
     .route("/followups/id/:surveyId")
     .get(cookieParser(), githubController.access)
-    .get(followups.showSimulation)
+    .get(followups.showSurveyResult)
 }

--- a/src/views/accompagnement/liste.vue
+++ b/src/views/accompagnement/liste.vue
@@ -235,7 +235,7 @@ export default {
         ? `/api/followups/id/${this.$route.params.surveyId}`
         : `/api/followups/surveys`
       try {
-        const response = await fetch(`${uri}?${new Date().getTime()}`, {
+        const response = await fetch(uri, {
           method: "GET",
           redirect: "error",
           headers: {


### PR DESCRIPTION
## Description

- [x] Sur une page spécifique d'un accompagnement, il n'était pas possible d'accéder aux résultats de la simulation
- [x] La page d'accompagnement envoyait toujours des query avec un paramètre random pour prévenir la mise en cache des données