### PR TITLE
Corrige l'affichage de l'entête de preview d'une aide dans l'outil de contribution

### DIFF
--- a/contribuer/public/css/style.css
+++ b/contribuer/public/css/style.css
@@ -42,7 +42,6 @@ body {
 
 .aj-droit-header {
   display: flex;
-  justify-content: space-between;
   gap: 20px;
   align-items: flex-start;
   width: 100%;
@@ -93,9 +92,9 @@ body {
 
 .aj-droit-montant {
   flex-basis: 200px;
-  flex-grow: 0;
   flex-shrink: 0;
   text-align: right;
+  flex: 1;
 
   font-weight: bold;
   font-size: 1.4rem;


### PR DESCRIPTION
## Description

Maximise la largeur d'affichage du header de l'outil de contribution.

Avant
<img width="799" alt="image" src="https://user-images.githubusercontent.com/16650011/165711397-f8552503-45a0-48d4-ad74-477f5c8fd80a.png">

Après
<img width="798" alt="image" src="https://user-images.githubusercontent.com/16650011/165711317-d744f95f-1178-47a6-bfa7-691e8bec715c.png">
