### PR TITLE
Suppression du lien d'instruction pour BAFA général

### DIFF
--- a/data/benefits/javascript/aide-au-bafa-pour-une-session-dapprofondissement-ou-de-qualification-caf-de-la-haute-savoie.yml
+++ b/data/benefits/javascript/aide-au-bafa-pour-une-session-dapprofondissement-ou-de-qualification-caf-de-la-haute-savoie.yml
@@ -3,9 +3,8 @@ institution: caf_haute_savoie
 description:
   L'aide au BAFA pour une session de formation générale est une aide locale mise
   à disposition par la CAF de la Haute-Savoie pour vous aider à financer votre
-  session en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la CAF</a>.<br><br>Pour bénéficier de cette aide, contactez directement la CAF
+  session en complément de l'aide
+  nationale apportée par la caf.<br><br>Pour bénéficier de cette aide, contactez directement la CAF
   de la Haute-Savoie pour connaître les démarches à suivre.
 conditions:
   - Avoir commencé une formation pour obtenir le brevet d’aptitude à la fonction d’animateur de centre de vacances et de loisirs (BAFA).

--- a/data/benefits/javascript/aide-au-bafa-pour-une-session-de-formation-générale-caf-de-la-haute-savoie.yml
+++ b/data/benefits/javascript/aide-au-bafa-pour-une-session-de-formation-générale-caf-de-la-haute-savoie.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_haute_savoie
 description: L'aide au BAFA pour une session de formation générale est une aide
   locale mise à disposition par la CAF de la Haute-Savoie pour vous aider à
-  financer votre session en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la CAF</a>.  <br> <br> Pour bénéficier de cette aide,
+  financer votre session en complément de  l'aide
+  nationale apportée par la caf.  <br> <br> Pour bénéficier de cette aide,
   contactez directement la CAF de la Haute-Savoie pour connaître les démarches à
   suivre.
 conditions: []

--- a/data/benefits/javascript/caf-ain-aide-bafa-session-approfondissement-qualification.yml
+++ b/data/benefits/javascript/caf-ain-aide-bafa-session-approfondissement-qualification.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d’approfondissement ou de qu
 institution: caf_ain
 description: L'aide au BAFA pour une session d'approfondissement ou de
   qualification est une aide locale mise à disposition par la CAF de l'Ain pour
-  vous aider à financer votre session en complément de  <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la CAF</a>.<br><br>
+  vous aider à financer votre session en complément de  l'aide
+  nationale apportée par la caf.
 conditions:
   - Avoir commencé une formation pour obtenir le brevet d’aptitude à la fonction
     d’animateur de centre de vacances et de loisirs (BAFA).

--- a/data/benefits/javascript/caf-ain-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-ain-aide-bafa-session-generale.yml
@@ -2,9 +2,8 @@ label: aide locale au BAFA pour une session de formation générale
 institution: caf_ain
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de l'Ain pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="l'aide nationale de la CAF - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale de la CAF</a>.<br><br>
+  complément de l'aide
+  nationale apportée par la caf.
 link: https://www.caf.fr/allocataires/caf-de-l-ain/offre-de-service/enfance-et-jeunesse/le-bafa
 form: https://www.caf.fr/sites/default/files/caf/011/Images/Offres%20de%20service/Logement/2021/ANNEXE%204.1%20_BAFA_session%20de%20form%20g%C3%A9n%C3%A9rale%20RIAS%202021.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-l-ain/offre-de-service/enfance-et-jeunesse/le-bafa

--- a/data/benefits/javascript/caf-allier-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-allier-aide-bafa-session-generale.yml
@@ -3,9 +3,8 @@ institution: caf_allier
 description: >
   L'aide au BAFA pour une session de formation générale est une aide locale mise
   à disposition par la CAF de l'Allier pour vous aider à financer votre session
-  en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la CAF</a>.
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire de la CAF.
 conditions_generales:

--- a/data/benefits/javascript/caf-alpes-maritimes-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-alpes-maritimes-aide-bafa-approfondissement.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_alpes_maritimes
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Alpes-Maritimes pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions_generales:
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-alpes-maritimes-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-alpes-maritimes-aide-bafa-generale.yml
@@ -3,10 +3,8 @@ institution: caf_alpes_maritimes
 description: >
   L'aide à la formation du BAFA est une aide locale mise à disposition par la
   CAF des Alpes-Maritimes pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre"
