### PR TITLE
[FIX] corrige edge case de mise en cache de précédent version de npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,9 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
+      - name: Install specific NPM version
+        shell: bash
+        run: npm install -g npm@8.1.2
       - name: Cache Cypress installation
         uses: actions/cache@v2
         id: restore-cypress


### PR DESCRIPTION
## Détails

Lors de l'installation de cypress sur la CI, la version de npm utilisé peut faire apparaitre un conflit dans les packages (ce fix est la continuité du #2935 ; le conflit survient encore car il y a une mise en cache de l'installation de cypress)