### PR TITLE
Ajout d'un fichier de config dependabot pour créer des PR de maj de Mes Aides Vélos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     rebase-strategy: "disabled"
     versioning-strategy: increase
     open-pull-requests-limit: 1


### PR DESCRIPTION
## Description

Cette PR permet de checker les changements de version du package Mes Aides Vélos suite à l'issue #2748 en ouvrant une PR de mise à jour de version.

## Notes

**Cette config ne désactive pas les alertes dependabot de sécurité**

[Documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

| Configuration | Détails |
|:--------------|:--------|
|  `interval: "weekly"`  |  check de mise à jour une fois par semaine (le lundi) pour économiser des instances  |
|  `rebase-strategy: "disabled"`  |  pour éviter d'éventuel rebase à chaque mise à jour de `master`  ce qui déclencherait la CI |
|  `versioning-strategy: increase`  |  mise à jour vers la dernière version du package (sans distinction version mineure / majeure)  |
|  `open-pull-requests-limit: 1`  | si une nouvelle version du package Mes Aides Vélos est publiée alors qu'il y a déjà une PR d'ouverte, celle-ci ne sera pas fermée et une nouvelle PR ne sera pas ouverte  |