### PR TITLE
[771] Ajouter un enfant puis directement revenir en arrière sans remplir d'information ne doit pas afficher un enfant

### DIFF
--- a/src/views/simulation/enfants.vue
+++ b/src/views/simulation/enfants.vue
@@ -92,8 +92,9 @@ export default {
       const enfants = this.enfants.filter((enfant) => {
         if (!enfant.date_naissance) {
           this.$store.dispatch("removeEnfant", enfant.id)
+          return false
         }
-        return enfant.date_naissance !== undefined
+        return true
       })
       this.$store.dispatch("answer", {
         entityName: "enfants",


### PR DESCRIPTION
## Détails

[Tâche Trello](https://trello.com/c/VIWdNmms/771-ajouter-un-enfant-puis-directement-revenir-en-arri%C3%A8re-sans-remplir-dinformation-ne-doit-pas-afficher-un-enfant)

Pour répondre à la problématique d'utilisateur cliquant par inadvertance sur le bouton "Ajouter un enfant" puis revenant en arrière, ne voyant pas le lien "supprimer".

La solution choisi ici est de ne pas prendre en compte un enfant tant qu'il n'a pas sa date de naissance définie.