-  rel="noopener"href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 link: https://www.caf.fr/allocataires/caf-des-alpes-maritimes/offre-de-service/enfance-et-jeunesse/le-financement-du-bafa
 form: https://www.caf.fr/sites/default/files/caf/061/Documents/OFFRESCE/ENFANCEJEUNESSE/2021/Demande%20bourse%20BAFA_200421.pdf
 instructions: https://www.caf.fr/allocataires/caf-des-alpes-maritimes/offre-de-service/enfance-et-jeunesse/le-financement-du-bafa

--- a/data/benefits/javascript/caf-ardeche-aide-bafa.yml
+++ b/data/benefits/javascript/caf-ardeche-aide-bafa.yml
@@ -1,10 +1,8 @@
 label: aide au BAFA pour une session de formation d'approfondissement ou de qualification
 institution: caf_ardeche
 description: La CAF de l'Ardèche peut financer une partie de la session
-  d'approfondissement au BAFA. Cette aide n'est pas cumulable avec <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la CAF</a>.
+  d'approfondissement au BAFA. Cette aide n'est pas cumulable avec l'aide
+  nationale apportée par la caf.
 conditions:
   - Avoir déjà suivi la session de formation générale au BAFA.
   - Avoir déjà effectué le stage pratique d'animation.

--- a/data/benefits/javascript/caf-ardennes-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-ardennes-aide-bafa-approfondissement.yml
@@ -3,10 +3,8 @@ institution: caf_ardennes
 description: >
   L'aide à la formation du BAFA est une aide locale mise à disposition par la
   CAF des Ardennes pour vous aider à financer votre session d’approfondissement
-  ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre rattaché au régime général de la Sécurité Sociale.
   - Engager votre formation avec un organisme ayant son siège ou une antenne

--- a/data/benefits/javascript/caf-ardennes-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-ardennes-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_ardennes
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Ardennes pour vous aider à financer votre session
-  en complément de l’aide nationale  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  en complément de l’aide nationale l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre rattaché au régime général de la sécurité sociale.
   - Engager votre formation avec un organisme ayant son siège ou une antenne

--- a/data/benefits/javascript/caf-aube-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-aube-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_aube
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de l'Aube pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de ses parents.
   - Avoir effectué, après la session théorique de 8 jours, le stage pratique

--- a/data/benefits/javascript/caf-aube-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-aube-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_aube
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de l'Aube pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de ses parents.
   - Avoir effectué, après la session théorique de 8 jours, le stage pratique

--- a/data/benefits/javascript/caf-aveyron-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-aveyron-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_aveyron
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de l'Aveyron pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Effectuer votre stage auprès d’un organisme habilité.
   - "Avoir suivi les 3 sessions de formation : base, pratique, perfectionnement."

--- a/data/benefits/javascript/caf-bas-rhin-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-bas-rhin-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_bas_rhin
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Bas-Rhin pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions: []
 conditions_generales:
   - type: age

--- a/data/benefits/javascript/caf-bas-rhin-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-bas-rhin-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_bas_rhin
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Bas-Rhin pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Effectuer votre stage de formation de base dans l'un des organismes de
     formation habilités par les services de la Jeunesse et des Sports.

--- a/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_bouches_du_rhone
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Bouches du Rhône pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Effectuer votre stage en France.
   - Être à la charge de vos parents bénéficiaires de prestations familiales pour

--- a/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_bouches_du_rhone
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Bouches-du-Rhône pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Effectuer votre stage en France.
   - Être à la charge de vos parents bénéficiaires de prestations familiales pour

--- a/data/benefits/javascript/caf-calvados-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-calvados-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_calvados
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Calvados pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.
   - Etre stagiaire ou bénéficiaire de l'aide au logement au moment du stage.

--- a/data/benefits/javascript/caf-calvados-aide-bafa-générale.yml
+++ b/data/benefits/javascript/caf-calvados-aide-bafa-générale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_calvados
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Calvados pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.
   - Etre stagiaire ou bénéficiaire de l'aide au logement au moment du stage.

