### PR TITLE
Supprime le delete lors du build:server

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:dev": "webpack --mode=development",
     "build:netlify": "npm run build && cp netlify_redirects dist/_redirects",
     "build:front": "vue-cli-service build --no-clean",
-    "build:server": "npm run clean:dist-server && tsc -p tsconfig.server.json && cp -r lib backend data contribuer tools dist-server/",
+    "build:server": "tsc -p tsconfig.server.json && cp -r lib backend data contribuer tools dist-server/",
     "test:unit": "vue-cli-service test:unit",
     "lint": "eslint .",
     "ci": "npm run stats && NODE_ENV=production node ./dist-server/server.js",


### PR DESCRIPTION
Etant donné que le projet met du temps à build, le rm laisse un court temps sans les fichiers existants.
Pour valider mon hypothèse : la date du premier événement https://sentry.incubateur.net/organizations/betagouv/issues/3633/?query=is%3Aunresolved date du 29 juin correpondant à la date de mise en prod :
https://github.com/betagouv/aides-jeunes/pull/2997