### PR TITLE
[FIX] Masque les montants pour les aides aux vélos sur la page d'aide

### DIFF
--- a/src/components/droit-estime.vue
+++ b/src/components/droit-estime.vue
@@ -3,7 +3,7 @@
     v-if="
       droit.type &&
       ($route.name !== 'aide' ||
-        ($route.name === 'aide' && droit.source !== 'openfisca'))
+        ($route.name === 'aide' && droit.source === 'javascript'))
     "
     class="aj-droit-estime"
   >


### PR DESCRIPTION
## Description

Pour les aides aux vélos un montant de `1€` était affiché par défaut sur la page de description de l'aide ([exemple](https://mes-aides.1jeune1solution.beta.gouv.fr/aides/aidesvelo_aides_bonus_v%C3%A9lo_cargo)).

Ce fix supprime la référence au montant pour les aides de type vélo