--- a/data/benefits/javascript/caf-charente-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-charente-aide-bafa-generale.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_charente
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Charente pour vous aider à financer votre session
-  en complément de <a target="_blank"
-  rel="noopener title="l'aide nationale de la Caf - Nouvelle fenêtre"
-  "href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale de la Caf</a>.<br><br>
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Effectuer la session de formation auprès d’un <a
     target="_blank" title="Etablissements conventionnés - Nouvelle fenêtre" rel="noopener"href="https://www.caf.fr/sites/default/files/caf/171/Documents/Offre%20de%20service/Bafa_Bafd/Organismes_conv_fevrier2020.pdf">établissement

--- a/data/benefits/javascript/caf-charente-maritime-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-charente-maritime-aide-bafa-approfondissement.yml
@@ -3,9 +3,8 @@ institution: caf_charente_maritime
 description: L'aide au BAFA pour une session d'approfondissement ou de
   qualification est une aide locale mise à disposition par la CAF de la
   Charente-Maritime pour vous aider à financer votre session en complément
-  de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de ses parents.
   - Effectuer la session de formation auprès d’un <a target="_blank"

--- a/data/benefits/javascript/caf-charente-maritime-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-charente-maritime-aide-bafa-generale.yml
@@ -3,9 +3,8 @@ institution: caf_charente_maritime
 description: >
   L'aide au BAFA pour une session de formation générale est une aide locale mise
   à disposition par la CAF de la Charente-Maritime pour vous aider à financer
-  votre session en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.
   - Effectuer la session de formation auprès d’un <a target="_blank"

--- a/data/benefits/javascript/caf-correze-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-correze-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_correze
 description: L'aide au BAFA pour une session de formation générale est une aide
   locale mise à disposition par la CAF de la Corrèze pour vous aider à financer
-  votre session en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.<br><br>
+  votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de ses parents.
   - >-

--- a/data/benefits/javascript/caf-corse-du-sud-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-corse-du-sud-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_corse_du_sud
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Corse du Sud pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents, ou bien être sans emploi.
   - Remplir les conditions d'attribution de l'aide légale de la CNAF.

--- a/data/benefits/javascript/caf-cotes-armor-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-cotes-armor-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_cotes_armor
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Côtes d'Armor pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.
   - Percevoir une prestation légale de la CAF des Côtes d’Armor.

--- a/data/benefits/javascript/caf-creuse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-creuse-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_creuse
 description: L'aide au BAFA pour une session générale est une aide locale mise à
   disposition par la CAF de la Creuse pour vous aider à financer votre session
-  en complément de <a target="_blank"
-  rel="noopener title="Voir l'aide nationale - Nouvelle fenêtre" "href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.
   - Effectuer la session de formation auprès d’un <a target="_blank"

--- a/data/benefits/javascript/caf-deux-sevres-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-deux-sevres-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_deux_sevres
 description: L'aide au BAFA pour une session de formation générale est une aide
   locale mise à disposition par la CAF des Deux-Sèvres pour vous aider à
-  financer votre session en complément de  <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre" href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  financer votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de ses parents en
     Deux-Sèvres.

--- a/data/benefits/javascript/caf-doubs-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-doubs-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_doubs
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Doubs pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions: []
 conditions_generales:
   - type: age

--- a/data/benefits/javascript/caf-doubs-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-doubs-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_doubs
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Doubs pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions: []
 conditions_generales:
   - type: age

--- a/data/benefits/javascript/caf-drome-aide-bafa-session-approfondissement-qualification.yml
+++ b/data/benefits/javascript/caf-drome-aide-bafa-session-approfondissement-qualification.yml
@@ -3,9 +3,8 @@ institution: caf_drome
 description: >
   L'aide au BAFA pour une session d'approfondissement ou de qualification est
   une aide locale mise à disposition par la CAF de la Drôme pour vous aider à
-  financer votre session en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la CAF</a>.
+  financer votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Avoir commencé une formation pour obtenir le brevet d’aptitude à la fonction
     d’animateur de centre de vacances et de loisirs (BAFA).

--- a/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
@@ -3,9 +3,8 @@ institution: caf_drome
 description: >
   L'aide au BAFA pour une session de formation générale est une aide locale mise
   à disposition par la CAF de la Drôme pour vous aider à financer votre session
-  en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la CAF</a>.
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire de la Caf de la Drôme au moment du stage (ou enfant d'un
     allocataire drômois).

--- a/data/benefits/javascript/caf-eure-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-eure-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_eure
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de l'Eure pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.
   - Dépendre du régime général de la sécurité sociale.

