### PR TITLE
config: ajout de dist-server à gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ node_modules
 
 # Compiled assets
 dist
+dist-server
 
 .project
 .sass-cache


### PR DESCRIPTION
## Détails

En anticipation des merges et éventuels besoin de revert de #2941 et #2909 le fichier `.gitignore` a été édité de manière à exclure le dossier `dist-server` qui sera ajouté par les 2 PR ci-dessus.