### PR TITLE
Intégration avec API tierce (accéder à une simulation pré-remplie & envoie du résultat de la simulation)

### DIFF
--- a/backend/models/followup.js
+++ b/backend/models/followup.js
@@ -12,7 +12,11 @@ const SurveySchema = new mongoose.Schema(
   {
     _oldId: { type: String },
     accessToken: { type: String },
-    createdAt: { type: Date, default: Date.now },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+      expires: parseInt(process.env.MONGODB_DOCUMENT_TTL_SECONDS) || undefined,
+    },
     messageId: { type: String },
     repliedAt: { type: Date },
     error: { type: Object },

--- a/backend/models/simulation.js
+++ b/backend/models/simulation.js
@@ -50,7 +50,11 @@ const SimulationSchema = new mongoose.Schema(
     },
     version: Number,
     abtesting: Object,
-    createdAt: { type: Date, default: Date.now },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+      expires: parseInt(process.env.MONGODB_DOCUMENT_TTL_SECONDS) || undefined,
+    },
     modifiedFrom: String,
     status: {
       type: String,
@@ -58,6 +62,7 @@ const SimulationSchema = new mongoose.Schema(
       enum: ["new", "test", "investigation"],
     },
     token: String,
+    thirdPartyData: Object,
   },
   { minimize: false }
 )

--- a/configure.ts
+++ b/configure.ts
@@ -5,14 +5,23 @@ const morgan = require("morgan")
 const Sentry = require("@sentry/node")
 
 module.exports = function (devServer) {
-  Sentry.init({
-    // Enable Sentry in production
-    // https://docs.sentry.io/development/sdk-dev/overview/#usage-for-end-users
-    dsn:
-      process.env.NODE_ENV === "production"
-        ? "https://b44fa037e37b4b9eb1a050675b253dce@sentry.incubateur.net/17"
-        : null,
-  })
+  if (process.env.ENABLE_SENTRY === "true") {
+    Sentry.init({
+      // Enable Sentry in production
+      // https://docs.sentry.io/development/sdk-dev/overview/#usage-for-end-users
+      dsn:
+        process.env.NODE_ENV === "production"
+          ? "https://b44fa037e37b4b9eb1a050675b253dce@sentry.incubateur.net/17"
+          : null,
+    })
+
+    // The request handler must be the first middleware on the app
+    devServer.app.use(Sentry.Handlers.requestHandler())
+
+    console.log("Sentry enabled")
+  } else {
+    console.log("Sentry disabled")
+  }
 
   // The request handler must be the first middleware on the app
   devServer.app.use(Sentry.Handlers.requestHandler())

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "mongodb": "^4.1.4",
         "mongoose": "^6.0.12",
         "morgan": "^1.10.0",
+        "mustache": "^4.2.0",
         "require-from-string": "^2.0.2",
         "sass": "^1.47.0",
         "sass-loader": "^12.4.0",
@@ -54,6 +55,7 @@
         "vue": "^3.2.32",
         "vue-matomo": "^4.1.0",
         "vue-router": "^4.0.14",
+        "vue3-cookies": "^1.0.6",
         "vuex": "^4.0.2",
         "webpack-dev-server": "^4.7.3"
       },
@@ -85,7 +87,6 @@
         "husky": "^7.0.4",
         "memory-fs": "^0.5.0",
         "minimist": "^1.2.6",
-        "mustache": "^4.2.0",
         "prettier": "^2.5.1",
         "pretty-quick": "^3.1.2",
         "typescript": "~4.1.5",
