### PR TITLE
Ajoute les champs anonymisés pour éviter les erreurs Mongoose

### DIFF
--- a/backend/lib/definitions.js
+++ b/backend/lib/definitions.js
@@ -61,6 +61,8 @@ const ANSWER_ENTITY_NAMES = [
   "menage",
 ]
 
+const ANONYMIZED_FIELD_NAMES = ["age"]
+
 // Liste des champs n'existant plus dans le simulateur mais stockés dans les anciennes simulation
 const LEGACY_FIELD_NAMES = [
   "aide_jeunes_diplomes_anciens_boursiers_base_ressources",
@@ -80,6 +82,7 @@ const ANSWER_FIELD_NAMES = [
   ...ressources.ressourceCategories.map((category) => category.id),
   "ressources",
   ...LEGACY_FIELD_NAMES,
+  ...ANONYMIZED_FIELD_NAMES,
 ]
 
 const ANSWER_BASIC_IDS = [undefined, "demandeur", "conjoint", "enfants"]

--- a/backend/models/simulation.js
+++ b/backend/models/simulation.js
@@ -56,7 +56,7 @@ const SimulationSchema = new mongoose.Schema(
     status: {
       type: String,
       default: "new",
-      enum: ["new", "test", "investigation"],
+      enum: ["new", "test", "investigation", "anonymized"],
     },
     token: String,
   },


### PR DESCRIPTION
Pour le contexte les données ont été anonymisées néanmoins quand on veut effectuer une migration, mongoose bloque à cause des champs qui n'existent pas dans les enums de validation.