### PR TITLE
Corrige un problème de runner de CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
   OPENFISCA_BIND_HOST: 127.0.0.1:2000
   LC_ALL: C.UTF-8
   LANG: C.UTF-8
-  PYTHON_VERSION: 3.7
+  PYTHON_VERSION: 3.7.12
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description

Le run de CI [2274854021](https://github.com/betagouv/aides-jeunes/actions/runs/2274854021) a échoué lors du job "Install OpenFisca", étape "Setup VirtualEnv" avec l'erreur suivante : 
```
FileExistsError: [Errno 17] File exists: '/opt/hostedtoolcache/Python/3.7.13/x64/bin/python' -> '/home/runner/work/aides-jeunes/aides-jeunes/.venv/bin/python'
```

En relançant un run de CI sur une autre PR qui était passé sans erreur ([2274613932](https://github.com/betagouv/aides-jeunes/actions/runs/2274613932)) on obtient la même erreur.

Étant donné qu'aucun changement n'a été fait au niveau du fichier de github action ou au niveau des pré-requis d'installation de package d'OpenFisca le problème vient d'ailleurs : les images Python utilisées par les runners github sont passés de la version `3.7.12` à la version `3.7.13`.

En fixant le numéro de version de l'image Python utilisé par le runner github à `3.7.12` on ne retrouve plus l'erreur de CI décrite ci-dessus.

À noter également le passage du package `virtualenv` à son subset natif `venv` qui ne devrait impacter ni les performances, ni s'éloigner de la logique d'installation de package sur la prod.