@@ -8088,20 +8089,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -18283,14 +18270,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -19332,7 +19311,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "dev": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -24345,90 +24323,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "node_modules/ts-jest": {
-      "version": "27.1.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.5.tgz",
-      "integrity": "sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "^27.0.0",
-        "json5": "2.x",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "7.x",
-        "yargs-parser": "20.x"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@types/jest": "^27.0.0",
-        "babel-jest": ">=27.0.0 <28",
-        "jest": "^27.0.0",
-        "typescript": ">=3.8 <5.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@types/jest": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-jest/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ts-jest/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/ts-loader": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
@@ -25421,6 +25315,14 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "node_modules/vue3-cookies": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vue3-cookies/-/vue3-cookies-1.0.6.tgz",
+      "integrity": "sha512-a1UvVD0qIgxyOqjlSOwnLnqAnz8ASltugEv8yX+96i/WGZAN9fEDci7xO4HIWZE1uToUnRq9JnFhvfDCSo45OA==",
+      "dependencies": {
+        "vue": "^3.0.0"
+      }
     },
     "node_modules/vuex": {
       "version": "4.0.2",
@@ -32881,17 +32783,6 @@
         "escalade": "^3.1.1",
         "node-releases": "^2.0.3",
         "picocolors": "^1.0.0"
-      }
-    },
-    "bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -40647,14 +40538,6 @@
         }
       }
     },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -41552,8 +41435,7 @@
     "mustache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "dev": true
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -45330,56 +45212,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "ts-jest": {
-      "version": "27.1.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.5.tgz",
-      "integrity": "sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "^27.0.0",
-        "json5": "2.x",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "7.x",
-        "yargs-parser": "20.x"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "ts-loader": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
@@ -46162,6 +45994,14 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue3-cookies": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vue3-cookies/-/vue3-cookies-1.0.6.tgz",
+      "integrity": "sha512-a1UvVD0qIgxyOqjlSOwnLnqAnz8ASltugEv8yX+96i/WGZAN9fEDci7xO4HIWZE1uToUnRq9JnFhvfDCSo45OA==",
+      "requires": {
+        "vue": "^3.0.0"
+      }
     },
     "vuex": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "minimist": "^1.2.6",
         "prettier": "^2.5.1",
         "pretty-quick": "^3.1.2",
+        "ts-jest": "^27.1.5",
         "typescript": "~4.1.5",
         "webpack": "^5.64.3",
         "webpack-bundle-analyzer": "^4.5.0"
@@ -8089,6 +8090,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -18270,6 +18283,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -24322,6 +24341,82 @@
       "dependencies": {
         "tslib": "^1.9.3"
       }
+    },
+    "node_modules/ts-jest": {
+      "version": "27.1.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.5.tgz",
+      "integrity": "sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^27.0.0",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@types/jest": "^27.0.0",
+        "babel-jest": ">=27.0.0 <28",
+        "jest": "^27.0.0",
+        "typescript": ">=3.8 <5.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/ts-loader": {
       "version": "6.2.2",
@@ -32785,6 +32880,15 @@
         "picocolors": "^1.0.0"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -40538,6 +40642,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -45210,6 +45320,48 @@
       "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
       "requires": {
         "tslib": "^1.9.3"
+      }
+    },
+    "ts-jest": {
+      "version": "27.1.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.5.tgz",
+      "integrity": "sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^27.0.0",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "ts-loader": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "minimist": "^1.2.6",
     "prettier": "^2.5.1",
     "pretty-quick": "^3.1.2",
+    "ts-jest": "^27.1.5",
     "typescript": "~4.1.5",
     "webpack": "^5.64.3",
     "webpack-bundle-analyzer": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "mongodb": "^4.1.4",
     "mongoose": "^6.0.12",
     "morgan": "^1.10.0",
+    "mustache": "^4.2.0",
     "require-from-string": "^2.0.2",
     "sass": "^1.47.0",
     "sass-loader": "^12.4.0",
@@ -81,6 +82,7 @@
     "vue": "^3.2.32",
     "vue-matomo": "^4.1.0",
     "vue-router": "^4.0.14",
+    "vue3-cookies": "^1.0.6",
     "vuex": "^4.0.2",
     "webpack-dev-server": "^4.7.3"
   },
@@ -112,7 +114,6 @@
     "husky": "^7.0.4",
     "memory-fs": "^0.5.0",
     "minimist": "^1.2.6",
-    "mustache": "^4.2.0",
     "prettier": "^2.5.1",
     "pretty-quick": "^3.1.2",
     "typescript": "~4.1.5",

--- a/src/components/summary.vue
+++ b/src/components/summary.vue
@@ -50,6 +50,15 @@
             }}</router-link
           >
           <BackButton v-else @click="goBack()">Retour</BackButton>
