### PR TITLE
[FIX] Arrondir le résultat des résultats de simulation sur l'outil d'accompagnement / le bot

### DIFF
--- a/backend/lib/mattermost-bot/poll-result.js
+++ b/backend/lib/mattermost-bot/poll-result.js
@@ -44,7 +44,7 @@ function postPollResult(simulation, answers) {
         process.env.MES_AIDES_ROOT_URL
       }/aides/${key.id}) ${
         key.unit && typeof key.amount === "number"
-          ? `**${key.amount}${key.unit}**`
+          ? `**${Math.round(key.amount * 100) / 100}${key.unit}**`
           : ""
       } ${key.comments?.length > 0 ? `*(${key.comments})*` : ""}`
     )

--- a/src/views/accompagnement/liste.vue
+++ b/src/views/accompagnement/liste.vue
@@ -102,7 +102,8 @@
                 >{{ benefitsMap[answer.id]?.label || answer.id }}</a
               >
               <b v-if="answer.unit && typeof answer.amount === `number`"
-                >({{ answer.amount }}{{ answer.unit }})</b
+                >({{ Math.round(answer.amount * 100) / 100
+                }}{{ answer.unit }})</b
               >
               <div v-if="answer.comments">{{ answer.comments }}</div>
             </li>


### PR DESCRIPTION
## Détails

[Tâche Trello](https://trello.com/c/eComZhLc/833-arrondir-le-r%C3%A9sultat-des-r%C3%A9sultats-de-simulation-sur-loutil-daccompagnement-le-bot)

## Notes

L'utilisation de `Math.round(amount * 100) / 100` ne permet pas d'avoir un arrondi viable (par exemple `15.509` sera arrondi en `15.50`).

Plusieurs alternatives existent mais rajoutent de mon point de vue trop de complexité par rapport à notre besoin sur un outil interne : 
- `parseFloat(amount).toFixed(2)` : le problème est que cela transformerait les entier en float (`2` deviendrait `2.00`). Cumulable avec une condition type `% 1` pour déterminer si on arrondi ou pas mais ça deviendrait compliqué
- utiliser `e+2` et `e-2` mais c'est particulièrement hacky et pas clair : 
```javascript
`${Math.round(`${amount}e+2`)}e-2}`
```