--- a/data/benefits/javascript/caf-eure-et-loir-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-eure-et-loir-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_eure_et_loir
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de l'Eure-et-Loir pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions: []
 conditions_generales:
   - type: age

--- a/data/benefits/javascript/caf-guyane-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-guyane-aide-bafa-approfondissement.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session d'approfondissement
 institution: caf_guyane
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Guyane pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Le délai entre la 1ère et la dernière session ne peut être supérieur à 18
     mois.

--- a/data/benefits/javascript/caf-haute-loire-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-haute-loire-aide-bafa-approfondissement.yml
@@ -1,10 +1,8 @@
 label: aide au BAFA pour une session d’approfondissement ou de qualification
 institution: caf_haute_loire
 description: L'aide au BAFA pour une session d'approfondissement ou de
-  qualification est une aide locale mise à disposition par la CAF de la Haute-Loire pour vous aider à financer votre session en complément de  <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la CAF</a>.<br><br>
+  qualification est une aide locale mise à disposition par la CAF de la Haute-Loire pour vous aider à financer votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Avoir commencé une formation pour obtenir le brevet d’aptitude à la fonction
     d’animateur de centre de vacances et de loisirs (BAFA).

--- a/data/benefits/javascript/caf-haute-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-loire-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_haute_loire
 description: L'aide au BAFA pour une session de formation générale est une aide
   locale mise à disposition par la CAF de la Haute-Loire pour vous aider à
-  financer votre session en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.<br><br>
+  financer votre session en complément de l'aide
+  nationale apportée par la caf.
 link: https://www.caf.fr/allocataires/caf-de-la-haute-loire/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa-et-bafd
 form: https://www.caf.fr/sites/default/files/caf/431/Offre%20de%20service/FORMULAIRE_%20BAFA%201_CAF43.pdf
 instructions: https://www.caf.fr/allocataires/caf-de-la-haute-loire/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa-et-bafd

--- a/data/benefits/javascript/caf-haute-marne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_haute_marne
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Haute-Marne pour vous aider à financer votre session
-  en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents au
     moment de la demande et de la réalisation du stage.

--- a/data/benefits/javascript/caf-haute-saone-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-haute-saone-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_haute_saone
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Haute-Saône pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-haute-saone-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-saone-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_haute_saone
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Haute-Saône pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-haute-vienne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-vienne-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_haute_vienne
 description: L'aide au BAFA pour une session de formation générale est une aide
   locale mise à disposition par la CAF de la Haute-Vienne pour vous aider à
-  financer votre session en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  financer votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.
   - Effectuer votre stage auprès <a target="_blank" rel="noopener" title="Voir les organismes conventionnés - Nouvelle fenêtre"

--- a/data/benefits/javascript/caf-hautes-alpes-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-hautes-alpes-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_hautes_alpes
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Hautes-Alpes pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être membre d'une famille percevant des prestations familiales au titre d'enfant à charge.
 conditions_generales:

--- a/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_hautes_pyrenees
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Hautes-Pyrénées pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-indre-et-loire-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-indre-et-loire-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_indre_et_loire
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de l'Indre-et-Loire pour vous aider à financer votre
-  session d’approfondissement ou de qualification et inclut <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session d’approfondissement ou de qualification et inclut l'aide
+  nationale apportée par la caf.
 conditions_generales:
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-indre-et-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-indre-et-loire-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_indre_et_loire
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de l'Indre-et-Loire pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions_generales:
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-jura-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-jura-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_jura
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Jura pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-jura-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-jura-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_jura
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Jura pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_loir_et_cher
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Loir-et-Cher pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_loir_et_cher
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Loir-et-Cher pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-loire-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loire-aide-bafa-approfondissement.yml
@@ -3,9 +3,8 @@ institution: caf_loire
 description: >
   L'aide au BAFA pour une session d'approfondissement ou de qualification est
   une aide locale mise à disposition par la CAF de la Loire pour vous aider à
-  financer votre session en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  financer votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Avoir commencé une formation pour obtenir le brevet d’aptitude à la fonction
     d’animateur de centre de vacances et de loisirs (BAFA).

--- a/data/benefits/javascript/caf-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loire-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_loire
 description: L'aide au BAFA pour une session de formation générale est une aide
   locale mise à disposition par la CAF de la Loire pour vous aider à financer
