### PR TITLE
Rend obligatoire le prefix de l'aide dans l'outil de contribution et ajoute les prefix manquants

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -291,9 +291,9 @@ fields:
     name: prefix
     hint: |
       L'ajout d'un article défini permet la formation de phrase grammaticalement correcte.
-      Par exemple, dans la phrase « Comment obtenir l'aide exceptionnelle ? », on choisit le préfixe est « l' ». Pour « Comment obtenir les aides au logement ? », on choisit le préfixe est « les ».
+      Par exemple, dans la phrase « Comment obtenir l'aide exceptionnelle ? », on choisit le préfixe « l' ». Pour « Comment obtenir les aides au logement ? », on choisit le préfixe « les ».
     widget: select
-    required: false
+    required: true
     options: [le, la, les, l’, une, l’aide]
   field_result_type: &field_result_type
     label: Type du résultat

--- a/data/benefits/aides-velo-generator.js
+++ b/data/benefits/aides-velo-generator.js
@@ -49,6 +49,7 @@ function generate_benefit_list(institutions) {
         collectivity: b.collectivity,
         title: b.title,
         institution: b.institution,
+        prefix: "l'",
         type: "float",
         periodicite: "ponctuelle",
         link: b.url,

--- a/data/benefits/javascript/aide-au-bafa-pour-une-session-dapprofondissement-ou-de-qualification-caf-de-la-haute-savoie.yml
+++ b/data/benefits/javascript/aide-au-bafa-pour-une-session-dapprofondissement-ou-de-qualification-caf-de-la-haute-savoie.yml
@@ -11,6 +11,7 @@ conditions:
   - Avoir commencé une formation pour obtenir le brevet d’aptitude à la fonction d’animateur de centre de vacances et de loisirs (BAFA).
 link: https://www.caf.fr/allocataires/caf-de-la-haute-savoie/contacter-ma-caf
 instructions: https://www.caf.fr/allocataires/caf-de-la-haute-savoie/contacter-ma-caf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/aide-au-bafa-pour-une-session-de-formation-générale-caf-de-la-haute-savoie.yml
+++ b/data/benefits/javascript/aide-au-bafa-pour-une-session-de-formation-générale-caf-de-la-haute-savoie.yml
@@ -10,6 +10,7 @@ description: L'aide au BAFA pour une session de formation générale est une aid
 conditions: []
 link: https://www.caf.fr/allocataires/caf-de-la-haute-savoie/contacter-ma-caf
 instructions: https://www.caf.fr/allocataires/caf-de-la-haute-savoie/contacter-ma-caf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/auvergne-rhone-alpes-pass-region.yml
+++ b/data/benefits/javascript/auvergne-rhone-alpes-pass-region.yml
@@ -22,6 +22,7 @@ profils:
 link: https://jeunes.auvergnerhonealpes.fr/106-pass-region.htm
 teleservice: https://auvergnerhonealpes.zecarte.fr/ARA/Forms/InscriptionBeneficiaire/InfosCarte.aspx
 instructions: https://www.auvergnerhonealpes.fr/aide/173/289-faire-le-plein-d-avantages-avec-le-pass-region-education-lycees.htm
+prefix: le
 type: bool
 unit: null
 periodicite: annuelle

--- a/data/benefits/javascript/bretagne-aide-code-permis.yml
+++ b/data/benefits/javascript/bretagne-aide-code-permis.yml
@@ -26,7 +26,7 @@ conditions_generales:
 profils: []
 link: https://www.bretagne.bzh/aides/fiches/aide-a-la-formation-au-code-et-au-permis-de-conduire/
 instructions: https://www.bretagne.bzh/aides/fiches/aide-a-la-formation-au-code-et-au-permis-de-conduire/
-prefix: la
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-ain-aide-bafa-session-approfondissement-qualification.yml
+++ b/data/benefits/javascript/caf-ain-aide-bafa-session-approfondissement-qualification.yml
@@ -12,6 +12,7 @@ conditions:
 link: https://www.caf.fr/allocataires/caf-de-l-ain/offre-de-service/enfance-et-jeunesse/le-bafa
 form: https://www.caf.fr/sites/default/files/caf/011/Images/Offres%20de%20service/Enfance%20et%20Jeunesse/Demande%20BAFA%203.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-l-ain/offre-de-service/enfance-et-jeunesse/le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-ain-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-ain-aide-bafa-session-generale.yml
@@ -8,6 +8,7 @@ description: L'aide à la formation du BAFA est une aide locale mise à
 link: https://www.caf.fr/allocataires/caf-de-l-ain/offre-de-service/enfance-et-jeunesse/le-bafa
 form: https://www.caf.fr/sites/default/files/caf/011/Images/Offres%20de%20service/Logement/2021/ANNEXE%204.1%20_BAFA_session%20de%20form%20g%C3%A9n%C3%A9rale%20RIAS%202021.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-l-ain/offre-de-service/enfance-et-jeunesse/le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-allier-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-allier-aide-bafa-session-generale.yml
@@ -25,6 +25,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-l-allier/offre-de-service/enfance-et-jeunesse/le-bafa-brevet-d-aptitude-aux-fonctions-d-animateur
 form: https://www.caf.fr/sites/default/files/caf/031/Enfance%20et%20jeunesse/BAFA/DBAFA.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-l-allier/offre-de-service/enfance-et-jeunesse/le-bafa-brevet-d-aptitude-aux-fonctions-d-animateur
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-alpes-de-haute-provence-aide-a-lautonomisation-des-jeunes.yml
+++ b/data/benefits/javascript/caf-alpes-de-haute-provence-aide-a-lautonomisation-des-jeunes.yml
@@ -26,6 +26,7 @@ profils:
         value: 25
 link: https://www.caf.fr/partenaires/caf-des-alpes-de-haute-provence/partenaires-locaux/aide-a-l-autonomisation-des-jeunes
 form: https://www.caf.fr/sites/default/files/caf/041/AFI/IMPRIME%20AAJ%2010-2021%20pour%20utilisation%202022.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: mensuelle

--- a/data/benefits/javascript/caf-alpes-maritimes-aide-autonomie-jeunes.yml
+++ b/data/benefits/javascript/caf-alpes-maritimes-aide-autonomie-jeunes.yml
@@ -1,4 +1,4 @@
-label: L'aide à l'autonomie des jeunes
+label: aide à l'autonomie des jeunes
 institution: caf_alpes_maritimes
 description: La Caf des Alpes-Maritimes peut verser à vos parents une Aide à
   l'autonomie des jeunes (Aaj).
@@ -30,6 +30,7 @@ profils:
 link: https://www.caf.fr/allocataires/caf-des-alpes-maritimes/offre-de-service/enfance-et-jeunesse/l-aide-a-l-autonomie-des-jeunes-aaj
 form: https://www.caf.fr/sites/default/files/caf/061/Documents/OFFRESCE/ENFANCEJEUNESSE/2020/Demande_2020_aide_autonomie_jeunes.pdf
 instructions: https://www.caf.fr/sites/default/files/caf/061/Documents/OFFRESCE/ENFANCEJEUNESSE/2021/NOTICE%20-%20DEMANDE%20AAJ%20%20sept%2021%20juin%2022%20%28MAJ%2005%2010%2021%29.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-alpes-maritimes-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-alpes-maritimes-aide-bafa-approfondissement.yml
@@ -16,6 +16,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-des-alpes-maritimes/offre-de-service/enfance-et-jeunesse/le-financement-du-bafa
 form: https://www.caf.fr/sites/default/files/caf/061/Documents/OFFRESCE/ENFANCEJEUNESSE/2021/Demande%20bourse%20BAFA_200421.pdf
 instructions: https://www.caf.fr/allocataires/caf-des-alpes-maritimes/offre-de-service/enfance-et-jeunesse/le-financement-du-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-alpes-maritimes-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-alpes-maritimes-aide-bafa-generale.yml
@@ -10,6 +10,7 @@ description: >
 link: https://www.caf.fr/allocataires/caf-des-alpes-maritimes/offre-de-service/enfance-et-jeunesse/le-financement-du-bafa
 form: https://www.caf.fr/sites/default/files/caf/061/Documents/OFFRESCE/ENFANCEJEUNESSE/2021/Demande%20bourse%20BAFA_200421.pdf
 instructions: https://www.caf.fr/allocataires/caf-des-alpes-maritimes/offre-de-service/enfance-et-jeunesse/le-financement-du-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-ardeche-aide-bafa.yml
+++ b/data/benefits/javascript/caf-ardeche-aide-bafa.yml
@@ -11,6 +11,7 @@ conditions:
 link: https://www.caf.fr/allocataires/caf-de-l-ardeche/offre-de-service/enfance-et-jeunesse/le-bafa
 form: https://www.caf.fr/sites/default/files/caf/078/Documents/demande_daide_bafa.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-l-ardeche/offre-de-service/enfance-et-jeunesse/le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-ardennes-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-ardennes-aide-bafa-approfondissement.yml
@@ -15,6 +15,7 @@ conditions:
 link: https://www.caf.fr/allocataires/caf-des-ardennes/offre-de-service/enfance-et-jeunesse/le-bafa
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres
 instructions: https://www.caf.fr/allocataires/caf-des-ardennes/offre-de-service/enfance-et-jeunesse/le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-ardennes-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-ardennes-aide-bafa-generale.yml
@@ -13,6 +13,7 @@ conditions:
 link: https://www.caf.fr/allocataires/caf-des-ardennes/offre-de-service/enfance-et-jeunesse/le-bafa
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres
 instructions: https://www.caf.fr/allocataires/caf-des-ardennes/offre-de-service/enfance-et-jeunesse/le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-aube-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-aube-aide-bafa-approfondissement.yml
@@ -24,6 +24,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-l-aube/offre-de-service/petite-enfance/bourses-bafa-et-bafd
 form: https://www.caf.fr/sites/default/files/caf/101/Documents/Bafa/formation%20BAFA%20aide%20complementaire.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-l-aube/offre-de-service/petite-enfance/bourses-bafa-et-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-aube-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-aube-aide-bafa-generale.yml
@@ -23,6 +23,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-l-aube/offre-de-service/petite-enfance/bourses-bafa-et-bafd
 form: https://www.caf.fr/sites/default/files/caf/101/Documents/Bafa/Bourse%20Compl%C3%A9mentaire%20BAFA%20stage%20de%20base.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-l-aube/offre-de-service/petite-enfance/bourses-bafa-et-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-aveyron-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-aveyron-aide-bafa-approfondissement.yml
@@ -20,6 +20,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-l-aveyron/offre-de-service/enfance-et-jeunesse/le-bafa
 form: https://www.caf.fr/sites/default/files/caf/121/Documents/Offre%20de%20service/demande_daide_bafa_r4.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-l-aveyron/offre-de-service/enfance-et-jeunesse/le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-bas-rhin-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-bas-rhin-aide-bafa-approfondissement.yml
@@ -17,6 +17,7 @@ conditions_generales:
 profils: []
 link: https://www.bafa-bafd.jeunes.gouv.fr/Region.aspx?MJSReg=67
 instructions: https://www.caf.fr/allocataires/caf-du-bas-rhin/offre-de-service/enfance-et-jeunesse/l-aide-au-bafa-brevet-d-aptitude-aux-fonctions-d-animateur
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-bas-rhin-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-bas-rhin-aide-bafa-generale.yml
@@ -19,6 +19,7 @@ profils: []
 link: https://www.bafa-bafd.jeunes.gouv.fr/Region.aspx?MJSReg=67
 form: ""
 instructions: https://www.caf.fr/allocataires/caf-du-bas-rhin/offre-de-service/enfance-et-jeunesse/l-aide-au-bafa-brevet-d-aptitude-aux-fonctions-d-animateur
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-approfondissement.yml
@@ -23,6 +23,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-bouches-du-rhone/offre-de-service/petite-enfance-enfance-et-jeunesse
 instructions: https://www.caf.fr/allocataires/caf-des-bouches-du-rhone/offre-de-service/petite-enfance-enfance-et-jeunesse
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-generale.yml
@@ -22,6 +22,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-bouches-du-rhone/offre-de-service/petite-enfance-enfance-et-jeunesse
 instructions: https://www.caf.fr/allocataires/caf-des-bouches-du-rhone/offre-de-service/petite-enfance-enfance-et-jeunesse
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-calvados-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-calvados-aide-bafa-approfondissement.yml
@@ -23,6 +23,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-du-calvados/offre-de-service/enfance-et-jeunesse/bafa-bafd
 form: https://www.caf.fr/sites/default/files/caf/141/Caf.fr/Offre%20de%20service/Enfance%20Jeunesse/Dem%20BAFA%20approfondis%202017.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-calvados/offre-de-service/enfance-et-jeunesse/bafa-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-calvados-aide-bafa-générale.yml
+++ b/data/benefits/javascript/caf-calvados-aide-bafa-générale.yml
@@ -22,6 +22,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-du-calvados/offre-de-service/enfance-et-jeunesse/bafa-bafd
 form: https://www.caf.fr/sites/default/files/caf/141/Caf.fr/Offre%20de%20service/Petite%20Enfance/2021/16_02/ASD019%20-%20Dem%20BAFA%20Grale%202021.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-calvados/offre-de-service/enfance-et-jeunesse/bafa-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-charente-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-charente-aide-bafa-generale.yml
@@ -26,6 +26,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-charente/offre-de-service/enfance-et-jeunesse/le-bafa-vous-tente
 instructions: https://www.caf.fr/allocataires/caf-de-la-charente/offre-de-service/enfance-et-jeunesse/le-bafa-vous-tente
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-charente-maritime-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-charente-maritime-aide-bafa-approfondissement.yml
@@ -31,6 +31,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-charente-maritime/offre-de-service-0/enfance-et-jeunesse/l-aide-a-la-formation-bafabafd
 instructions: https://www.caf.fr/allocataires/caf-de-la-charente-maritime/offre-de-service-0/enfance-et-jeunesse/l-aide-a-la-formation-bafabafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-charente-maritime-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-charente-maritime-aide-bafa-generale.yml
@@ -31,6 +31,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-charente-maritime/offre-de-service-0/enfance-et-jeunesse/l-aide-a-la-formation-bafabafd
 instructions: https://www.caf.fr/allocataires/caf-de-la-charente-maritime/offre-de-service-0/enfance-et-jeunesse/l-aide-a-la-formation-bafabafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-correze-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-correze-aide-bafa-generale.yml
@@ -30,6 +30,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-correze/offre-de-service/enfance-et-jeunesse/le-bafa
 instructions: https://www.caf.fr/allocataires/caf-de-la-correze/offre-de-service/enfance-et-jeunesse/le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-corse-du-sud-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-corse-du-sud-aide-bafa-approfondissement.yml
@@ -23,6 +23,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-corse-du-sud/offre-de-service/enfance-et-jeunesse/le-brevet-d-aptitude-aux-fonctions-d-animateur-bafa
 form: https://www.caf.fr/sites/default/files/caf/201/Documents/_demande_bourse_bafa-majoration.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-corse-du-sud/offre-de-service/enfance-et-jeunesse/le-brevet-d-aptitude-aux-fonctions-d-animateur-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-cotes-armor-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-cotes-armor-aide-bafa-approfondissement.yml
@@ -24,6 +24,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-des-cotes-d-armor/offre-de-service/enfance-et-jeunesse/bafa-et-bafd
 form: https://www.caf.fr/sites/default/files/caf/221/offre_services/Enfance_jeunesse/bafa/20160418_demande_aide_bafa-bafd.pdf
 instructions: https://www.caf.fr/allocataires/caf-des-cotes-d-armor/offre-de-service/enfance-et-jeunesse/bafa-et-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-creuse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-creuse-aide-bafa-generale.yml
@@ -28,6 +28,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-creuse/offre-de-service/enfance-et-jeunesse/aides-pour-le-financement-du-bafa
 instructions: https://www.caf.fr/allocataires/caf-de-la-creuse/offre-de-service/enfance-et-jeunesse/aides-pour-le-financement-du-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-deux-sevres-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-deux-sevres-aide-bafa-generale.yml
@@ -16,6 +16,7 @@ conditions:
   - Ne pas être pris en charge à 100 % par l'employeur.
 link: https://www.caf.fr/allocataires/caf-des-deux-sevres/offre-de-service/enfance-et-jeunesse/bafa-l-aide-pour-la-formation-generale-coup-de-pouce-bafa
 instructions: https://www.caf.fr/allocataires/caf-des-deux-sevres/offre-de-service/enfance-et-jeunesse/bafa-l-aide-pour-la-formation-generale-coup-de-pouce-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-doubs-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-doubs-aide-bafa-approfondissement.yml
@@ -18,6 +18,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-du-doubs/offre-de-service/enfance-et-jeunesse/le-bafa-et-le-bafd
 form: https://www.caf.fr/sites/default/files/caf/253/Pages%20locales%202021/demande_daide_bafa.pdf
 instructions: https://www.caf.fr/sites/default/files/caf/253/Pages%20locales%202021/NOTICE%20BAFA%20BAFD.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-doubs-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-doubs-aide-bafa-generale.yml
@@ -16,6 +16,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-doubs/offre-de-service/enfance-et-jeunesse/le-bafa-et-le-bafd
 instructions: https://www.caf.fr/sites/default/files/caf/253/Pages%20locales%202021/NOTICE%20BAFA%20BAFD.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-drome-aide-bafa-session-approfondissement-qualification.yml
+++ b/data/benefits/javascript/caf-drome-aide-bafa-session-approfondissement-qualification.yml
@@ -12,6 +12,7 @@ conditions:
   - Ne pas avoir déjà obtenu la totalité du financement par d'autres organismes.
 link: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres
 instructions: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/jeune-de-11-a-25-ans/aide-pour-passer-le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
@@ -25,6 +25,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/jeune-de-11-a-25-ans/aide-pour-passer-le-bafa
 form: https://www.caf.fr/sites/default/files/caf/261/offre-de-service/enfance-jeunesse/aides-projets-jeunes-bafa/demande-aide-session-formation-generale-bafa2021.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/jeune-de-11-a-25-ans/aide-pour-passer-le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-eure-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-eure-aide-bafa-generale.yml
@@ -22,6 +22,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-l-eure/offre-de-service/enfance-et-jeunesse/le-brevet-d-aptitude-aux-fonctions-d-animateur-bafa
 form: https://www.caf.fr/sites/default/files/caf/271/Documents/DEM_BAFA_BAFD.pdf
 instructions: https://www.caf.fr/sites/default/files/caf/271/Documents/Notice%20BAFA3.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-eure-et-loir-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-eure-et-loir-aide-bafa-approfondissement.yml
@@ -18,6 +18,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-l-eure-et-loir/offre-de-service/enfance-et-jeunesse/les-aides-au-brevet-d-aptitude-aux-fonctions-d-animateur-bafa
 form: https://www.caf.fr/sites/default/files/caf/281/Documents/Bafa/demande_daide_bafa_r4.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-l-eure-et-loir/offre-de-service/enfance-et-jeunesse/les-aides-au-brevet-d-aptitude-aux-fonctions-d-animateur-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-guyane-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-guyane-aide-bafa-approfondissement.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-guyane/offre-de-service/enfance-et-jeunesse/aide-au-brevet-d-aptitude-aux-fonctions-d-animation-bafa
 form: https://www.caf.fr/sites/default/files/caf/973/Documents/formulaires/bafa.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-guyane/offre-de-service/enfance-et-jeunesse/aide-au-brevet-d-aptitude-aux-fonctions-d-animation-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-haute-loire-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-haute-loire-aide-bafa-approfondissement.yml
@@ -11,6 +11,7 @@ conditions:
 link: https://www.caf.fr/allocataires/caf-de-la-haute-loire/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa-et-bafd
 form: https://www.caf.fr/sites/default/files/caf/431/FORMULAIRES_ACSO/BAFA-Cerfa11381-02.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-haute-loire/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa-et-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-haute-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-loire-aide-bafa-generale.yml
@@ -8,6 +8,7 @@ description: L'aide au BAFA pour une session de formation générale est une aid
 link: https://www.caf.fr/allocataires/caf-de-la-haute-loire/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa-et-bafd
 form: https://www.caf.fr/sites/default/files/caf/431/Offre%20de%20service/FORMULAIRE_%20BAFA%201_CAF43.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-haute-loire/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa-et-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-haute-marne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-bafa-generale.yml
@@ -19,6 +19,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/enfance-et-jeunesse
 instructions: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/enfance-et-jeunesse
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-haute-marne-aide-bafd.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-bafd.yml
@@ -15,6 +15,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/enfance-et-jeunesse
 form: https://www.caf.fr/sites/default/files/caf/521/IMPRIME%20BAFD.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/enfance-et-jeunesse
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-haute-marne-aide-equipement-informatique.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-equipement-informatique.yml
@@ -29,6 +29,7 @@ conditions_generales:
 profils: []
 link: https://clg-vincenot.monbureaunumerique.fr/lectureFichiergw.do?ID_FICHIER=5901#:~:text=La%20Caisse%20d'Allocations%20Familiales,vous%20soutenir%20dans%20cette%20acquisition.&text=Pour%20les%20allocataires%20avec%20un,aller%20jusqu'%C3%A0%20800%E2%82%AC.
 instructions: https://clg-vincenot.monbureaunumerique.fr/lectureFichiergw.do?ID_FICHIER=5901#:~:text=La%20Caisse%20d'Allocations%20Familiales,vous%20soutenir%20dans%20cette%20acquisition.&text=Pour%20les%20allocataires%20avec%20un,aller%20jusqu'%C3%A0%20800%E2%82%AC.
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/caf-haute-marne-aide-parcours-jeunes.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-parcours-jeunes.yml
@@ -24,6 +24,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/sites/default/files/caf/521/Flyer%20Parcours%20Jeunes%202021.pdf#pdfjs.action=download
 instructions: https://www.caf.fr/sites/default/files/caf/521/Flyer%20Parcours%20Jeunes%202021.pdf#pdfjs.action=download
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/caf-haute-saone-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-haute-saone-aide-bafa-approfondissement.yml
@@ -22,6 +22,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-haute-saone/offre-de-service-0/enfance-et-jeunesse/bafa-bafd-dispositif-regional
 form: https://www.caf.fr/sites/default/files/caf/701/SITE/Offre%20de%20service/Enfance%20jeunesse/Aide%20r%C3%A9gionale%20BAFA%20BAFD/BAFA-BAFD%202017%20REGIONAL.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-haute-saone/offre-de-service-0/enfance-et-jeunesse/bafa-bafd-dispositif-regional
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-haute-saone-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-saone-aide-bafa-generale.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-haute-saone/offre-de-service-0/enfance-et-jeunesse/bafa-bafd-dispositif-regional
 form: https://www.caf.fr/sites/default/files/caf/701/SITE/Offre%20de%20service/Enfance%20jeunesse/Aide%20r%C3%A9gionale%20BAFA%20BAFD/BAFA-BAFD%202017%20REGIONAL.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-haute-saone/offre-de-service-0/enfance-et-jeunesse/bafa-bafd-dispositif-regional
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-haute-vienne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-vienne-aide-bafa-generale.yml
@@ -28,6 +28,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-haute-vienne/offre-de-service/enfance-et-jeunesse/vous-voulez-passer-le-bafa
 instructions: https://www.caf.fr/allocataires/caf-de-la-haute-vienne/offre-de-service/enfance-et-jeunesse/vous-voulez-passer-le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-hautes-alpes-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-hautes-alpes-aide-bafa-generale.yml
@@ -18,6 +18,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-des-hautes-alpes/offre-de-service-0/enfance-et-jeunesse
 form: https://www.caf.fr/sites/default/files/caf/051/Documents/BAFA%20formulaire%20stage1.pdf
 instructions: https://www.caf.fr/allocataires/caf-des-hautes-alpes/offre-de-service-0/enfance-et-jeunesse
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-des-hautes-pyrenees/offre-de-service/solidarite-et-insertion/vous-souhaitez-financer-votre-formation-d-animateur
 form: https://www.caf.fr/sites/default/files/caf/651/Images/Actualite/Plaquette%20social/FORMULAIRE%20DEMANDE%20AIDE%20EXCEPTIONNELLE%20A%20LA%20FORMATION%20BAFA%20proposition.pdf
 instructions: https://www.caf.fr/allocataires/caf-des-hautes-pyrenees/offre-de-service/solidarite-et-insertion/vous-souhaitez-financer-votre-formation-d-animateur
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-indre-et-loire-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-indre-et-loire-aide-bafa-approfondissement.yml
@@ -20,6 +20,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-touraine/offre-de-service/enfance-et-jeunesse/vous-avez-plus-de-17-ans-et-vous-suivez-une-formation-pour-obtenir-le-bafa
 form: https://www.caf.fr/sites/default/files/caf/371/2%20-%20Offre%20de%20services/Enfance%20et%20jeunesse/Imprim%C3%A9%20BAFA%20Unique%20-%20Annexe%202_%C3%A0_remplir%2005.21.pdf
 instructions: ""
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-indre-et-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-indre-et-loire-aide-bafa-generale.yml
@@ -18,6 +18,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-touraine/offre-de-service/enfance-et-jeunesse/vous-avez-plus-de-17-ans-et-vous-suivez-une-formation-pour-obtenir-le-bafa
 form: https://www.caf.fr/sites/default/files/caf/371/2%20-%20Offre%20de%20services/Enfance%20et%20jeunesse/Imprim%C3%A9%20BAFA%20Unique%20-%20Annexe%202_%C3%A0_remplir%2005.21.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-jura-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-jura-aide-bafa-approfondissement.yml
@@ -21,6 +21,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-jura/offre-de-service/enfance-et-jeunesse/l-aide-a-la-formation-bafa
 instructions: https://www.caf.fr/allocataires/caf-du-jura/offre-de-service/enfance-et-jeunesse/l-aide-a-la-formation-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-jura-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-jura-aide-bafa-generale.yml
@@ -20,6 +20,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-jura/offre-de-service/enfance-et-jeunesse/l-aide-a-la-formation-bafa
 instructions: https://www.caf.fr/allocataires/caf-du-jura/offre-de-service/enfance-et-jeunesse/l-aide-a-la-formation-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
@@ -25,6 +25,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-loir-et-cher/offre-de-service/enfance-et-jeunesse/financer-son-bafa
 form: https://www.caf.fr/sites/default/files/caf/411/PDF%202021/Formulaire%20demande%20aide%20Bafa%2041%20v5.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-loir-et-cher/offre-de-service/enfance-et-jeunesse/financer-son-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-generale.yml
@@ -24,6 +24,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-loir-et-cher/offre-de-service/enfance-et-jeunesse/financer-son-bafa
 form: https://www.caf.fr/sites/default/files/caf/411/PDF%202021/Formulaire%20demande%20aide%20Bafa%2041%20v5.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-loir-et-cher/offre-de-service/enfance-et-jeunesse/financer-son-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-loire-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loire-aide-bafa-approfondissement.yml
@@ -12,6 +12,7 @@ conditions:
 link: https://www.caf.fr/sites/default/files/caf/428/Documents/Rias%202020/Caf%20Loire%20-%20Allocataires%20-%20Aide%20Bafa%202020.pdf
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres?codePrestation=DBAFA#prestation-DBAFA-cnaf
 instructions: https://www.caf.fr/sites/default/files/caf/428/Documents/Rias%202020/Caf%20Loire%20-%20Allocataires%20-%20Aide%20Bafa%202020.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loire-aide-bafa-generale.yml
@@ -8,6 +8,7 @@ description: L'aide au BAFA pour une session de formation générale est une aid
 link: https://www.caf.fr/sites/default/files/caf/428/Documents/Rias%202020/Caf%20Loire%20-%20Allocataires%20-%20Aide%20Bafa%202020.pdf
 form: https://www.caf.fr/sites/default/files/caf/428/Documents/Bafa/51%2060%20A%2007_DBAFA.pdf
 instructions: https://www.caf.fr/sites/default/files/caf/428/Documents/Rias%202020/Caf%20Loire%20-%20Allocataires%20-%20Aide%20Bafa%202020.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-loire-atlantique-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loire-atlantique-aide-bafa-approfondissement.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-loire-atlantique/offre-de-service/enfance-et-jeunesse/l-aide-locale-au-financement-du-bafa
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres?codePrestation=DBAFA#prestation-DBAFA-cnaf
 instructions: https://www.caf.fr/allocataires/caf-de-loire-atlantique/offre-de-service/enfance-et-jeunesse/l-aide-locale-au-financement-du-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-loiret-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loiret-aide-bafa-approfondissement.yml
@@ -24,6 +24,7 @@ profils: []
 link: https://www.caf.fr/sites/default/files/caf/451/Livret%20action%20sociale%202020/Info%20et%20dde%20BAFA%20CAF%202020.pdf
 form: https://www.caf.fr/sites/default/files/caf/451/Livret%20action%20sociale%202020/Info%20et%20dde%20BAFA%20CAF%202020.pdf
 instructions: https://www.caf.fr/sites/default/files/caf/451/Livret%20action%20sociale%202020/Info%20et%20dde%20BAFA%20CAF%202020.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-loiret-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loiret-aide-bafa-generale.yml
@@ -23,6 +23,7 @@ profils: []
 link: https://www.caf.fr/sites/default/files/caf/451/Livret%20action%20sociale%202020/Info%20et%20dde%20BAFA%20CAF%202020.pdf
 form: https://www.caf.fr/sites/default/files/caf/451/Livret%20action%20sociale%202020/Info%20et%20dde%20BAFA%20CAF%202020.pdf
 instructions: https://www.caf.fr/sites/default/files/caf/451/Livret%20action%20sociale%202020/Info%20et%20dde%20BAFA%20CAF%202020.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/enfance-et-jeunesse/bafa
 form: https://www.caf.fr/sites/default/files/caf/471/Documents/offre_de_service/enfance_jeunesse/Demande%20Bafa.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/enfance-et-jeunesse/bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
@@ -19,6 +19,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/enfance-et-jeunesse/bafa
 instructions: https://www.caf.fr/sites/default/files/caf/471/Bafa_conditions_2021.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-martinique-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-martinique-aide-bafa-generale.yml
@@ -22,6 +22,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/sites/default/files/caf/972/Documents/LE%20BAFA%20VOUS%20TENTE.pdf
 instructions: https://www.caf.fr/sites/default/files/caf/972/Documents/LE%20BAFA%20VOUS%20TENTE.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-mayenne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-mayenne-aide-bafa-approfondissement.yml
@@ -17,6 +17,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-mayenne/offre-de-service/enfance-et-jeunesse/bafabafd-votre-caf-vous-aide
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres
 instructions: https://www.caf.fr/allocataires/caf-de-la-mayenne/offre-de-service/enfance-et-jeunesse/bafabafd-votre-caf-vous-aide
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-mayenne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-mayenne-aide-bafa-generale.yml
@@ -16,6 +16,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-mayenne/offre-de-service/enfance-et-jeunesse/bafabafd-votre-caf-vous-aide
 form: http://www.caf53.fr/ods/pdf/caf53_bafa_demande_aide_formation.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-mayenne/offre-de-service/enfance-et-jeunesse/bafabafd-votre-caf-vous-aide
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
@@ -21,6 +21,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/enfance-et-jeunesse/la-caf-peut-participer-au-financement-de-la-formation-au-bafa-ou-au-bafd
 instructions: https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/enfance-et-jeunesse/la-caf-peut-participer-au-financement-de-la-formation-au-bafa-ou-au-bafd
+prefix: l'
 type: bool
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-generale.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/enfance-et-jeunesse/la-caf-peut-participer-au-financement-de-la-formation-au-bafa-ou-au-bafd
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres?codePrestation=DBAFA#prestation-DBAFA-cnaf
 instructions: https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/enfance-et-jeunesse/la-caf-peut-participer-au-financement-de-la-formation-au-bafa-ou-au-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-meuse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-meuse-aide-bafa-generale.yml
@@ -16,6 +16,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-meuse/offre-de-service/enfance-et-jeunesse/l-aide-a-la-formation-bafa-bafd
 form: ""
 instructions: https://www.caf.fr/sites/default/files/caf/551/Documents/Offre%20de%20service/enfance%20jeunesse/BAFA%20BAFD/notice_BAFA_BAFD%20202101.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-morbihan-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-morbihan-aide-bafa-approfondissement.yml
@@ -22,6 +22,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-du-morbihan/offre-de-service/enfance-et-jeunesse/bourses-bafa-brevet-d-aptitude-aux-fonctions-d-animateur-et-bafd-brevet-d-aptitude-aux-fonctions-de-directeur
 form: https://www.caf.fr/sites/default/files/caf/561/Documents/enfance%20jeunesse/bafa.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-morbihan/offre-de-service/enfance-et-jeunesse/bourses-bafa-brevet-d-aptitude-aux-fonctions-d-animateur-et-bafd-brevet-d-aptitude-aux-fonctions-de-directeur
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-nord-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-nord-aide-bafa-approfondissement.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-du-nord/offre-de-service/enfance-et-jeunesse/bafabafd-la-caf-du-nord-peut-vous-aider
 form: https://www.caf.fr/sites/default/files/DEMANDE%20AIDE%20BAFA.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-nord/offre-de-service/enfance-et-jeunesse/bafabafd-la-caf-du-nord-peut-vous-aider
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-orne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-orne-aide-bafa-generale.yml
@@ -20,6 +20,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-l-orne/offre-de-service/enfance-et-jeunesse/la-formation-bafa-bafd
 instructions: https://www.caf.fr/allocataires/caf-de-l-orne/offre-de-service/enfance-et-jeunesse/la-formation-bafa-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-pas-de-calais-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-pas-de-calais-aide-bafa-generale.yml
@@ -21,6 +21,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-pas-de-calais/offre-de-service/enfance-et-jeunesse/les-aides-de-la-caf-pour-le-stage-de-base-et-d-approfondissement
 instructions: https://www.caf.fr/allocataires/caf-du-pas-de-calais/offre-de-service/enfance-et-jeunesse/les-aides-de-la-caf-pour-le-stage-de-base-et-d-approfondissement
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-puy-de-dome-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-puy-de-dome-aide-bafa-generale.yml
@@ -10,6 +10,7 @@ conditions:
 link: https://www.caf.fr/allocataires/caf-du-puy-de-dome/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa
 form: https://www.caf.fr/sites/default/files/caf/631/Documents/Partenaires/BAFA_mai%20_2021.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-puy-de-dome/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-pyrenees-orientales-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-pyrenees-orientales-aide-bafa-approfondissement.yml
@@ -25,6 +25,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-pyrenees-orientales/offre-de-service/enfance-et-jeunesse/l-aide-aux-stagiaires-en-formation-bafa
 instructions: https://www.caf.fr/allocataires/caf-des-pyrenees-orientales/offre-de-service/enfance-et-jeunesse/l-aide-aux-stagiaires-en-formation-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-pyrenees-orientales-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-pyrenees-orientales-aide-bafa-generale.yml
@@ -24,6 +24,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-pyrenees-orientales/offre-de-service/enfance-et-jeunesse/l-aide-aux-stagiaires-en-formation-bafa
 instructions: https://www.caf.fr/allocataires/caf-des-pyrenees-orientales/offre-de-service/enfance-et-jeunesse/l-aide-aux-stagiaires-en-formation-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-reunion-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-reunion-aide-bafa-approfondissement.yml
@@ -19,6 +19,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-reunion/offre-de-service/enfance-et-jeunesse/le-bafa-ou-le-bafd-vous-tente-votre-caf-peut-vous-aider
 form: https://www.caf.fr/sites/default/files/caf/974/2019/ACTION%20SOCIALE/demande_daide_bafa-2019.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-reunion/offre-de-service/enfance-et-jeunesse/le-bafa-ou-le-bafd-vous-tente-votre-caf-peut-vous-aider
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-reunion-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-reunion-aide-bafa-generale.yml
@@ -18,6 +18,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-reunion/offre-de-service/enfance-et-jeunesse/le-bafa-ou-le-bafd-vous-tente-votre-caf-peut-vous-aider
 instructions: https://www.caf.fr/allocataires/caf-de-la-reunion/offre-de-service/enfance-et-jeunesse/le-bafa-ou-le-bafd-vous-tente-votre-caf-peut-vous-aider
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-saone-et-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-saone-et-loire-aide-bafa-generale.yml
@@ -19,6 +19,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-saone-et-loire/actualites/annee/2020/bafa-savez-vous-que-la-caf-peut-financer-une-partie-de-la-formation
 form: http://blog.caf71.fr/wp-content/uploads/2020/02/BOURSE-BAFA-CAF.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-saone-et-loire/actualites/annee/2020/bafa-savez-vous-que-la-caf-peut-financer-une-partie-de-la-formation
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-sarthe-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-sarthe-aide-bafa-approfondissement.yml
@@ -23,6 +23,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-sarthe/offre-de-service/enfance-et-jeunesse/aides-aux-projets-pour-les-jeunes-0
 instructions: https://www.caf.fr/allocataires/caf-de-la-sarthe/offre-de-service/enfance-et-jeunesse/aides-aux-projets-pour-les-jeunes-0
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-sarthe-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-sarthe-aide-bafa-generale.yml
@@ -19,6 +19,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-sarthe/offre-de-service/enfance-et-jeunesse/aides-aux-projets-pour-les-jeunes-0
 instructions: https://www.caf.fr/allocataires/caf-de-la-sarthe/offre-de-service/enfance-et-jeunesse/aides-aux-projets-pour-les-jeunes-0
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-seine-et-marne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-seine-et-marne-aide-bafa-generale.yml
@@ -20,6 +20,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-seine-et-marne/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres?codePrestation=DBAFA#prestation-DBAFA-cnaf
 instructions: https://www.caf.fr/allocataires/caf-de-seine-et-marne/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-seine-maritime-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-seine-maritime-aide-bafa-approfondissement.yml
@@ -25,6 +25,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-seine-maritime/offre-de-service/enfance-et-jeunesse/l-aide-a-la-formation-au-brevet-d-aptitude-aux-fonctions-d-animateurs-caf-de-seine-maritime
 form: https://www.caf.fr/sites/default/files/caf/768/Offre%20de%20service/enfance%20et%20jeunesse%20%286%20%C3%A0%2018%20nas%29/bafacnaf.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-seine-maritime/offre-de-service/enfance-et-jeunesse/l-aide-a-la-formation-au-brevet-d-aptitude-aux-fonctions-d-animateurs-caf-de-seine-maritime
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-seine-st-denis-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-seine-st-denis-aide-bafa-approfondissement.yml
@@ -17,6 +17,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-seine-saint-denis/offre-de-service-0/enfance-et-jeunesse/l-aide-a-la-formation-bafa-session-d-approfondissement
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres?codePrestation=DBAFA#prestation-DBAFA-cnaf
 instructions: https://www.caf.fr/allocataires/caf-de-la-seine-saint-denis/offre-de-service-0/enfance-et-jeunesse/l-aide-a-la-formation-bafa-session-d-approfondissement
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-somme-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-somme-aide-bafa-approfondissement.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-somme/offre-de-service/enfance-et-jeunesse/l-aide-au-bafa
 form: https://www.caf.fr/sites/default/files/caf/801/PDF/Bafa%20Cerfa%2011381%2002.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-somme/offre-de-service/enfance-et-jeunesse/l-aide-au-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-somme-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-somme-aide-bafa-generale.yml
@@ -19,6 +19,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-somme/offre-de-service/enfance-et-jeunesse/l-aide-au-bafa
 instructions: https://www.caf.fr/allocataires/caf-de-la-somme/offre-de-service/enfance-et-jeunesse/l-aide-au-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-tarn-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-tarn-aide-bafa-approfondissement.yml
@@ -23,6 +23,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-du-tarn/offre-de-service/enfance-et-jeunesse/aides-a-la-formation-et-a-l-inclusion-numerique
 form: https://www.caf.fr/sites/default/files/caf/811/Imprim%C3%A9%20BAFA%20CAF81.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-tarn/offre-de-service/enfance-et-jeunesse/aides-a-la-formation-et-a-l-inclusion-numerique
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-approfondissement.yml
@@ -27,6 +27,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-tarn-et-garonne/offre-de-service/enfance-et-jeunesse/la-formation-au-bafa
 form: https://www.caf.fr/sites/default/files/caf/821/Documents/BAFA%20imprime%20NB.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-tarn-et-garonne/offre-de-service/enfance-et-jeunesse/la-formation-au-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-generale.yml
@@ -26,6 +26,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-tarn-et-garonne/offre-de-service/enfance-et-jeunesse/la-formation-au-bafa
 form: https://www.caf.fr/sites/default/files/caf/821/Documents/BAFA%20imprime%20NB.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-tarn-et-garonne/offre-de-service/enfance-et-jeunesse/la-formation-au-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-territoire-de-belfort-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-territoire-de-belfort-aide-bafa-approfondissement.yml
@@ -25,6 +25,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-du-territoire-de-belfort/offre-de-service/Enfance-et-jeunesse/la-bourse-de-stage-d-animateur-ou-de-directeur-de-centres-de-vacances-et-de-loisirs
 form: https://www.caf.fr/sites/default/files/caf/901/BAFA/BAFA%20Perfectionnement.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-territoire-de-belfort/offre-de-service/Enfance-et-jeunesse/la-bourse-de-stage-d-animateur-ou-de-directeur-de-centres-de-vacances-et-de-loisirs
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-territoire-de-belfort-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-territoire-de-belfort-aide-bafa-generale.yml
@@ -24,6 +24,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-du-territoire-de-belfort/offre-de-service/Enfance-et-jeunesse/la-bourse-de-stage-d-animateur-ou-de-directeur-de-centres-de-vacances-et-de-loisirs
 form: https://www.caf.fr/sites/default/files/caf/901/BAFA/BAFA%20BASE.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-territoire-de-belfort/offre-de-service/Enfance-et-jeunesse/la-bourse-de-stage-d-animateur-ou-de-directeur-de-centres-de-vacances-et-de-loisirs
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-val-de-marne-aide-bafa-approfondissement-qualification.yml
+++ b/data/benefits/javascript/caf-val-de-marne-aide-bafa-approfondissement-qualification.yml
@@ -12,6 +12,7 @@ conditions:
 link: https://www.caf.fr/allocataires/caf-du-val-de-marne/offre-de-service/enfance-et-jeunesse/l-aide-au-bafa
 form: https://www.caf.fr/sites/default/files/caf/941/Documents/Offre-services/demande_daide_bafa.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-val-de-marne/offre-de-service/enfance-et-jeunesse/l-aide-au-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-var-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-var-aide-bafa-approfondissement.yml
@@ -25,6 +25,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-du-var/offre-de-service/j-ai-un-ou-plusieurs-enfants-de-6-a-18-ans/aide-aux-formations-bafa
 form: https://www.caf.fr/sites/default/files/caf/831/Documents/2020%20BAFA/Demande%20aide%20Bafa%20Caf%20du%20Var.pdf
 instructions: https://www.caf.fr/allocataires/caf-du-var/offre-de-service/j-ai-un-ou-plusieurs-enfants-de-6-a-18-ans/aide-aux-formations-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
@@ -25,6 +25,7 @@ profils: []
 link: https://www.caf.fr/sites/default/files/caf/841/Images/pages-partenaires/newpartenaires/documents/FLYER%20-%20BAFA%2072.pdf
 form: https://www.caf.fr/sites/default/files/caf/841/Documents/Offredeservice/demande_daide_bafa.pdf
 instructions: https://www.caf.fr/sites/default/files/caf/841/Images/pages-partenaires/newpartenaires/documents/FLYER%20-%20BAFA%2072.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
@@ -25,6 +25,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/partenaires/caf-de-vaucluse/partenaires-locaux/jeunesse/brevet-d-aptitude-aux-fonctions-d-animateurs-bafa-les-aides-de-la-caf#:~:text=La%20CAF%20de%20Vaucluse%20apporte,dans%20leur%20d%C3%A9marche%20de%20formation.&text=%3E%20L'organisme%20de%20formation%20doit,Administration%20est%20de%20198%20%E2%82%AC.
 instructions: https://www.caf.fr/partenaires/caf-de-vaucluse/partenaires-locaux/jeunesse/brevet-d-aptitude-aux-fonctions-d-animateurs-bafa-les-aides-de-la-caf#:~:text=La%20CAF%20de%20Vaucluse%20apporte,dans%20leur%20d%C3%A9marche%20de%20formation.&text=%3E%20L'organisme%20de%20formation%20doit,Administration%20est%20de%20198%20%E2%82%AC.
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-vienne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vienne-aide-bafa-generale.yml
@@ -26,6 +26,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-vienne/offre-de-service/enfance-et-jeunesse/vous-recherchez-des-informations-sur-le-bafa
 instructions: https://www.caf.fr/allocataires/caf-de-la-vienne/offre-de-service/enfance-et-jeunesse/vous-recherchez-des-informations-sur-le-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-vosges-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vosges-aide-bafa-generale.yml
@@ -24,6 +24,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-vosges/offre-de-service/enfance-et-jeunesse/les-bourses-bafa-et-bafd
 instructions: https://www.caf.fr/allocataires/caf-des-vosges/offre-de-service/enfance-et-jeunesse/les-bourses-bafa-et-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf-yvelines-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-yvelines-aide-bafa-generale.yml
@@ -16,6 +16,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-des-yvelines/offre-de-service/enfance-et-jeunesse/l-aide-au-bafa-et-au-bafd
 form: https://www.caf.fr/sites/default/files/caf/781/Documents/Action-sociale/Enfance-jeunesse/BAFA/7.5%2806-2021%29-bafa-bafd-3.pdf
 instructions: https://www.caf.fr/allocataires/caf-des-yvelines/offre-de-service/enfance-et-jeunesse/l-aide-au-bafa-et-au-bafd
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf_alpes_maritimes-une-aide-au-départ-en-vacances-pour-les-jeunes-le-dispositif-sac-ados.yml
+++ b/data/benefits/javascript/caf_alpes_maritimes-une-aide-au-départ-en-vacances-pour-les-jeunes-le-dispositif-sac-ados.yml
@@ -1,4 +1,4 @@
-label: "Une aide au départ en vacances pour les jeunes : le dispositif Sac Ados"
+label: "aide au départ en vacances pour les jeunes : le dispositif Sac Ados"
 institution: caf_alpes_maritimes
 description: Créé par l’association « Vacances Ouvertes », c'est une aide aux
   projets de départs en vacances autonomes. Il s'agit de 150 € en chèques
@@ -22,6 +22,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-des-alpes-maritimes/offre-de-service/enfance-et-jeunesse/le-dispositif-sac-ados
 form: ""
 instructions: https://fb.watch/bVzOfhtnp2/
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf_moselle-aide-au-bafa-pour-une-session-de-formation-générale.yml
+++ b/data/benefits/javascript/caf_moselle-aide-au-bafa-pour-une-session-de-formation-générale.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-moselle/offre-de-service/enfance-et-jeunesse/l-aide-a-la-formation-bafa
 form: https://www.caf.fr/sites/default/files/caf/571/pdfDivers/Bafa/Bafa_aideFormGle_dec2020.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-moselle/offre-de-service/enfance-et-jeunesse/l-aide-a-la-formation-bafa
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf_pas_de_calais-aide-au-bafa-pour-une-session-de-formation-générale.yml
+++ b/data/benefits/javascript/caf_pas_de_calais-aide-au-bafa-pour-une-session-de-formation-générale.yml
@@ -24,6 +24,7 @@ conditions_generales:
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-pas-de-calais/offre-de-service/enfance-et-jeunesse/les-aides-de-la-caf-pour-le-stage-de-base-et-d-approfondissement
 instructions: https://www.caf.fr/allocataires/caf-du-pas-de-calais/offre-de-service/enfance-et-jeunesse/les-aides-de-la-caf-pour-le-stage-de-base-et-d-approfondissement
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf_pas_de_calais-aide-à-loutillage.yml
+++ b/data/benefits/javascript/caf_pas_de_calais-aide-à-loutillage.yml
@@ -36,6 +36,7 @@ profils:
         value: 20
 link: https://www.caf.fr/allocataires/caf-du-pas-de-calais/offre-de-service/solidarite-et-insertion/prime-a-l-outillage
 instructions: https://www.caf.fr/allocataires/caf-du-pas-de-calais/offre-de-service/solidarite-et-insertion/prime-a-l-outillage
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/caf_saone_et_loire-aide-à-lautonomie-des-jeunes.yml
+++ b/data/benefits/javascript/caf_saone_et_loire-aide-à-lautonomie-des-jeunes.yml
@@ -35,6 +35,7 @@ profils:
     conditions: []
 link: https://caf.fr/allocataires/caf-de-saone-et-loire/offre-de-service/jeunesse/l-aide-a-l-autonomie-des-jeunes
 form: https://caf.fr/sites/default/files/caf/711/Offre%20de%20services/Formulaires/Demande%20aide%20%C3%A0%20l%27autonomie%20des%20jeunes.pdf
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/centre-val-de-loire-aide-au-1er-equipement-professionnel.yml
+++ b/data/benefits/javascript/centre-val-de-loire-aide-au-1er-equipement-professionnel.yml
@@ -17,6 +17,7 @@ profils:
     conditions: []
 link: https://www.yeps.fr/articles/947C9784-CA1E-4CA1-870B-90406FC60EAF
 instructions: https://www.yeps.fr/articles/947C9784-CA1E-4CA1-870B-90406FC60EAF
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/centre-val-de-loire-aide-depot-garantie.yml
+++ b/data/benefits/javascript/centre-val-de-loire-aide-depot-garantie.yml
@@ -19,6 +19,7 @@ conditions_generales:
 profils: []
 link: https://www.yeps.fr/articles/9373061B-A260-4626-ABA2-BEEC54AD5782
 instructions: https://www.yeps.fr/articles/9373061B-A260-4626-ABA2-BEEC54AD5782
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/centre-val-de-loire-cheque-emploi.yml
+++ b/data/benefits/javascript/centre-val-de-loire-cheque-emploi.yml
@@ -14,6 +14,7 @@ profils:
     conditions: []
 link: https://www.remi-centrevaldeloire.fr/tarifsetachats/choisirmontitre/cheque-emploi/
 instructions: https://www.remi-centrevaldeloire.fr/tarifsetachats/choisirmontitre/cheque-emploi/
+prefix: le
 type: bool
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/departement-corse-bourse-animazioni.yml
+++ b/data/benefits/javascript/departement-corse-bourse-animazioni.yml
@@ -24,6 +24,7 @@ conditions_generales:
 profils: []
 link: https://www.isula.corsica/jeunesse/Bourse-Animazioni_a269.html
 instructions: https://www.isula.corsica/jeunesse/Bourse-Animazioni_a269.html
+prefix: la
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/grand-est-bourse-du-secteur-sanitaire-et-social.yml
+++ b/data/benefits/javascript/grand-est-bourse-du-secteur-sanitaire-et-social.yml
@@ -17,6 +17,7 @@ profils:
 link: https://www.grandest.fr/vos-aides-regionales/bourse-secteur-sanitaire-social/
 teleservice: https://boursesanitaireetsociale.grandest.fr/BSS-WEB/jsp/nouveauContexte.action?codeAction=M42-PORTAILSIMULATION
 instructions: https://www.grandest.fr/vos-aides-regionales/bourse-secteur-sanitaire-social/
+prefix: la
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/grand-est-experiences-de-jeunesse.yml
+++ b/data/benefits/javascript/grand-est-experiences-de-jeunesse.yml
@@ -23,6 +23,7 @@ conditions_generales:
 profils: []
 link: https://www.grandest.fr/vos-aides-regionales/experience-de-jeunesse/
 instructions: https://www.grandest.fr/vos-aides-regionales/experience-de-jeunesse/
+prefix: l'aide
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/grand-est-jeunest.yml
+++ b/data/benefits/javascript/grand-est-jeunest.yml
@@ -17,6 +17,7 @@ profils: []
 link: https://www.grandest.fr/vos-aides-regionales/jeunest-pour-les-15-29-ans/
 teleservice: https://beneficiaire.jeunest.fr/Connexion.aspx?ReturnUrl=%2f
 instructions: https://www.grandest.fr/vos-aides-regionales/jeunest-pour-les-15-29-ans/
+prefix: l'aide
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/grand-est-mobilite-internationale-sanitaire-et-sociale.yml
+++ b/data/benefits/javascript/grand-est-mobilite-internationale-sanitaire-et-sociale.yml
@@ -21,6 +21,7 @@ profils:
     conditions: []
 link: https://www.grandest.fr/vos-aides-regionales/formation-sanitaire-et-sociale-aide-a-la-mobilite-internationale/
 instructions: https://www.grandest.fr/vos-aides-regionales/formation-sanitaire-et-sociale-aide-a-la-mobilite-internationale/
+prefix: l'
 type: float
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/grand-est-parcours-acquisition-des-competences-en-entreprises.yml
+++ b/data/benefits/javascript/grand-est-parcours-acquisition-des-competences-en-entreprises.yml
@@ -17,6 +17,7 @@ profils: []
 link: http://www.pace-grandest.fr/
 teleservice: https://docs.google.com/forms/d/e/1FAIpQLScCXPV5JorT_JapH36mzwvFFMN_tlhXNCYibuU1Ow3qdykYkA/viewform
 instructions: http://www.pace-grandest.fr/
+prefix: le
 type: float
 unit: €
 periodicite: mensuelle

--- a/data/benefits/javascript/grand-est-passetudes.yml
+++ b/data/benefits/javascript/grand-est-passetudes.yml
@@ -27,6 +27,7 @@ profils:
     conditions: []
 link: https://www.ter.sncf.com/grand-est/offres/forfaits/champagne-ardenne/champagne-ardenne_pass-etudes#:~:text=Avec%20la%20carte%20PASS'%C3%89TUDES,vos%20billets%20TER%20Grand%20Est.
 form: https://cdn.ter.sncf.com/medias/PDF/grand_est/2021%20formulaire%20demande%20de%20carte%20PASS%20ETUDES_tcm75-151436_tcm75-136212.pdf
+prefix: le
 type: bool
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/grand_est-pass-mobilite-formation.yml
+++ b/data/benefits/javascript/grand_est-pass-mobilite-formation.yml
@@ -19,6 +19,7 @@ profils:
     conditions: []
 link: https://www.grandest.fr/vos-aides-regionales/pass-mobilite-formation/
 instructions: https://www.grandest.fr/vos-aides-regionales/pass-mobilite-formation/
+prefix: le
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/guadeloupe-aide-au-permis-de-conduire-des-jeunes-en-service-civique.yml
+++ b/data/benefits/javascript/guadeloupe-aide-au-permis-de-conduire-des-jeunes-en-service-civique.yml
@@ -21,6 +21,7 @@ profils:
         value: 25
 link: https://www.regionguadeloupe.fr/les-aides-les-services/guide-des-aides/detail/actualites/aide-au-permis-de-conduire-des-jeunes-en-service-civique/categorie/etudiant/#_
 instructions: https://www.regionguadeloupe.fr/les-aides-les-services/guide-des-aides/detail/actualites/aide-au-permis-de-conduire-des-jeunes-en-service-civique/categorie/etudiant/#_
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/guadeloupe-bourse-sanitaire.yml
+++ b/data/benefits/javascript/guadeloupe-bourse-sanitaire.yml
@@ -25,6 +25,7 @@ profils:
     conditions: []
 link: https://www.regionguadeloupe.fr/les-aides-les-services/guide-des-aides/detail/actualites/bourse-sanitaire/categorie/formation-enseignement-jeunesse/#_
 teleservice: https://aides.regionguadeloupe.fr/gesaides_web/jsp/nouveauContexte.action?codeAction=M42-ACCUEIL
+prefix: la
 type: float
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/hauts-de-france-aide-à-la-restauration-des-étudiants-boursiers-en-filière-sanitaire-et-sociale.yml
+++ b/data/benefits/javascript/hauts-de-france-aide-à-la-restauration-des-étudiants-boursiers-en-filière-sanitaire-et-sociale.yml
@@ -25,6 +25,7 @@ profils:
       - type: boursier
 link: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=385
 instructions: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=385
+prefix: l'
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/hauts-de-france-billet-enfant-1euro.yml
+++ b/data/benefits/javascript/hauts-de-france-billet-enfant-1euro.yml
@@ -13,6 +13,7 @@ link: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositi
 teleservice: https://m.ter.sncf.com/hauts-de-france/tarifs-cartes/billets/enfant-1-euro
 form: ""
 instructions: ""
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/hauts-de-france-bourses-etudes-sanitaires-et-sociales.yml
+++ b/data/benefits/javascript/hauts-de-france-bourses-etudes-sanitaires-et-sociales.yml
@@ -22,6 +22,7 @@ profils:
 link: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=667
 teleservice: https://aides.hautsdefrance.fr/sub/tiers/aides/details/?sigle=BESS-01%2F22
 instructions: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=667
+prefix: la
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/hauts-de-france-carte-generation-apprentis-aide-equipement.yml
+++ b/data/benefits/javascript/hauts-de-france-carte-generation-apprentis-aide-equipement.yml
@@ -16,6 +16,7 @@ profils:
     conditions: []
 link: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=595
 instructions: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=595
+prefix: la
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/hauts-de-france-en-route-pour-lemploi-parc-auto-1euro.yml
+++ b/data/benefits/javascript/hauts-de-france-en-route-pour-lemploi-parc-auto-1euro.yml
@@ -16,6 +16,7 @@ conditions_generales:
 profils: []
 link: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=632
 teleservice: https://enroutepourlemploi.hautsdefrance.fr/public/compte/login
+prefix: l'aide
 type: bool
 unit: €
 periodicite: mensuelle

--- a/data/benefits/javascript/hauts-de-france-fonds-regional-aide-urgence-sanitaire-social.yml
+++ b/data/benefits/javascript/hauts-de-france-fonds-regional-aide-urgence-sanitaire-social.yml
@@ -23,6 +23,7 @@ profils:
     conditions: []
 link: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=341
 instructions: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=341
+prefix: les
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/hauts-de-france-formations-sanitaires-sociales-niveaux-3-4.yml
+++ b/data/benefits/javascript/hauts-de-france-formations-sanitaires-sociales-niveaux-3-4.yml
@@ -21,6 +21,7 @@ profils:
     conditions: []
 link: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=656
 instructions: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=656
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/hauts-de-france-indemnites-protec-soc-formation-pro.yml
+++ b/data/benefits/javascript/hauts-de-france-indemnites-protec-soc-formation-pro.yml
@@ -25,6 +25,7 @@ profils:
     conditions: []
 link: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=147
 instructions: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=147
+prefix: la
 type: float
 unit: €
 periodicite: mensuelle

--- a/data/benefits/javascript/hauts-de-france-ma-carte-ter.yml
+++ b/data/benefits/javascript/hauts-de-france-ma-carte-ter.yml
@@ -15,6 +15,7 @@ conditions_generales:
 profils: []
 link: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=802
 teleservice: https://m.ter.sncf.com/hauts-de-france/tarifs-cartes/ma-carte-ter-hauts-de-france/+26-ans
+prefix: l'aide
 type: bool
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/martinique-bourses-sanitaires-et-sociales.yml
+++ b/data/benefits/javascript/martinique-bourses-sanitaires-et-sociales.yml
@@ -20,6 +20,7 @@ profils:
     conditions: []
 link: https://www.collectivitedemartinique.mq/wp-content/uploads/2021/07/Pr_Broch_a5_Espace-Etudiants_Form-Sanitaires_2107.pdf
 teleservice: https://etudiants.collectivitedemartinique.mq/
+prefix: les
 type: float
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/occitanie-bourse-etudes-sanitaires-et-sociales.yml
+++ b/data/benefits/javascript/occitanie-bourse-etudes-sanitaires-et-sociales.yml
@@ -25,6 +25,7 @@ profils:
     conditions: []
 link: https://www.laregion.fr/bourses-etudes-sanitaires-sociales
 instructions: https://www.laregion.fr/bourses-etudes-sanitaires-sociales
+prefix: la
 type: float
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/pays-de-la-loire-aide-acquisition-ordinateur-portable.yml
+++ b/data/benefits/javascript/pays-de-la-loire-aide-acquisition-ordinateur-portable.yml
@@ -7,6 +7,7 @@ description: Pour la rentrée 2021, la Région des Pays de la Loire fournit un
   de leurs études.
 link: https://www.paysdelaloire.fr/jeunesse-et-education/un-ordinateur-portable-fourni-par-la-region-aux-eleves-de-seconde-et-1ere-annee-de-cap
 instructions: https://www.paysdelaloire.fr/les-aides/mon-ordi-au-lycee
+prefix: l'
 type: bool
 conditions_generales:
   - type: regions

--- a/data/benefits/javascript/provence-alpes-cote-azur-bourse-sanitaire-social.yml
+++ b/data/benefits/javascript/provence-alpes-cote-azur-bourse-sanitaire-social.yml
@@ -17,6 +17,7 @@ profils:
 link: https://www.maregionsud.fr/aides-et-appels-a-projets/detail/bourse-regionale-detudes-dans-les-filieres-sanitaires-et-du-travail-social
 teleservice: https://aidesformation.maregionsud.fr/SignIn?ReturnUrl=%2Fprofile%2F
 instructions: https://www.maregionsud.fr/aides-et-appels-a-projets/detail/bourse-regionale-detudes-dans-les-filieres-sanitaires-et-du-travail-social
+prefix: la
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/provence-alpes-cote-azur-fonds-sanitaire-social.yml
+++ b/data/benefits/javascript/provence-alpes-cote-azur-fonds-sanitaire-social.yml
@@ -22,6 +22,7 @@ profils:
 link: https://www.maregionsud.fr/aides-et-appels-a-projets/detail/fonds-daide-regional-aux-etudiants-du-secteur-sanitaire-et-du-travail-social
 teleservice: https://aidesformation.maregionsud.fr/SignIn?ReturnUrl=%2Fprofile%2F
 instructions: https://www.maregionsud.fr/aides-et-appels-a-projets/detail/fonds-daide-regional-aux-etudiants-du-secteur-sanitaire-et-du-travail-social
+prefix: le
 type: float
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/region-auvergne-rhone-alpes-abonnement-illico.yml
+++ b/data/benefits/javascript/region-auvergne-rhone-alpes-abonnement-illico.yml
@@ -14,6 +14,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/auvergne-rhone-alpes/offres/tarifs/illico-hebdo-jeunes
 instructions: https://www.ter.sncf.com/auvergne-rhone-alpes/offres/tarifs/illico-hebdo-jeunes
+prefix: l'
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-auvergne-rhone-alpes-abonnement-ter-illico.yml
+++ b/data/benefits/javascript/region-auvergne-rhone-alpes-abonnement-ter-illico.yml
@@ -15,6 +15,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/auvergne-rhone-alpes/offres/tarifs/illico-mensuel-jeune
 instructions: https://www.ter.sncf.com/auvergne-rhone-alpes/offres/tarifs/illico-mensuel-jeune
+prefix: l'
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-auvergne-rhone-alpes-aide-financement-permis.yml
+++ b/data/benefits/javascript/region-auvergne-rhone-alpes-aide-financement-permis.yml
@@ -18,6 +18,7 @@ profils: []
 link: https://www.auvergnerhonealpes.fr/aide/385/289-financer-ma-formation-au-permis-de-conduire-orientation-formation.htm
 teleservice: https://aides.auvergnerhonealpes.fr/aides/#/crauraprod/connecte/F_FP_REL_CONDUI/depot/simple
 instructions: https://www.auvergnerhonealpes.fr/aide/385/289-financer-ma-formation-au-permis-de-conduire-orientation-formation.htm
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-auvergne-rhone-alpes-bourse-merite.yml
+++ b/data/benefits/javascript/region-auvergne-rhone-alpes-bourse-merite.yml
@@ -24,6 +24,7 @@ profils:
     conditions: []
 link: https://www.auvergnerhonealpes.fr/aide/81/289-beneficier-de-la-bourse-au-merite-en-tant-que-lyceen-ou-apprenti-education-lycees.htm
 instructions: https://www.auvergnerhonealpes.fr/aide/81/289-beneficier-de-la-bourse-au-merite-en-tant-que-lyceen-ou-apprenti-education-lycees.htm
+prefix: la
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-auvergne-rhone-alpes-bourse-mobilite-internationale-lycee-apprentissage.yml
+++ b/data/benefits/javascript/region-auvergne-rhone-alpes-bourse-mobilite-internationale-lycee-apprentissage.yml
@@ -22,6 +22,7 @@ link: https://www.auvergnerhonealpes.fr/aide/93/89-se-former-a-l-etranger-avec-l
 teleservice: https://sicorra.auvergnerhonealpes.fr/public
 form: ""
 instructions: https://www.auvergnerhonealpes.fr/aide/93/89-se-former-a-l-etranger-avec-la-bourse-region-mobilite-internationale-lyceens-et-apprentis-education-lycees.htm
+prefix: la
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-auvergne-rhone-alpes-carte-ter-illico-liberte-jeunes.yml
+++ b/data/benefits/javascript/region-auvergne-rhone-alpes-carte-ter-illico-liberte-jeunes.yml
@@ -16,6 +16,7 @@ profils: []
 link: https://www.ter.sncf.com/auvergne-rhone-alpes/offres/tarifs/illico-liberte-jeune
 teleservice: https://www.ter.sncf.com/auvergne-rhone-alpes/offres/tarifs/illico-liberte-jeune
 instructions: https://www.ter.sncf.com/auvergne-rhone-alpes/offres/tarifs/illico-liberte-jeune
+prefix: la
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-auvergne-rhone-alpes-ter-illico-solidaire.yml
+++ b/data/benefits/javascript/region-auvergne-rhone-alpes-ter-illico-solidaire.yml
@@ -14,6 +14,7 @@ conditions_generales:
 profils: []
 link: https://mmt.vsct.fr/sites/default/files/swt/CARA/2021-06/Depliant%20illico%20Solidaire-janvier%202019.pdf
 teleservice: https://illicosolidaire.cba.fr/
+prefix: la
 type: bool
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/region-bourgogne-franche-comte-abonnement-scolaire-bfc.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-abonnement-scolaire-bfc.yml
@@ -11,6 +11,7 @@ profils:
     conditions: []
 link: https://www.ter.sncf.com/bourgogne-franche-comte/offres/tarif-train/abonnement-scolaire-college-lycee-rentree
 instructions: https://www.ter.sncf.com/bourgogne-franche-comte/offres/tarif-train/abonnement-scolaire-college-lycee-rentree
+prefix: l'
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-bourgogne-franche-comte-aide-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-aide-au-permis-de-conduire.yml
@@ -22,6 +22,7 @@ conditions_generales:
 profils: []
 link: https://www.bourgognefranchecomte.fr/permisdeconduire
 instructions: https://www.bourgognefranchecomte.fr/permisdeconduire
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-bourgogne-franche-comte-e-carte-avantages-jeunes.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-e-carte-avantages-jeunes.yml
@@ -16,6 +16,7 @@ profils: []
 link: https://www.avantagesjeunes.com/
 teleservice: https://www.avantagesjeunes.com/boutique/etape-1
 instructions: ""
+prefix: l'
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-bourgogne-franche-comte-ordil.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-ordil.yml
@@ -14,6 +14,7 @@ profils:
 link: https://www.bourgognefranchecomte.fr/ordil
 teleservice: ""
 form: https://www.bourgognefranchecomte.fr/sites/default/files/2021-10/Convention%20pret%20eleve%20signee.pdf
+prefix: l'aide
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-bourgogne-franche-comte-tarif-jeune-26-ans.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-tarif-jeune-26-ans.yml
@@ -17,6 +17,7 @@ profils: []
 link: https://www.ter.sncf.com/bourgogne-franche-comte/offres/tarif-train/reduction-tarif-jeune-etudiant
 teleservice: https://www.ter.sncf.com/bourgogne-franche-comte/offres/tarif-train/reduction-tarif-jeune-etudiant
 instructions: ""
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-bretagne-abonnement-breizhgo.yml
+++ b/data/benefits/javascript/region-bretagne-abonnement-breizhgo.yml
@@ -19,6 +19,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/bretagne/offres/tarifs/quotidien-moins-26
 instructions: https://www.ter.sncf.com/bretagne/offres/tarifs/quotidien-moins-26
+prefix: l'
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-centre-val-de-loire-carte-rémi-liberté-jeune.yml
+++ b/data/benefits/javascript/region-centre-val-de-loire-carte-rémi-liberté-jeune.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.ter.sncf.com/centre-val-de-loire/offres/gamme-occasionnels-remi/remiliberte/carte-remi-liberte-jeune
 teleservice: https://vad.keolis.com/ter-centre-commandecarte/#/offres
 instructions: https://www.ter.sncf.com/centre-val-de-loire/offres/gamme-occasionnels-remi/remiliberte/carte-remi-liberte-jeune
+prefix: la
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-centre-val-de-loire-le-combo-parfait-aide-a-la-formation.yml
+++ b/data/benefits/javascript/region-centre-val-de-loire-le-combo-parfait-aide-a-la-formation.yml
@@ -1,4 +1,4 @@
-label: le Combo parfait (aide à la formation)
+label: Combo parfait (aide à la formation)
 institution: region_centre_val_de_loire
 description: "Le Combo Parfait regroupe des formations qualifiantes ou
   pré-qualifiantes à des métiers de proximité, destinées aux jeunes en recherche
@@ -22,6 +22,7 @@ profils:
     conditions: []
 link: https://www.yeps.fr/articles/891A0CF9-7DA0-421F-893C-327BAFE976CB
 instructions: https://www.yeps.fr/articles/891A0CF9-7DA0-421F-893C-327BAFE976CB
+prefix: le
 type: float
 unit: €
 periodicite: mensuelle

--- a/data/benefits/javascript/region-corse-aide-au-permis-prima-strada.yml
+++ b/data/benefits/javascript/region-corse-aide-au-permis-prima-strada.yml
@@ -27,6 +27,7 @@ conditions_generales:
 profils: []
 link: https://www.isula.corsica/jeunesse/Une-aide-pour-les-jeunes-pour-passer-le-permis-de-conduire-Prima-Strada_a80.html
 instructions: https://www.isula.corsica/jeunesse/attachment/2263155/
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-corse-bourse-a-la-mobilite-mobighjovani.yml
+++ b/data/benefits/javascript/region-corse-bourse-a-la-mobilite-mobighjovani.yml
@@ -23,6 +23,7 @@ conditions_generales:
 profils: []
 link: https://www.isula.corsica/jeunesse/Bourse-a-la-mobilite-Mobighjovani_a276.html
 instructions: https://www.isula.corsica/jeunesse/Bourse-a-la-mobilite-Mobighjovani_a276.html
+prefix: la
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-grand-est-abonnement-primo.yml
+++ b/data/benefits/javascript/region-grand-est-abonnement-primo.yml
@@ -15,6 +15,7 @@ profils: []
 link: https://www.ter.sncf.com/grand-est/offres/primo/primo_abonnement
 teleservice: https://www.sncf-abo-annuel-ter.com/tapas-tel-web/devisAbonnement?codeRegion=LOR
 instructions: https://www.ter.sncf.com/grand-est/offres/primo/primo_abonnement
+prefix: l'
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-grand-est-carte-primo.yml
+++ b/data/benefits/javascript/region-grand-est-carte-primo.yml
@@ -15,6 +15,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/grand-est/offres/primo/primo_carte#ancre
 instructions: https://www.ter.sncf.com/grand-est/offres/primo/primo_carte#ancre
+prefix: la
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-hauts-de-france-carte-ter-26-ans.yml
+++ b/data/benefits/javascript/region-hauts-de-france-carte-ter-26-ans.yml
@@ -18,5 +18,6 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/hauts-de-france/offres/cartes-de-reduction/carte-ter-26-ans
 instructions: https://www.ter.sncf.com/hauts-de-france/offres/cartes-de-reduction/carte-ter-26-ans
+prefix: la
 type: bool
 periodicite: autre

--- a/data/benefits/javascript/region-ile-de-france-aide-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/region-ile-de-france-aide-au-permis-de-conduire.yml
@@ -27,6 +27,7 @@ profils:
     conditions: []
 link: https://www.iledefrance.fr/aide-au-permis-de-conduire-pour-jeunes-en-insertion
 instructions: https://www.iledefrance.fr/aide-au-permis-de-conduire-pour-jeunes-en-insertion
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-ile-de-france-carte-imagine-r-scolaire.yml
+++ b/data/benefits/javascript/region-ile-de-france-carte-imagine-r-scolaire.yml
@@ -24,6 +24,7 @@ profils:
     conditions: []
 link: https://www.iledefrance-mobilites.fr/titres-et-tarifs/detail/forfait-imagine-r-scolaire
 teleservice: https://www.iledefrance-mobilites.fr/je-gere-ma-carte
+prefix: la
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-ile-de-france-carte-scolaire-bus-lignes-regulieres.yml
+++ b/data/benefits/javascript/region-ile-de-france-carte-scolaire-bus-lignes-regulieres.yml
@@ -31,6 +31,7 @@ profils:
     conditions: []
 link: https://www.iledefrance-mobilites.fr/titres-et-tarifs/detail/carte-scolaire-bus-lignes-regulieres#conditions
 instructions: https://www.iledefrance-mobilites.fr/titres-et-tarifs/detail/carte-scolaire-bus-lignes-regulieres#conditions
+prefix: la
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-ile-de-france-ecoute-etudiants.yml
+++ b/data/benefits/javascript/region-ile-de-france-ecoute-etudiants.yml
@@ -12,6 +12,7 @@ profils:
     conditions: []
 link: https://www.iledefrance.fr/ecoute-etudiants-ile-de-france-plateforme-daide-pour-les-etudiants-en-souffrance
 teleservice: https://ecouteetudiants-iledefrance.fr/home
+prefix: l'
 type: float
 unit: séances
 periodicite: autre

--- a/data/benefits/javascript/region-ile-de-france-forfait-gratuite-jeunes-en-insertion.yml
+++ b/data/benefits/javascript/region-ile-de-france-forfait-gratuite-jeunes-en-insertion.yml
@@ -24,6 +24,7 @@ conditions_generales:
 profils: []
 link: https://www.iledefrance-mobilites.fr/titres-et-tarifs/detail/le-forfait-gratuite-jeunes-en-insertion
 instructions: https://www.iledefrance-mobilites.fr/titres-et-tarifs/detail/le-forfait-gratuite-jeunes-en-insertion
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-ile-de-france-forfait-navigo-jeunes-weekend.yml
+++ b/data/benefits/javascript/region-ile-de-france-forfait-navigo-jeunes-weekend.yml
@@ -22,6 +22,7 @@ conditions_generales:
 profils: []
 link: https://www.iledefrance-mobilites.fr/titres-et-tarifs/detail/navigo-jeunes-week-end#comment-l-obtenir
 instructions: https://www.iledefrance-mobilites.fr/titres-et-tarifs/detail/navigo-jeunes-week-end#comment-l-obtenir
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-ile-de-france-reduction-50-volontaires-du-service-civique.yml
+++ b/data/benefits/javascript/region-ile-de-france-reduction-50-volontaires-du-service-civique.yml
@@ -16,6 +16,7 @@ profils:
     conditions: []
 link: https://www.iledefrance-mobilites.fr/titres-et-tarifs/detail/reduction-50-pourcents-volontaires-service-civique
 instructions: https://www.iledefrance-mobilites.fr/titres-et-tarifs/detail/reduction-50-pourcents-volontaires-service-civique
+prefix: la
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-normandie-abonnement-tempo-26-ans.yml
+++ b/data/benefits/javascript/region-normandie-abonnement-tempo-26-ans.yml
@@ -21,6 +21,7 @@ profils: []
 link: https://www.ter.sncf.com/normandie/offres/tempo-nomad/abonnement-normandie-moins26
 teleservice: https://www.sncf-abo-annuel-ter.com/tapas-tel-web/devisAbonnement?codeRegion=NHO
 instructions: https://www.ter.sncf.com/normandie/offres/tempo-nomad/abonnement-normandie-moins26
+prefix: l'
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-normandie-atouts-normandie-aide-bafa-bafd-bnssa-1er-secours-et-chantiers-de-bénévoles.yml
+++ b/data/benefits/javascript/region-normandie-atouts-normandie-aide-bafa-bafd-bnssa-1er-secours-et-chantiers-de-bénévoles.yml
@@ -23,6 +23,7 @@ conditions_generales:
 profils: []
 link: https://atouts.normandie.fr/
 teleservice: https://atouts.normandie.fr/
+prefix: l'aide
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/region-normandie-pass-monde-etudes-secondaires.yml
+++ b/data/benefits/javascript/region-normandie-pass-monde-etudes-secondaires.yml
@@ -35,6 +35,7 @@ profils:
 link: https://www.normandie.fr/pass-monde-etudes-secondaires
 teleservice: https://atouts.normandie.fr/beneficiaires/Views/Accueil.aspx
 instructions: ""
+prefix: le
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-nouvelle-aquitaine-billet-jeunes-28ans.yml
+++ b/data/benefits/javascript/region-nouvelle-aquitaine-billet-jeunes-28ans.yml
@@ -18,6 +18,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/nouvelle-aquitaine/offres/cartes-abonnements/billet-jeunes-nouvelle-aquitaine
 instructions: https://www.ter.sncf.com/nouvelle-aquitaine/offres/cartes-abonnements/billet-jeunes-nouvelle-aquitaine
+prefix: l'aide
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-nouvelle-aquitaine-pass-abonne-28-ans.yml
+++ b/data/benefits/javascript/region-nouvelle-aquitaine-pass-abonne-28-ans.yml
@@ -18,6 +18,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/nouvelle-aquitaine/offres/cartes-abonnements/pass-abonne-moins-28
 teleservice: https://www.sncf-abo-annuel-ter.com/tapas-tel-web/?codeRegion=AQU
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-occitanie-aide-au-merite-pour-les-etudiants-en-formations-sanitaires-et-sociales.yml
+++ b/data/benefits/javascript/region-occitanie-aide-au-merite-pour-les-etudiants-en-formations-sanitaires-et-sociales.yml
@@ -20,6 +20,7 @@ profils:
       - type: boursier
 link: https://www.laregion.fr/Aide-au-merite
 teleservice: https://www.laregion.fr/Aide-au-merite
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-occitanie-financement-formations-sanitaires-sociales-niveaux-v-iv.yml
+++ b/data/benefits/javascript/region-occitanie-financement-formations-sanitaires-sociales-niveaux-v-iv.yml
@@ -27,6 +27,7 @@ profils:
 link: https://www.laregion.fr/Financement-des-formations-sanitaires-et-sociales-de-niveaux-V-et-IV
 form: ""
 instructions: https://www.laregion.fr/Financement-des-formations-sanitaires-et-sociales-de-niveaux-V-et-IV
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-occitanie-frequencio-jeunes.yml
+++ b/data/benefits/javascript/region-occitanie-frequencio-jeunes.yml
@@ -14,6 +14,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/occitanie/offres/tarifs-occitanie/frequent-jeunes
 instructions: https://cdn.ter.sncf.com/medias/PDF/occitanie/BROCHURE-FREQUENCIO-TOUT-PUBLIC_tcm76-136443_tcm76-200824.pdf
+prefix: l'aide
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-occitanie-libertio-jeunes.yml
+++ b/data/benefits/javascript/region-occitanie-libertio-jeunes.yml
@@ -12,6 +12,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/occitanie/offres/tarifs-occitanie/jeunes
 instructions: https://www.ter.sncf.com/occitanie/offres/tarifs-occitanie/jeunes
+prefix: l'aide
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-pays-de-la-loire-abonnement-tutti-26-illimite.yml
+++ b/data/benefits/javascript/region-pays-de-la-loire-abonnement-tutti-26-illimite.yml
@@ -17,6 +17,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/pays-de-la-loire/offres/tarifs-et-abonnements/je-voyage-beaucoup/forfait-tutti-illimite
 teleservice: https://www.sncf-abo-annuel-ter.com/tapas-tel-web/devisAbonnement.html
+prefix: l'
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-pays-de-la-loire-abonnement-tutti.yml
+++ b/data/benefits/javascript/region-pays-de-la-loire-abonnement-tutti.yml
@@ -18,6 +18,7 @@ profils: []
 link: https://www.ter.sncf.com/pays-de-la-loire/offres/tarifs-et-abonnements/je-voyage-beaucoup/forfait-tutti-illimite
 teleservice: https://www.sncf-abo-annuel-ter.com/tapas-tel-web/devisAbonnement.html
 instructions: ""
+prefix: l'
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-pays-de-la-loire-carte-mezzo-26-ans.yml
+++ b/data/benefits/javascript/region-pays-de-la-loire-carte-mezzo-26-ans.yml
@@ -15,6 +15,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/pays-de-la-loire/offres/tarifs-et-abonnements/je-voyage-un-peu/carte-mezzo/%5Btab%5Dlescartes
 instructions: https://www.ter.sncf.com/pays-de-la-loire/offres/tarifs-et-abonnements/je-voyage-un-peu/carte-mezzo/%5Btab%5Dlescartes
+prefix: la
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-pays-de-la-loire-carte-mezzo.yml
+++ b/data/benefits/javascript/region-pays-de-la-loire-carte-mezzo.yml
@@ -15,6 +15,7 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/pays-de-la-loire/offres/tarifs-et-abonnements/je-voyage-un-peu/carte-mezzo/%5Btab%5Dlescartes
 instructions: https://www.ter.sncf.com/pays-de-la-loire/offres/tarifs-et-abonnements/je-voyage-un-peu/carte-mezzo/%5Btab%5Dlescartes
+prefix: la
 type: bool
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/region-pays-de-la-loire-ehop-emploi.yml
+++ b/data/benefits/javascript/region-pays-de-la-loire-ehop-emploi.yml
@@ -1,4 +1,4 @@
-label: Éhop - Covoiturage Solidaire pour l'emploi
+label: Covoiturage Solidaire pour l'emploi - Éhop
 institution: region_pays_de_la_loire
 description: L'aide Éhop vous permet de trouver facilement un covoiturage pour
   vous rendre sur votre lieu de travail. Le service de mise en relation est
@@ -22,6 +22,7 @@ profils:
     conditions: []
 link: https://ehopcovoiturons-nous.fr/particuliers
 teleservice: https://m.ouestgo.fr/#/solidary-transport/home/request
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-carte-zou.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-carte-zou.yml
@@ -18,5 +18,6 @@ conditions_generales:
 profils: []
 link: https://www.ter.sncf.com/sud-provence-alpes-cote-d-azur/offres/cartes-abonnements/zou-50-75-26
 instructions: https://www.ter.sncf.com/sud-provence-alpes-cote-d-azur/offres/cartes-abonnements/zou-50-75-26
+prefix: la
 type: bool
 periodicite: autre

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-chequier-pass-sante-jeunes.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-chequier-pass-sante-jeunes.yml
@@ -25,6 +25,7 @@ link: https://www.maregionsud.fr/aides-et-appels-a-projets/detail/pass-sante-jeu
 teleservice: https://passantejeunes.maregionsud.fr/Account/LogOn?ReturnUrl=%2fAccount%2fLogOn%3fReturnUrl%3d%252fAccount%252fLogOn%253fReturnUrl%253d%25252f
 form: ""
 instructions: https://www.maregionsud.fr/aides-et-appels-a-projets/detail/pass-sante-jeunes
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-pass-mutuelles.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-pass-mutuelles.yml
@@ -15,6 +15,7 @@ conditions:
     href="https://www.maregionsud.fr/aides-et-appels-a-projets/detail/pass-mutuelles">un
     des 7 organismes</a> conventionnés par la Région.
 interestFlag: _interetAidesSanitaireSocial
+prefix: le
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-pass-zou-etudes.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-pass-zou-etudes.yml
@@ -28,6 +28,7 @@ profils:
 link: https://www.ter.sncf.com/sud-provence-alpes-cote-d-azur/offres/cartes-abonnements/pass-zou-etudes
 teleservice: https://services-zou.maregionsud.fr/fr/billetterie/action/8#zouetudes
 instructions: https://www.ter.sncf.com/sud-provence-alpes-cote-d-azur/offres/cartes-abonnements/pass-zou-etudes
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-prame-sanitaire-et-social.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-prame-sanitaire-et-social.yml
@@ -25,6 +25,7 @@ conditions_generales:
 profils: []
 link: https://www.maregionsud.fr/aides-et-appels-a-projets/detail/programme-regional-daide-a-la-mobilite-etudiante-prame-sanitaire-et-social-2021-2022
 teleservice: https://aidesformation.maregionsud.fr/
+prefix: le
 instructions: https://www.maregionsud.fr/aides-et-appels-a-projets/detail/programme-regional-daide-a-la-mobilite-etudiante-prame-sanitaire-et-social-2021-2022
 type: float
 unit: €

--- a/data/benefits/javascript/region_auvergne_rhone_alpes-bourse-du-secteur-santé-social.yml
+++ b/data/benefits/javascript/region_auvergne_rhone_alpes-bourse-du-secteur-santé-social.yml
@@ -18,6 +18,7 @@ profils:
     conditions: []
 link: https://www.auvergnerhonealpes.fr/aide/47/89-obtenir-une-bourse-pour-suivre-une-formation-dans-le-secteur-sante-social-orientation-formation.htm
 teleservice: https://rhone-alpes.commeunservice.com/bourses/jsp/nouveauContexte.action?codeAction=M42-ACCUEIL#FSS
+prefix: la
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/region_bourgogne_franche_comte-bourses-détudes-sanitaires-et-sociales.yml
+++ b/data/benefits/javascript/region_bourgogne_franche_comte-bourses-détudes-sanitaires-et-sociales.yml
@@ -21,6 +21,7 @@ profils:
 link: https://www.bourgognefranchecomte.fr/demande-de-bourse-sanitaire-et-sociale
 teleservice: https://ibssp.bourgognefranchecomte.fr/etudiant.php/compte/login
 instructions: https://www.bourgognefranchecomte.fr/demande-de-bourse-sanitaire-et-sociale
+prefix: les
 type: bool
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/region_bretagne-aide-au-premier-équipement-professionnel-des-lycéen-ne-s.yml
+++ b/data/benefits/javascript/region_bretagne-aide-au-premier-équipement-professionnel-des-lycéen-ne-s.yml
@@ -19,6 +19,7 @@ profils:
 link: https://www.bretagne.bzh/aides/fiches/premier-equipement-professionnel/
 teleservice: ""
 instructions: https://www.bretagne.bzh/aides/fiches/premier-equipement-professionnel/
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/region_bretagne-b-mouve-–-mobilité-des-formations-sanitaires-et-sociales.yml
+++ b/data/benefits/javascript/region_bretagne-b-mouve-–-mobilité-des-formations-sanitaires-et-sociales.yml
@@ -23,6 +23,7 @@ profils:
     conditions: []
 link: https://www.bretagne.bzh/aides/fiches/bmouve-bretagne-mobilite-ouverture-europe/
 teleservice: https://extranets.region-bretagne.fr/Portail-Aides/jsp/nouveauContexte.action?codeAction=M42-CONNEXION
+prefix: l'aide
 type: bool
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/region_bretagne-les-aides-prepa.yml
+++ b/data/benefits/javascript/region_bretagne-les-aides-prepa.yml
@@ -26,6 +26,7 @@ profils:
 link: https://www.bretagne.bzh/aides/?mot-clef=%22prepa%22&cloture=0&showall=0
 teleservice: https://aides.bretagne.bzh/account-management/crbr-demandeurs/ux/#/login?redirectTo=https:%2F%2Faides.bretagne.bzh%2Faides%2F%23%2Fcrbr%2Fconnecte%2Fdashboard%2Faccueil&jwtKey=jwt-crbr-portail-depot-demande-aides&footer=https:%2F%2Faides.bretagne.bzh%2Faides%2F%23%2Fcrbr%2Fmentions-legales,Mentions%20l%C3%A9gales,_self
 instructions: ""
+prefix: les
 type: bool
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/region_bretagne-qualif-sanitaire-et-social.yml
+++ b/data/benefits/javascript/region_bretagne-qualif-sanitaire-et-social.yml
@@ -18,6 +18,7 @@ profils:
 link: https://www.bretagne.bzh/aides/fiches/copie-de-qualif-sanitaire-et-social/
 teleservice: https://extranets.region-bretagne.fr/Portail-Aides/jsp/nouveauContexte.action?codeAction=M42-CONNEXION
 instructions: https://www.bretagne.bzh/aides/fiches/copie-de-qualif-sanitaire-et-social/
+prefix: la
 type: float
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/region_bretagne-éhop-covoiturage-solidaire-pour-lemploi.yml
+++ b/data/benefits/javascript/region_bretagne-éhop-covoiturage-solidaire-pour-lemploi.yml
@@ -1,4 +1,4 @@
-label: Éhop - Covoiturage Solidaire pour l'emploi
+label: Covoiturage Solidaire pour l'emploi - Éhop
 institution: region_bretagne
 description: L'aide Éhop vous permet de trouver facilement un covoiturage pour
   vous rendre sur votre lieu de travail. Le service de mise en relation est
@@ -22,6 +22,7 @@ profils:
     conditions: []
 link: https://ehopcovoiturons-nous.fr/particuliers
 teleservice: https://m.ouestgo.fr/#/solidary-transport/home/request
+prefix: le
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region_centre_val_de_loire-aides-pour-la-formation-sanitaire-et-social.yml
+++ b/data/benefits/javascript/region_centre_val_de_loire-aides-pour-la-formation-sanitaire-et-social.yml
@@ -18,6 +18,7 @@ profils:
 link: https://www.centre-valdeloire.fr/vivre/accompagner-la-formation/secteur-sanitaire-et-social/les-aides-pour-la-formation-sanitaire-et
 teleservice: https://www.aress.regioncentre-valdeloire.fr/basscep/
 instructions: https://www.centre-valdeloire.fr/vivre/accompagner-la-formation/secteur-sanitaire-et-social/les-aides-pour-la-formation-sanitaire-et
+prefix: les
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/region_corse-bourses-d’études-de-formations-sanitaires-et-sociales.yml
+++ b/data/benefits/javascript/region_corse-bourses-d’études-de-formations-sanitaires-et-sociales.yml
@@ -16,6 +16,7 @@ profils:
     conditions: []
 link: https://www.isula.corsica/Borse-di-studii-di-furmazione-sanitarie-e-suciale-Bourses-d-etudes-de-formations-sanitaires-et-sociales_a1541.html
 form: https://www.isula.corsica/attachment/1979793/
+prefix: les
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region_ile_de_france-aide-régionale-au-passage-du-diplôme-daccès-aux-études-universitaires-daeu.yml
+++ b/data/benefits/javascript/region_ile_de_france-aide-régionale-au-passage-du-diplôme-daccès-aux-études-universitaires-daeu.yml
@@ -18,6 +18,7 @@ profils:
 link: https://www.iledefrance.fr/aide-regionale-pour-le-diplome-dacces-aux-etudes-universitaires-daeu
 teleservice: https://mesdemarches.iledefrance.fr/account-management/cridfprd-demandeurs/ux/#/login?redirectTo=https:%2F%2Fmesdemarches.iledefrance.fr%2Faides%2F%23%2Fcridfprd%2Fconnecte%2Fdashboard%2Faccueil&jwtKey=jwt-cridfprd-portail-depot-demande-aides&footer=https:%2F%2Fmesdemarches.iledefrance.fr%2Faides%2F%23%2Fcridfprd%2Fmentions-legales,Mentions%20l%C3%A9gales%20et%20RGPD,_self
 instructions: ""
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
+++ b/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
@@ -21,6 +21,7 @@ profils:
 link: https://lycees.iledefrance.fr/dotation-budgetaire
 teleservice: ""
 instructions: https://lycees.iledefrance.fr/dotation-budgetaire
+prefix: l'
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/region_ile_de_france-aide-régionale-à-léquipement-individuel-dans-les-filières-pro-et-technologiques.yml
+++ b/data/benefits/javascript/region_ile_de_france-aide-régionale-à-léquipement-individuel-dans-les-filières-pro-et-technologiques.yml
@@ -24,6 +24,7 @@ profils:
           - bts_1
 link: https://lycees.iledefrance.fr/dotation-budgetaire
 instructions: https://lycees.iledefrance.fr/dotation-budgetaire
+prefix: l'
 type: bool
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/region_la_reunion-bourse-régionale-sanitaire-et-sociale.yml
+++ b/data/benefits/javascript/region_la_reunion-bourse-régionale-sanitaire-et-sociale.yml
@@ -20,6 +20,7 @@ profils:
 link: https://regionreunion.com/aides-services/article/bourse-regionale-sanitaire-et-socialebourse-ecole-de-gestion-et-de-commerce-de-la-reunion-egcr
 teleservice: https://connexion-demarches.cr-reunion.fr/accounts/register/
 instructions: https://regionreunion.com/aides-services/article/bourse-regionale-sanitaire-et-socialebourse-ecole-de-gestion-et-de-commerce-de-la-reunion-egcr
+prefix: la
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region_normandie-aides-aux-formations-paramédicales-sociales-ou-de-santé.yml
+++ b/data/benefits/javascript/region_normandie-aides-aux-formations-paramédicales-sociales-ou-de-santé.yml
@@ -17,6 +17,7 @@ profils:
 link: https://www.crous-normandie.fr/bourses/aides-paramedicales-sociales-de-sante/
 teleservice: https://www.messervices.etudiant.gouv.fr/envole/
 instructions: https://www.crous-normandie.fr/bourses/aides-paramedicales-sociales-de-sante/
+prefix: les
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region_normandie-atouts-normandie-avantages-loisirs.yml
+++ b/data/benefits/javascript/region_normandie-atouts-normandie-avantages-loisirs.yml
@@ -20,6 +20,7 @@ conditions_generales:
 profils: []
 link: https://www.normandie.fr/sites/default/files/2021-07/Flyer%20Loisirs%20Atouts%20Normandie.pdf
 teleservice: https://atouts.normandie.fr/
+prefix: l'aide
 type: float
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/region_normandie-pass-monde-etudes-supérieures-1.yml
+++ b/data/benefits/javascript/region_normandie-pass-monde-etudes-supérieures-1.yml
@@ -38,6 +38,7 @@ profils:
     conditions: []
 link: https://www.normandie.fr/pass-monde
 teleservice: https://atouts.normandie.fr/beneficiaires/Views/Accueil.aspx
+prefix: le
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region_normandie-pass-monde-volontariat.yml
+++ b/data/benefits/javascript/region_normandie-pass-monde-volontariat.yml
@@ -48,6 +48,7 @@ profils:
     conditions: []
 link: https://www.normandie.fr/pass-monde-volontariat
 teleservice: https://atouts.normandie.fr/beneficiaires/Views/Accueil.aspx
+prefix: le
 type: float
 unit: €
 periodicite: annuelle

--- a/data/benefits/javascript/region_nouvelle_aquitaine-bourses-pour-les-étudiants-en-formations-sociales-paramédicales-et-de-santé.yml
+++ b/data/benefits/javascript/region_nouvelle_aquitaine-bourses-pour-les-étudiants-en-formations-sociales-paramédicales-et-de-santé.yml
@@ -15,6 +15,7 @@ profils:
 link: https://les-aides.nouvelle-aquitaine.fr/amenagement-du-territoire/bourses-detudes-sur-criteres-sociaux-2022-etudiants-en-formations-sociales-paramedicales-et-de-sante?Profil=Apprenti____%C3%89tudiant____Jeune%20actif____Lyc%C3%A9en____Particulier&Jeunesse=Accompagnement%20scolaire____Apprentissage____%C3%89ducation%20et%20formation____Engagement%20et%20citoyennet%C3%A9____Enseignement%20sup%C3%A9rieur____Insertion%20professionnelle____Lyc%C3%A9es____Mobilit%C3%A9%20internationale____Orientation____Sanitaire%20et%20social&Type=Aides
 teleservice: https://mes-demarches.nouvelle-aquitaine.fr/craPortailFO/
 instructions: ""
+prefix: les
 type: bool
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region_nouvelle_aquitaine-chèque-livre.yml
+++ b/data/benefits/javascript/region_nouvelle_aquitaine-chèque-livre.yml
@@ -19,6 +19,7 @@ link: https://jeunes.nouvelle-aquitaine.fr/formation/accompagnement-scolaire/le-
 teleservice: https://www.mesdemarches.aidesrentree.fr/Beneficiaires/Views/Accueil.aspx
 form: ""
 instructions: ""
+prefix: le
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/region_occitanie-éco-chèque-mobilité-achat-d’une-voiture-électrique-ou-hybride-rechargeable-d’occasion.yml
+++ b/data/benefits/javascript/region_occitanie-éco-chèque-mobilité-achat-d’une-voiture-électrique-ou-hybride-rechargeable-d’occasion.yml
@@ -20,6 +20,7 @@ conditions_generales:
 profils: []
 link: https://www.laregion.fr/Eco-cheque-mobilite-voiture-electrique-ou-hybride
 teleservice: https://mesaidesenligne.laregion.fr/aides/#/croccitanie/connecte/F_DMP_E_CHEQ_VO/depot/simple
+prefix: l'
 type: float
 unit: €
 periodicite: autre

--- a/data/benefits/javascript/region_pays_de_la_loire-bourses-pour-les-élèves-et-étudiant-e-s-en-formation-sanitaire-et-sociale.yml
+++ b/data/benefits/javascript/region_pays_de_la_loire-bourses-pour-les-élèves-et-étudiant-e-s-en-formation-sanitaire-et-sociale.yml
@@ -15,6 +15,7 @@ profils:
     conditions: []
 link: https://www.paysdelaloire.fr/les-aides/bourses-regionales-pour-les-eleves-et-etudiants-en-formation-initiale-sociale-paramedicale-et-de?sous_thematique=215
 teleservice: https://maboursesanitaireetsociale.paysdelaloire.fr/Profil-public/public/paysdelaloire/bourse/accueil.do
+prefix: les
 type: bool
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/openfisca/apa_eligibilite.yml
+++ b/data/benefits/openfisca/apa_eligibilite.yml
@@ -16,6 +16,7 @@ link: >-
   https://www.pour-les-personnes-agees.gouv.fr/preserver-son-autonomie-s-informer-et-anticiper/perte-d-autonomie-evaluation-et-droits/lallocation-personnalisee-dautonomie-apa
 instructions: >-
   https://www.pour-les-personnes-agees.gouv.fr/preserver-son-autonomie-s-informer-et-anticiper/perte-d-autonomie-evaluation-et-droits/lallocation-personnalisee-dautonomie-apa#anchor5
+prefix: l'
 type: bool
 top: 6
 entity: individus

--- a/data/benefits/openfisca/hauts_de_france_aide_permis.yml
+++ b/data/benefits/openfisca/hauts_de_france_aide_permis.yml
@@ -6,6 +6,7 @@ conditions:
   - être en apprentissage, demandeur d'emploi, stagiaire ou dans un parcours contractualisé d’accompagnement vers l’emploi et l’autonomie (PACEA).
 link: https://www.hautsdefrance.fr/permis-de-conduire-aide-2/
 teleservice: https://www.hautsdefrance.fr/testez-votre-eligibilite-aide-au-permis-de-conduire/
+prefix: l'
 type: float
 unit: "€"
 interestFlag: _interetPermisDeConduire

--- a/data/benefits/openfisca/paris_forfait_familles.yml
+++ b/data/benefits/openfisca/paris_forfait_familles.yml
@@ -4,6 +4,7 @@ description: >
   Paris Forfait Familles est une aide destinée aux familles nombreuses avec au moins trois enfants à charge. Elle peut se cumuler avec l’Allocation de Soutien aux Parents d’Enfants Handicapés. L’aide est accordée pour une durée maximale d’un an. Elle peut être renouvelée en présentant un nouveau dossier.
 link: https://www.paris.fr/pages/simulateur-mes-aides-gouv-fr-pour-la-ville-de-paris-3626/#paris-forfait-familles
 form: https://cdn.paris.fr/paris/2019/07/24/8fa764ddcfa7659c447e2b383b8cb986.pdf
+prefix: l'aide
 type: float
 unit: "€"
 entity: familles

--- a/data/benefits/openfisca/paris_logement.yml
+++ b/data/benefits/openfisca/paris_logement.yml
@@ -7,6 +7,7 @@ conditions:
   - Ne toucher aucune autre prestation logement de la part de la mairie de Paris ou du département.
 link: https://www.paris.fr/pages/aides-au-logement-3827/#paris-logement
 form: https://cdn.paris.fr/paris/2020/01/13/9951415db06e3d73e54625d5972c7229.pdf
+prefix: l'aide
 type: float
 unit: "€"
 entity: familles

--- a/data/benefits/openfisca/paris_logement_familles.yml
+++ b/data/benefits/openfisca/paris_logement_familles.yml
@@ -7,6 +7,7 @@ conditions:
   - Ne toucher aucune autre prestation logement de la part de la mairie de Paris ou du département.
 link: https://www.paris.fr/pages/simulateur-mes-aides-gouv-fr-pour-la-ville-de-paris-3626/#paris-logement-familles
 form: https://cdn.paris.fr/paris/2019/07/24/736d309a8cdbf436475f7514f443a08b.pdf
+prefix: l'aide
 type: float
 unit: "€"
 entity: familles

--- a/data/benefits/openfisca/paris_logement_plfm.yml
+++ b/data/benefits/openfisca/paris_logement_plfm.yml
@@ -7,6 +7,7 @@ conditions:
   - Ne toucher aucune autre prestation logement de la part de la mairie de Paris ou du département.
 link: https://www.paris.fr/pages/simulateur-mes-aides-gouv-fr-pour-la-ville-de-paris-3626/#paris-logement-famille-monoparentale
 form: https://cdn.paris.fr/paris/2019/07/24/75686b9338b397db4b05069015762d8b.pdf
+prefix: l'aide
 type: float
 unit: "€"
 entity: familles

--- a/data/benefits/openfisca/paris_logement_psol.yml
+++ b/data/benefits/openfisca/paris_logement_psol.yml
@@ -7,6 +7,7 @@ conditions:
   - Ne pas avoir déjà bénéficié du dispositif sur une durée de deux ans.
 link: https://www.paris.fr/pages/simulateur-mes-aides-gouv-fr-pour-la-ville-de-paris-3626/#paris-solidarite
 form: https://cdn.paris.fr/paris/2019/07/24/44a441e89f01b513b678ecde6e088ce4.pdf
+prefix: l'aide
 type: float
 unit: "€"
 entity: familles

--- a/src/components/benefit-cta-link.vue
+++ b/src/components/benefit-cta-link.vue
@@ -50,7 +50,7 @@ export default {
       return typeLabels[this.type]
     },
     longLabel: function () {
-      return `${longLabels[this.type]} pour ${this.benefit.prefix}${
+      return `${longLabels[this.type]} pour ${this.benefit.prefix || ""}${
         this.benefit.prefix?.endsWith("’") ? "" : " "
       }${this.benefit.label}`
     },


### PR DESCRIPTION
Dans la visée ``accessibilité``, les aides sans ``prefix`` ne permettent pas d'avoir des phrases correctes dans le cas d'un lecteur d'écran sur les CTA par exemple

![Capture d’écran du 2022-06-01 12-18-12](https://user-images.githubusercontent.com/78914809/171418933-a43ccf3c-f07f-4b10-8b16-17cc9f635e3b.png)
