### PR TITLE
[FIX] corrige un bug qui empêchait l'envoi d'email de sondage

### DIFF
--- a/backend/models/followup.js
+++ b/backend/models/followup.js
@@ -109,8 +109,7 @@ FollowupSchema.methods.renderSurveyEmail = function (survey) {
 }
 
 FollowupSchema.methods.createSurvey = function (type) {
-  const followup = this
-  return followup.surveys.create({
+  return this.surveys.create({
     type: type,
   })
 }


### PR DESCRIPTION
## Détails

Suite à la normalisation des id de sondage en `ObjectId`, l'assignation d'un token généré de manière aléatoire comme id subsistait dans le code et empêchait l'envoi d'email de sondage (les emails de récapitulatifs n'ont pas été impactés).

La tâche cron responsable de l'envoi des emails enregistrait l'erreur suivante dans un fichier de log à part (voir `tail -n 200 /var/log/main/emails.log`) : 
```
value: '[REDACTED FOR PRIVACY]',
      path: '_id',
      reason: TypeError: Argument passed in must be a string of 12 bytes or a string of 24 hex characters
          at new BSONTypeError (/home/main/aides_jeunes/repository/node_modules/bson/lib/error.js:39:42)
          at new ObjectId (/home/main/aides_jeunes/repository/node_modules/bson/lib/objectid.js:65:23)
          at castObjectId (/home/main/aides_jeunes/repository/node_modules/mongoose/lib/cast/objectid.js:25:12)
          at ObjectId.cast (/home/main/aides_jeunes/repository/node_modules/mongoose/lib/schema/objectid.js:245:12)
          at ObjectId.SchemaType.applySetters (/home/main/aides_jeunes/repository/node_modules/mongoose/lib/schematype.js:1135:12)
          at EmbeddedDocument.$set (/home/main/aides_jeunes/repository/node_modules/mongoose/lib/document.js:1407:20)
          at EmbeddedDocument.$set (/home/main/aides_jeunes/repository/node_modules/mongoose/lib/document.js:1149:16)
          at EmbeddedDocument.Document (/home/main/aides_jeunes/repository/node_modules/mongoose/lib/document.js:158:12)
          at EmbeddedDocument.Subdocument (/home/main/aides_jeunes/repository/node_modules/mongoose/lib/types/subdocument.js:28:12)
          at EmbeddedDocument.ArraySubdocument [as constructor] (/home/main/aides_jeunes/repository/node_modules/mongoose/lib/types/ArraySubdocument.js:36:15)
          at new EmbeddedDocument (/home/main/aides_jeunes/repository/node_modules/mongoose/lib/schema/documentarray.js:115:17)
          at Proxy.create (/home/main/aides_jeunes/repository/node_modules/mongoose/lib/types/DocumentArray/methods/index.js:272:12)
          at /home/main/aides_jeunes/repository/backend/models/followup.js:114:29
          at tryCatcher (/home/main/aides_jeunes/repository/node_modules/bluebird/js/release/util.js:16:23)
          at Promise._settlePromiseFromHandler (/home/main/aides_jeunes/repository/node_modules/bluebird/js/release/promise.js:547:31)
          at Promise._settlePromise (/home/main/aides_jeunes/repository/node_modules/bluebird/js/release/promise.js:604:18),
      valueType: 'string'
    }
```

## Remarque

**Avant de merger la PR il faut prendre en compte qu'il y a 2034 emails de sondages non envoyés en attente. La tâche CRON responsable de l'envoi des emails le fait par batch quotidien de `1000` emails ce qui fait que l'envoi ne devrait probablement pas être considéré comme du spam par SendinBlue. Cependant ce dernier point est à débattre ; une solution pourrait être de baisser ce ratio pendant quelques jours le temps que le retard soit rattrapé.**