### PR TITLE
Ajoute un type d'aide à la liste de toutes les aides

### DIFF
--- a/data/benefits/javascript/collectivite-europeenne-alsace-fonds-aide-jeunes.yml
+++ b/data/benefits/javascript/collectivite-europeenne-alsace-fonds-aide-jeunes.yml
@@ -22,7 +22,7 @@ conditions_generales:
 profils: []
 link: https://www.haut-rhin.fr/content/des-aides-pour-les-jeunes
 instructions: https://www.haut-rhin.fr/content/des-aides-pour-les-jeunes
-prefix: l’
+prefix: les
 type: bool
 unit: €
 periodicite: ponctuelle

--- a/src/views/liste-aides.vue
+++ b/src/views/liste-aides.vue
@@ -38,10 +38,10 @@ const TYPES = {
   national: "Aides nationales",
   region: "Aides régionales",
   departement: "Aides départementales",
-  autre: "Collectivités territoriales",
   epci: "EPCI (Métropole, inter-communauté, etc.)",
   caf: "CAF Locales",
   commune: "Aides communales",
+  autre: "Autres aides",
 }
 
 export default {

--- a/src/views/liste-aides.vue
+++ b/src/views/liste-aides.vue
@@ -38,6 +38,7 @@ const TYPES = {
   national: "Aides nationales",
   region: "Aides régionales",
   departement: "Aides départementales",
+  autre: "Collectivités territoriales",
   epci: "EPCI (Métropole, inter-communauté, etc.)",
   caf: "CAF Locales",
   commune: "Aides communales",


### PR DESCRIPTION
Permet à l'aide de la ``Collectivité européenne d'Alsace`` d'être affichée sur la page listant toutes les aides

![Capture d’écran du 2022-06-02 13-40-40](https://user-images.githubusercontent.com/78914809/171622556-fb09564e-cffb-4999-aa98-41aad1b9f16f.png)