+
+          <button
+            v-if="showReturnUrl"
+            class="button aj-return-url"
+            @click="browseToReturnUrl()"
+          >
+            <i class="fa fa-share-square-o" aria-hidden="true"></i>
+            {{ returnUrl.label }}
+          </button>
         </div>
       </div>
     </div>
@@ -58,6 +67,7 @@
 
 <script>
 import BackButton from "@/components/buttons/back-button"
+import { redirect } from "@/lib/redirect"
 
 export default {
   name: "Summary",
@@ -79,6 +89,12 @@ export default {
         this.$route.name === "resultatsDetails"
       )
     },
+    showReturnUrl() {
+      return this.returnUrl && this.returnUrl.label && this.returnUrl.url
+    },
+    returnUrl() {
+      return this.$store.getters.thirdPartyData?.returnUrl
+    },
   },
   methods: {
     disabledLink(chapter, index) {
@@ -88,6 +104,9 @@ export default {
     },
     goBack() {
       window?.history.back()
+    },
+    browseToReturnUrl() {
+      redirect(this.returnUrl.url)
     },
   },
 }

--- a/src/lib/cookies.js
+++ b/src/lib/cookies.js
@@ -1,0 +1,3 @@
+export function setSituationCredentials($cookies, situationId, token) {
+  $cookies.set(`simulation_${situationId}`, token, "24h")
+}

