### PR TITLE
[709] Migrer le projet sentry historique vers le sentry beta gouv

### DIFF
--- a/configure.js
+++ b/configure.js
@@ -11,7 +11,7 @@ module.exports = function (devServer) {
     // https://docs.sentry.io/development/sdk-dev/overview/#usage-for-end-users
     dsn:
       process.env.NODE_ENV === "production"
-        ? "https://dff4dd1245ed4ed2b05a11f513c23cb4@o548798.ingest.sentry.io/5709109"
+        ? "https://b44fa037e37b4b9eb1a050675b253dce@sentry.incubateur.net/17"
         : null,
   })
 

--- a/src/main.js
+++ b/src/main.js
@@ -39,7 +39,7 @@ app.directive("selectOnClick", SelectOnClickDirective)
 if (process.env.NODE_ENV === "production") {
   Sentry.init({
     app,
-    dsn: "https://80847fcdc7e74cbfb9d2f47751e42889@o548798.ingest.sentry.io/5709078",
+    dsn: "https://77f2520f2558451c80b1b95131135bcd@sentry.incubateur.net/18",
   })
 }
 


### PR DESCRIPTION
## Détails

[Tâche Trello](https://trello.com/c/ZGS0PJpz/709-migrer-le-projet-sentry-historique-vers-le-sentry-beta-gouv)


## Tâches
- [x] Créer des projets `aides-jeunes-front` et `aides-jeunes-node` ont été créés sur le [nouveau Sentry](https://sentry.incubateur.net/organizations/betagouv/projects/)
- [x] Ajouter l'alerting tel que présent sur le Sentry historique