-  votre session en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.<br><br>
+  votre session en complément de l'aide
+  nationale apportée par la caf.
 link: https://www.caf.fr/sites/default/files/caf/428/Documents/Rias%202020/Caf%20Loire%20-%20Allocataires%20-%20Aide%20Bafa%202020.pdf
 form: https://www.caf.fr/sites/default/files/caf/428/Documents/Bafa/51%2060%20A%2007_DBAFA.pdf
 instructions: https://www.caf.fr/sites/default/files/caf/428/Documents/Rias%202020/Caf%20Loire%20-%20Allocataires%20-%20Aide%20Bafa%202020.pdf

--- a/data/benefits/javascript/caf-loire-atlantique-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loire-atlantique-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_loire_atlantique
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Loire-Atlantique pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Avoir validé la session de formation générale et son stage pratique.
   - Etre inscrit en session d'approfondissement ou de qualification et déposer

--- a/data/benefits/javascript/caf-loiret-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loiret-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_loiret
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Loiret pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.
   - Adresser votre demande à la Caf, dans un délai maximum de trois mois après

--- a/data/benefits/javascript/caf-loiret-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loiret-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_loiret
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Loiret pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.
   - Adresser votre demande à la CAF, dans un délai maximum de trois mois après

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_lot_et_garonne
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Lot-et-Garonne pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions: []
 conditions_generales:
   - type: departements

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_lot_et_garonne
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Lot-et-Garonne pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions: []
 conditions_generales:
   - type: age

--- a/data/benefits/javascript/caf-martinique-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-martinique-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_martinique
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Martinique pour vous aider à financer votre session
-  en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - >-
     Suivre la formation générale dans <a target="_blank" rel="noopener" title="Voir les organismes de formation - Nouvelle fenêtre"

--- a/data/benefits/javascript/caf-mayenne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-mayenne-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_mayenne
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Mayenne pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions_generales:
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-mayenne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-mayenne-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_mayenne
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Mayenne pour vous aider à financer votre session
-  en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions_generales:
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_meurthe_et_moselle
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Meurthe-et-Moselle pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_meurthe_et_moselle
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Meurthe-et-Moselle pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-meuse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-meuse-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_meuse
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Meuse pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions_generales:
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-morbihan-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-morbihan-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_morbihan
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Morbihan pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-nord-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-nord-aide-bafa-approfondissement.yml
@@ -3,10 +3,8 @@ label: aide au BAFA pour une session de formation d'approfondissement ou de
 institution: caf_nord
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la Caf du Nord pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Déposer votre demande dans les trois mois suivant l’inscription au stage
     d’approfondissement ou de qualification.

--- a/data/benefits/javascript/caf-orne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-orne-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_orne
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de l'Orne pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-pas-de-calais-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-pas-de-calais-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_pas_de_calais
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Pas-de-Calais pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Effectuer votre formation en externat et en demi-pension.
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-puy-de-dome-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-puy-de-dome-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_puy_de_dome
 description: L'aide au BAFA pour une session de formation générale est une aide
   locale mise à disposition par la CAF du Puy-de-Dôme pour vous aider à financer
-  votre session en complément de  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.<br><br>
+  votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre inscrit à la session de formation générale BAFA.
 link: https://www.caf.fr/allocataires/caf-du-puy-de-dome/offre-de-service/enfance-et-jeunesse/les-aides-a-la-formation-bafa

--- a/data/benefits/javascript/caf-pyrenees-orientales-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-pyrenees-orientales-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_pyrenees_orientales
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Pyrénées-Orientales pour vous aider à financer
-  votre session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  votre session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Effectuer votre stage dans son intégralité.
   - Déposer votre demande dans les 6 mois suivant la fin du stage.

--- a/data/benefits/javascript/caf-pyrenees-orientales-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-pyrenees-orientales-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_pyrenees_orientales
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Pyrénées-Orientales pour vous aider à financer
-  votre session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Effectuer votre stage dans son intégralité.
   - Déposer votre demande  dans les 6 mois suivant la fin du stage.

--- a/data/benefits/javascript/caf-reunion-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-reunion-aide-bafa-approfondissement.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_la_reunion
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Réunion pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre" href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre inscrit auprès de la Direction Régionale de la Jeunesse, des Sports et
     de la Cohésion sociale (DRJSCS) de votre lieu de résidence.

