### PR TITLE
[656] Lors de la création d'une institution, le code insee est optionnel dans l'interface mais obligatoire dans les tests

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -748,11 +748,13 @@ collections:
         name: code_insee
         widget: string
         required: false
+        required_group: identifier
       - label: Code SIREN
         hint: En l'absence de code INSEE
         name: code_siren
         widget: string
         required: false
+        required_group: identifier
   - name: contribution-pages
     label: Pages
     label_singular: page

--- a/contribuer/public/admin/main.js
+++ b/contribuer/public/admin/main.js
@@ -7,6 +7,7 @@ const LEGENDE_PERIODICITE_AIDE_ENUM = {
 // Effectue une vérification groupée sur les champs ayant l'attribut required_group
 const groupFieldsLegend = {
   cta: "Liens vers un site, téléservice ou formulaire",
+  identifier: "Code INSEE ou code SIRET",
 }
 const groupFieldsHint = "Au moins un des champs suivants doit être rempli"
 

--- a/contribuer/public/admin/main.js
+++ b/contribuer/public/admin/main.js
@@ -7,7 +7,7 @@ const LEGENDE_PERIODICITE_AIDE_ENUM = {
 // Effectue une vérification groupée sur les champs ayant l'attribut required_group
 const groupFieldsLegend = {
   cta: "Liens vers un site, téléservice ou formulaire",
-  identifier: "Code INSEE ou code SIRET",
+  identifier: "Code INSEE ou code SIREN",
 }
 const groupFieldsHint = "Au moins un des champs suivants doit être rempli"
 


### PR DESCRIPTION
## Description

[Tâche Trello](https://trello.com/c/eUEpi4eb/656-lors-de-la-cr%C3%A9ation-dune-institution-le-code-insee-est-optionnel-dans-linterface-mais-obligatoire-dans-les-tests)