### PR TITLE
Corrige wording sur les ressources perçues

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -29,8 +29,7 @@ let ressourceCategories = [
   },
   {
     id: "autre",
-    label: (individu) =>
-      `${Individu.label(individu, "percevoir")} d'autres revenus ?`,
+    label: () => `Autres revenus`,
   },
 ]
 


### PR DESCRIPTION
Oubli de modifier le wording pour le dernier groupe de checkbox sur la PR [#2855](https://github.com/betagouv/aides-jeunes/pull/2855)

DE
![Capture d’écran du 2022-05-11 18-31-48](https://user-images.githubusercontent.com/78914809/167902020-d59d37f6-641e-446c-8a0f-9a118734baa7.png)
A
![Capture d’écran du 2022-05-11 18-34-10](https://user-images.githubusercontent.com/78914809/167902064-4fb59365-909e-4afe-94d1-8106a85d58b1.png)
À