--- a/data/benefits/javascript/caf-reunion-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-reunion-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_la_reunion
 description: L'aide au BAFA pour une session de formation générale est une aide
   locale mise à disposition par la CAF de la Réunion pour vous aider à financer
-  votre session en complément de  <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre" href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.<br><br>
+  votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Etre inscrit auprès de la Direction Régionale de la Jeunesse, des Sports et
     de la Cohésion sociale (DRJSCS) de votre lieu de résidence.

--- a/data/benefits/javascript/caf-saone-et-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-saone-et-loire-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_saone_et_loire
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Saône-et-Loire pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Avoir déposé une demande dans les 3 mois qui suivent l’inscription au
     premier stage.

--- a/data/benefits/javascript/caf-sarthe-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-sarthe-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_sarthe
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Sarthe pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être inscrit·e pour le troisième module de formation à une session
     d’approfondissement centrée sur le handicap, la petite enfance, l'accueil de

--- a/data/benefits/javascript/caf-sarthe-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-sarthe-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_sarthe
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Sarthe pour vous aider à financer votre session
-  en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions: []
 conditions_generales:
   - type: age

--- a/data/benefits/javascript/caf-savoie-aide-bafa.yml
+++ b/data/benefits/javascript/caf-savoie-aide-bafa.yml
@@ -3,9 +3,8 @@ institution: caf_savoie
 description: >
   L'aide à la formation du BAFA est une aide locale mise à disposition par la
   CAF de la Savoie pour vous aider à financer votre session de formation
-  générale en complément de
-
-  <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre" href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide nationale apportée par la Caf</a>.<br><br>
+  générale en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Suivre une formation assurée par un organisme de formation à but non
     lucratif habilité par le ministère de la Jeunesse, des Sports et de la Vie

--- a/data/benefits/javascript/caf-seine-et-marne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-seine-et-marne-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: " aide au BAFA pour une session de formation générale"
 institution: caf_seine_et_marne
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Seine-et-Marne pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions: []
 conditions_generales:
   - type: age

--- a/data/benefits/javascript/caf-seine-maritime-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-seine-maritime-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_seine_maritime
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de Seine-Maritime pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.
   - Effectuer votre stage pratique auprès d'un organisme habilité par la

