### PR TITLE
Corrige les code_insee des régions Guadeloupe et Martinique

### DIFF
--- a/data/institutions/guadeloupe.yml
+++ b/data/institutions/guadeloupe.yml
@@ -1,4 +1,4 @@
 name: Guadeloupe
 imgSrc: img/logo_guadeloupe.png
 type: region
-code_insee: "971"
+code_insee: "01"

--- a/data/institutions/martinique.yml
+++ b/data/institutions/martinique.yml
@@ -1,4 +1,4 @@
 name: Martinique
 imgSrc: img/logo_martinique.png
 type: region
-code_insee: "972"
+code_insee: "02"


### PR DESCRIPTION
Les pages dédiées aux régions indiquent bien les nouveaux codes 01 et 02 au niveau des régions et les anciens codes qui, eux, correspondent aux départements.


https://www.insee.fr/fr/metadonnees/cog/region/REG01-guadeloupe
https://www.insee.fr/fr/metadonnees/cog/region/REG02-martinique

https://geo.api.gouv.fr/regions