--- a/src/lib/redirect.js
+++ b/src/lib/redirect.js
@@ -1,0 +1,8 @@
+export function redirect(url) {
+  if (window.self !== window.top) {
+    // We are in an iframe
+    window.parent.location.href = url
+  } else {
+    window.location.href = url
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import StateService from "./plugins/state-service"
 import * as Sentry from "@sentry/vue"
 // @ts-ignore
 import VueMatomo from "vue-matomo"
+import VueCookies from "vue3-cookies"
 
 import "template.data.gouv.fr/dist/main.css"
 import "font-awesome/scss/font-awesome.scss"
@@ -38,7 +39,10 @@ app.directive("analytics", AnalyticsDirective)
 app.directive("mail", MailDirective)
 app.directive("selectOnClick", SelectOnClickDirective)
 
-if (process.env.NODE_ENV === "production") {
+if (
+  process.env.ENABLE_SENTRY === "true" &&
+  process.env.NODE_ENV === "production"
+) {
   Sentry.init({
     app,
     dsn: "https://77f2520f2558451c80b1b95131135bcd@sentry.incubateur.net/18",
@@ -47,13 +51,16 @@ if (process.env.NODE_ENV === "production") {
 
 app.use(Resizer)
 app.use(StateService)
+app.use(VueCookies)
 
-app.use(VueMatomo, {
-  host: "https://stats.data.gouv.fr",
-  trackerFileName: "piwik",
-  siteId: process.env.VUE_APP_MATOMO_ID,
-  router: router,
-})
+if (process.env.ENABLE_PIWIK === "true") {
+  app.use(VueMatomo, {
+    host: "https://stats.data.gouv.fr",
+    trackerFileName: "piwik",
+    siteId: process.env.VUE_APP_MATOMO_ID,
+    router: router,
+  })
+}
 
 app.config.globalProperties.$filters = {
   capitalize(value: string) {

--- a/src/store.js
+++ b/src/store.js
@@ -249,6 +249,9 @@ const store = createStore({
     situation: (state) => {
       return generateSituation(state.simulation, true)
     },
+    thirdPartyData: function (state) {
+      return state.simulation?.thirdPartyData
+    },
   },
   mutations: {
     answer: (state, answer) => {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -76,6 +76,7 @@ $screen-smaller-than-mobile: 399px;
   @import "partials/mobile/home";
   @import "partials/mobile/simulation";
   @import "partials/mobile/resultats";
+  @import "partials/mobile/recapitulatif";
 }
 
 /* UTILS */

--- a/src/styles/partials/desktop/_recapitulatif.scss
+++ b/src/styles/partials/desktop/_recapitulatif.scss
@@ -55,4 +55,14 @@
       border: 1px solid var(--light-grey);
     }
   }
+
+  .aj-actions {
+    & > div {
+      display: flex;
+    }
+
+    .third-party-button {
+      display: none;
+    }
+  }
 }

--- a/src/styles/partials/desktop/_summary.scss
+++ b/src/styles/partials/desktop/_summary.scss
@@ -142,10 +142,12 @@ html {
 
         .aj-btn-container {
           display: flex;
+          flex-direction: column;
+          gap: 8px;
           width: 100%;
-          justify-content: center;
           margin-top: 46px;
           .button {
+            width: 100%;
             padding: 10px 32px;
           }
         }

--- a/src/styles/partials/desktop/_ui-kit.scss
+++ b/src/styles/partials/desktop/_ui-kit.scss
@@ -304,6 +304,7 @@ html {
           background-color: var(--white);
           padding: 50px;
           border-radius: var(--theme-border-radius);
+          text-align: center;
         }
       }
     }

--- a/src/styles/partials/mobile/_recapitulatif.scss
+++ b/src/styles/partials/mobile/_recapitulatif.scss
@@ -1,0 +1,14 @@
+.recapitulatif {
+  .aj-actions {
+    flex-direction: column;
+    gap: 16px;
+
+    & > div {
+      justify-content: space-between;
+    }
+
+    .third-party-button {
+      display: block;
+    }
+  }
+}

--- a/src/styles/partials/mobile/_ui-kit.scss
+++ b/src/styles/partials/mobile/_ui-kit.scss
@@ -44,6 +44,7 @@ html {
       .aj-loading-modal {
         .aj-loading-modal-content {
           margin: 0 1rem;
+          text-align: center;
         }
       }
 

--- a/src/styles/partials/tablet/_recapitulatif.scss
+++ b/src/styles/partials/tablet/_recapitulatif.scss
@@ -12,4 +12,15 @@
       }
     }
   }
+
+  .aj-actions {
+    .next-button {
+      margin-left: 8px !important;
+    }
+
+    .third-party-button {
+      display: block;
+      margin-left: 8px;
+    }
+  }
 }

--- a/src/views/home.vue
+++ b/src/views/home.vue
@@ -15,25 +15,43 @@
             leur charge.</div
           >
           <div class="aj-home-hero-buttons-wrapper">
-            <button
-              v-if="hasExistingSituation"
-              v-analytics="{
-                action: 'Reprendre ma simulation',
-                category: 'Home',
-              }"
-              :class="`button ${ctaSize} secondary`"
-              @click="next()"
-            >
-              Reprendre ma simulation
-            </button>
-            <button
-              v-analytics="{ action: ctaLabel, category: 'Home' }"
-              :class="`button ${ctaSize} primary`"
-              data-testid="new-simulation"
-              @click="newSituation()"
-            >
-              {{ ctaLabel }}
-            </button>
+            <template v-if="hasSituationCredentials">
+              <button
+                :class="`button ${ctaSize} secondary`"
+                @click="startPrefilledSimulation()"
+              >
+                Accéder à ma simulation pré-remplie
+              </button>
+
+              <button
+                v-if="returnUrl"
+                :class="`button ${ctaSize} secondary`"
+                @click="browseToReturnUrl()"
+              >
+                {{ returnUrl.label }}
+              </button>
+            </template>
+            <template v-else>
+              <button
+                v-if="hasExistingSituation"
+                v-analytics="{
+                  action: 'Reprendre ma simulation',
+                  category: 'Home',
+                }"
+                :class="`button ${ctaSize} secondary`"
+                @click="next()"
+              >
+                Reprendre ma simulation
+              </button>
+              <button
+                v-analytics="{ action: ctaLabel, category: 'Home' }"
+                :class="`button ${ctaSize} primary`"
+                data-testid="new-simulation"
+                @click="newSituation()"
+              >
+                {{ ctaLabel }}
+              </button>
+            </template>
           </div>
         </div>
       </div>
@@ -47,11 +65,32 @@
 </template>
 
 <script>
+import { setSituationCredentials } from "@/lib/cookies"
+import { redirect } from "@/lib/redirect"
+
 export default {
   name: "Home",
+  mounted: function () {
+    if (this.hasSituationCredentials) {
+      setSituationCredentials(
+        this.$cookies,
+        this.$route.query.situationId,
+        this.$route.query.token
+      )
+
+      this.$store.dispatch("fetch", this.$route.query.situationId)
+    }
+  },
   computed: {
     hasExistingSituation: function () {
       return this.$store.getters.passSanityCheck
+    },
+    hasSituationCredentials: function () {
+      return (
+        this.$route.query &&
+        this.$route.query.situationId &&
+        this.$route.query.token
+      )
     },
     ctaLabel: function () {
       return this.hasExistingSituation
@@ -66,16 +105,25 @@ export default {
         ? process.env.VUE_APP_BENEFIT_COUNT
         : "plus de 400"
     },
+    returnUrl() {
+      return this.$store.getters.thirdPartyData?.returnUrl
+    },
   },
   methods: {
     newSituation: function () {
       this.$store.dispatch("clear", this.$route.query.external_id)
       this.next()
     },
+    startPrefilledSimulation: function () {
+      this.next()
+    },
     next: function () {
       this.$store.dispatch("openFiscaParameters")
       this.$store.dispatch("verifyBenefitVariables")
       this.$push()
+    },
+    browseToReturnUrl() {
+      redirect(this.returnUrl.url)
     },
   },
 }

--- a/src/views/simulation/recapitulatif.vue
+++ b/src/views/simulation/recapitulatif.vue
@@ -42,13 +42,26 @@
       </template>
     </div>
     <div class="aj-actions">
-      <BackButton @click="goBack"></BackButton>
-      <router-link
-        v-if="showResultButton"
-        class="button next-button"
-        to="/simulation/resultats"
-        >Accéder aux résultats</router-link
+      <div>
+        <BackButton @click="goBack"></BackButton>
+
+        <router-link
+          v-if="showResultButton"
+          class="button next-button"
+          to="/simulation/resultats"
+        >
+          Accéder aux résultats
+        </router-link>
+      </div>
+
+      <button
+        v-if="showReturnUrl"
+        class="button third-party-button"
+        @click="browseToReturnUrl()"
       >
+        <i class="fa fa-share-square-o" aria-hidden="true"></i>
+        {{ returnUrl.label }}
+      </button>
     </div>
   </div>
 </template>
@@ -65,6 +78,7 @@ import BackButton from "@/components/buttons/back-button"
 import { getStepAnswer } from "../../../lib/answers"
 import ProgressMixin from "@/mixins/progress-mixin"
 import { useIndividu } from "@/composables/individu.ts"
+import { redirect } from "@/lib/redirect"
 
 export default {
   name: "Recapitulatif",
@@ -109,6 +123,12 @@ export default {
         this.progress === 1 &&
         this.$router.options.history.state.back !== "/simulation/resultats"
       )
+    },
+    showReturnUrl() {
+      return this.returnUrl && this.returnUrl.label && this.returnUrl.url
+    },
+    returnUrl() {
+      return this.$store.getters.thirdPartyData?.returnUrl
     },
   },
   methods: {
@@ -161,6 +181,10 @@ export default {
 
     stepPerChapter(chapterName) {
       return this.activeJourney.filter((step) => step.chapter === chapterName)
+    },
+
+    browseToReturnUrl() {
+      redirect(this.returnUrl.url)
     },
   },
 }

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -87,6 +87,7 @@ import ResultatsMixin from "@/mixins/resultats"
 import StatisticsMixin from "@/mixins/statistics"
 import WarningMessage from "@/components/warning-message"
 import Recapitulatif from "./recapitulatif"
+import { setSituationCredentials } from "@/lib/cookies"
 
 export default {
   name: "SimulationResultats",
@@ -109,6 +110,13 @@ export default {
       return
     } else if (this.$route.query?.situationId) {
       if (this.$store.state.situationId !== this.$route.query.situationId) {
+        if (this.hasSituationCredentials) {
+          setSituationCredentials(
+            this.$cookies,
+            this.$route.query.situationId,
+            this.$route.query.token
+          )
+        }
         this.$store
           .dispatch("fetch", this.$route.query.situationId)
           .then(() => {
@@ -164,6 +172,15 @@ export default {
   methods: {
     isEmpty: function (array) {
       return !array || array.length === 0
+    },
+  },
+  computed: {
+    hasSituationCredentials: function () {
+      return (
+        this.$route.query &&
+        this.$route.query.situationId &&
+        this.$route.query.token
+      )
     },
   },
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -32,6 +32,8 @@ process.env.VUE_APP_STATS_VERSION = statistics?.version ? statistics.version : 2
 process.env.VUE_APP_NETLIFY_PR = process.env.BRANCH
 process.env.VUE_APP_TITLE = `Évaluez vos droits aux aides avec le simulateur de ${process.env.VUE_APP_CONTEXT_NAME}`
 process.env.VUE_APP_DESCRIPTION = `7 minutes suffisent pour évaluer vos droits à ${process.env.VUE_APP_BENEFIT_COUNT} aides avec le simulateur de ${process.env.VUE_APP_CONTEXT_NAME}.`
+process.env.ENABLE_SENTRY = "true"
+process.env.ENABLE_PIWIK = "true"
 
 module.exports = {
   configureWebpack: (config) => {


### PR DESCRIPTION
# Description

Cette évolution permet à une application tierce
- De pré-remplir un formulaire
- De récupérer le résultat de la simulation openfisca.

# Comment ça fonctionne ?

## Étape 1 : L'application tierce envoie un payload vers 1J1S
```
POST https://BASE_URL/api/simulation
{
    ...payloadStandard,

    thirdPartyData: {
        returnUrl: {
            url: "https://example.com",
            label: "Texte qui apparaît dans le nouveau bouton de redirection"
        },
        resultsUrl: "https://api.example.com/result"
    }
}
```

- Les propriétés `url` et `label` sont utilisées pour créer un bouton de redirection dans le front
- Lorsqu'un utilisateur termine sa simulation et que l'on reçoit le resultat d'openfisca, l'url `resultsUrl` est appelé avec la méthode `POST` contenant dans son body le payload d'entrée et la réponse d'openfisca.
  - La variable d’environnement `RESULT_URL_API_KEY` permet de spécifier un token qui sera ajouté dans le header `Authorization` comme suit `Authorization: Bearer ${RESULT_URL_API_KEY}`
- Le bloc `thirdPartyData` est optionnel. S'il n'est pas présent, il n'y a aucun changement de comportement.

## Étape 2 : Rediriger l'utilisateur sur le formulaire prérempli

Rediriger l'utilisateur vers `https://BASE_URL?situationId=<id de la situation>&token=<token de la situation>&iframe`