--- a/data/benefits/javascript/caf-somme-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-somme-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_somme
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Somme pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Suivre votre formation dans un organisme conventionné (Céméa de Picardie,
     Fédération Départementale Familles Rurales de la Somme, foyers ruraux, UFCV,

--- a/data/benefits/javascript/caf-somme-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-somme-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_somme
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Somme pour vous aider à financer votre session de
-  formation générale en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  formation générale en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Suivre votre formation dans un organisme conventionné (Céméa de Picardie,
     Fédération Départementale Familles Rurales de la Somme, foyers ruraux, UFCV,

--- a/data/benefits/javascript/caf-tarn-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-tarn-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_tarn
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Tarn pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de <a target="_blank"
-  rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - 'Vous adresser au service Jeunesse & Sports de la DDCSPP de votre
     département pour vous inscrire et connaître les organismes de formation : <a

--- a/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_tarn_et_garonne
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Tarn-et-Garonne pour vous aider à financer votre
-  session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être considéré·e à charge de vos parents ou être placé·e par décision
     judiciaire sous l'autorité des services de l'Etat.

--- a/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_tarn_et_garonne
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Tarn-et-Garonne pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être considéré·e à charge de vos parents ou être placé·e par décision
     judiciaire sous l'autorité des services de l'Etat.

--- a/data/benefits/javascript/caf-territoire-de-belfort-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-territoire-de-belfort-aide-bafa-approfondissement.yml
@@ -2,10 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_territoire_de_belfort
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Territoire de Belfort pour vous aider à financer
-  votre session d’approfondissement ou de qualification en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  votre session d’approfondissement ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Vous engager à suivre la totalité de la formation.
   - Vous engager à exercer votre activité d'animateur pendant au moins deux

--- a/data/benefits/javascript/caf-territoire-de-belfort-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-territoire-de-belfort-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_territoire_de_belfort
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Territoire de Belfort pour vous aider à financer
-  votre session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Vous engager à suivre la totalité de la formation.
   - Vous engager à exercer votre activité d'animateur pendant au moins deux

--- a/data/benefits/javascript/caf-val-de-marne-aide-bafa-approfondissement-qualification.yml
+++ b/data/benefits/javascript/caf-val-de-marne-aide-bafa-approfondissement-qualification.yml
@@ -2,10 +2,8 @@ label: aide au Bafa pour une session d’approfondissement ou de qualification
 institution: caf_val_de_marne
 description: L'aide au Bafa pour une session d'approfondissement ou de
   qualification est une aide locale mise à disposition par la CAF du
-  Val-de-Marne pour vous aider à financer votre session en complément de <a
-  target="_blank" title="Voir l'aide nationale - Nouvelle fenêtre" rel="noopener"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la CAF</a>.
+  Val-de-Marne pour vous aider à financer votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Avoir commencé une formation pour obtenir le brevet d’aptitude à la fonction
     d’animateur de centre de vacances et de loisirs (BAFA).

--- a/data/benefits/javascript/caf-val-de-marne-aide-bafa-formation-generale.yml
+++ b/data/benefits/javascript/caf-val-de-marne-aide-bafa-formation-generale.yml
@@ -2,9 +2,8 @@ label: aide locale au BAFA pour une session de formation générale
 institution: caf_val_de_marne
 description: L'aide au BAFA pour une session de formation générale est une aide
   locale mise à disposition par la CAF du Val-de-Marne pour vous aider à
-  financer votre session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.<br><br>
+  financer votre session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Vous engagez à achever votre formation dans les délais prévus par la
     réglementation (30 mois).

--- a/data/benefits/javascript/caf-var-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-var-aide-bafa-approfondissement.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_var
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Var pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents, ou
     bien être stagiaire orphelin·e ou placé·e en famille d’accueil.

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
@@ -3,9 +3,8 @@ institution: caf_vaucluse
 description: >
   L'aide à la formation du BAFA est une aide locale mise à disposition par la
   CAF du Vaucluse pour vous aider à financer votre session d’approfondissement
-  ou de qualification en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  ou de qualification en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_vaucluse
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Vaucluse pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.
   - Être sans emploi fixe rémunéré.

--- a/data/benefits/javascript/caf-vienne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vienne-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_vienne
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Vienne pour vous aider à financer votre session
-  en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.
   - Effectuer votre stage auprès d’un organisme conventionné.

--- a/data/benefits/javascript/caf-vosges-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vosges-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_vosges
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Vosges pour vous aider à financer votre session en
-  complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Suivre votre stage dans un organisme agréé par les services de la DDSCPP
     (ex. DDJS).

--- a/data/benefits/javascript/caf-yvelines-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-yvelines-aide-bafa-generale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_yvelines
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF des Yvelines pour vous aider à financer votre session
-  en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la Caf</a>.
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions_generales:
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf_moselle-aide-au-bafa-pour-une-session-de-formation-générale.yml
+++ b/data/benefits/javascript/caf_moselle-aide-au-bafa-pour-une-session-de-formation-générale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_moselle
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF de la Moselle pour vous aider à financer votre session
-  en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la caf</a>.
+  en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.
 conditions_generales:

--- a/data/benefits/javascript/caf_pas_de_calais-aide-au-bafa-pour-une-session-de-formation-générale.yml
+++ b/data/benefits/javascript/caf_pas_de_calais-aide-au-bafa-pour-une-session-de-formation-générale.yml
@@ -2,9 +2,8 @@ label: aide au BAFA pour une session de formation générale
 institution: caf_pas_de_calais
 description: L'aide à la formation du BAFA est une aide locale mise à
   disposition par la CAF du Pas-de-Calais pour vous aider à financer votre
-  session en complément de <a target="_blank" rel="noopener" title="Voir l'aide nationale - Nouvelle fenêtre"
-  href="https://www.caf.fr/allocataires/vies-de-famille/jeune-ou-etudiant/vie-active/comment-financer-son-bafa">l'aide
-  nationale apportée par la CAF</a>.
+  session en complément de l'aide
+  nationale apportée par la caf.
 conditions:
   - Effectuer votre formation en externat et en demi-pension.
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.


### PR DESCRIPTION
## Détails

Cette PR supprime dans les fichiers d'aide au Bafa régionales les liens vers l'aide nationale puisque celui-ci ne semble plus être accessible pour le moment.