### PR TITLE
Met à jour l'ordre d'affichage des résultats

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -764,6 +764,7 @@ collections:
       - *field_link_instructions
       - *field_amount_reliability
       # hidden fields
+      - *field_benefit_position
       - *field_private_benefit
       - *field_benefit_partial_support
   - name: benefits_openfisca
@@ -862,6 +863,7 @@ collections:
         name: repository
         widget: hidden
         required: false
+      - *field_benefit_position
   - name: contribution-pages
     label: Pages
     label_singular: page

--- a/data/benefits/javascript/cohesion-territoires-conseillers-numeriques-france-services.yml
+++ b/data/benefits/javascript/cohesion-territoires-conseillers-numeriques-france-services.yml
@@ -25,3 +25,4 @@ link: https://www.conseiller-numerique.gouv.fr/
 teleservice: ""
 form: ""
 instructions: https://www.conseiller-numerique.gouv.fr/
+top: 10

--- a/data/benefits/javascript/pole-emploi-aif.yml
+++ b/data/benefits/javascript/pole-emploi-aif.yml
@@ -16,3 +16,4 @@ type: bool
 unit: €
 periodicite: ponctuelle
 interestFlag: null
+top: 10

--- a/data/benefits/openfisca/aide_logement.yml
+++ b/data/benefits/openfisca/aide_logement.yml
@@ -24,3 +24,4 @@ floorAt: 10
 prefix: les
 msa: true
 institution: caf
+top: 1

--- a/data/benefits/openfisca/apa_eligibilite.yml
+++ b/data/benefits/openfisca/apa_eligibilite.yml
@@ -18,7 +18,6 @@ instructions: >-
   https://www.pour-les-personnes-agees.gouv.fr/preserver-son-autonomie-s-informer-et-anticiper/perte-d-autonomie-evaluation-et-droits/lallocation-personnalisee-dautonomie-apa#anchor5
 prefix: l’
 type: bool
-top: 6
 entity: individus
 openfiscaPeriod: thisMonth
 institution: departements

--- a/data/benefits/openfisca/crous_logement_eligibilite.yml
+++ b/data/benefits/openfisca/crous_logement_eligibilite.yml
@@ -7,7 +7,6 @@ link: https://www.etudiant.gouv.fr/fr/bourse-et-logement-constituez-votre-dossie
 teleservice: https://trouverunlogement.lescrous.fr
 prefix: un
 type: bool
-top: 2
 entity: individus
 openfiscaPeriod: thisMonth
 openfisca_eligibility_source: bourse_criteres_sociaux

--- a/data/benefits/openfisca/css_participation_forfaitaire.yml
+++ b/data/benefits/openfisca/css_participation_forfaitaire.yml
@@ -19,3 +19,4 @@ entity: familles
 openfiscaPeriod: thisMonth
 msa: true
 participation: true
+top: 2.5

--- a/data/benefits/openfisca/depart1825_montant_maximum.yml
+++ b/data/benefits/openfisca/depart1825_montant_maximum.yml
@@ -10,7 +10,6 @@ prefix: l’aide
 type: float
 unit: "€"
 legend: "maximum"
-top: 4
 entity: individus
 openfiscaPeriod: thisMonth
 periodicite: annuelle

--- a/data/benefits/openfisca/gratuite_musees_monuments.yml
+++ b/data/benefits/openfisca/gratuite_musees_monuments.yml
@@ -6,7 +6,6 @@ conditions:
 link: https://www.service-public.fr/particuliers/vosdroits/F20348
 prefix: l’
 type: bool
-top: 2
 entity: individus
 openfiscaPeriod: thisMonth
 periodicite: ponctuelle

--- a/data/benefits/openfisca/livret_epargne_populaire_taux.yml
+++ b/data/benefits/openfisca/livret_epargne_populaire_taux.yml
@@ -17,6 +17,6 @@ entity: individus
 openfiscaPeriod: thisMonth
 isBaseRessourcesYearMinusTwo: true
 floorAt: 0.01
-top: 20
+top: 30
 prefix: le
 institution: banque_de_france

--- a/data/benefits/openfisca/locapass_eligibilite.yml
+++ b/data/benefits/openfisca/locapass_eligibilite.yml
@@ -3,7 +3,6 @@ teleservice: https://locapass.actionlogement.fr
 prefix: l’aide
 entity: individus
 openfiscaPeriod: thisMonth
-top: 5
 institution: action_logement
 description: L'avance LOCA-PASS® est une aide gratuite sous forme d'un prêt à 0
   % pour financer tout ou partie de votre dépôt de garantie.

--- a/data/benefits/openfisca/logement_social_eligible.yml
+++ b/data/benefits/openfisca/logement_social_eligible.yml
@@ -9,7 +9,7 @@ conditions:
 link: https://www.service-public.fr/particuliers/vosdroits/F869
 teleservice: https://www.demande-logement-social.gouv.fr/creation/accesCriteresEligibilites.do
 isBaseRessourcesYearMinusTwo: true
-top: 10
+top: 15
 prefix: le
 type: bool
 entity: familles

--- a/data/benefits/openfisca/ppa.yml
+++ b/data/benefits/openfisca/ppa.yml
@@ -21,3 +21,4 @@ entity: familles
 openfiscaPeriod: thisMonth
 msa: true
 institution: caf
+top: 2

--- a/data/benefits/openfisca/rsa.yml
+++ b/data/benefits/openfisca/rsa.yml
@@ -33,3 +33,4 @@ prefix: le
 floorAt: 10
 msa: true
 institution: caf
+top: 2

--- a/data/benefits/openfisca/seances_sante_psy_etudiant.yml
+++ b/data/benefits/openfisca/seances_sante_psy_etudiant.yml
@@ -12,3 +12,4 @@ periodicite: ponctuelle
 floorAt: 1
 entity: individus
 openfiscaPeriod: thisMonth
+top: 2

--- a/data/benefits/openfisca/visale_eligibilite.yml
+++ b/data/benefits/openfisca/visale_eligibilite.yml
@@ -3,7 +3,6 @@ teleservice: https://fo.visale.fr/#!/register/locataire
 prefix: "la "
 entity: menages
 openfiscaPeriod: thisMonth
-top: 5
 institution: action_logement
 description: La garantie Visale est une caution accordée par Action logement au
   locataire qui veut louer un logement. Elle couvre les loyers et charges

--- a/data/index.js
+++ b/data/index.js
@@ -14,6 +14,7 @@ function transformInstitutions(collection) {
       imgSrc: data.imgSrc,
       benefitsIds: [],
       type: data.type,
+      top: data.top,
       repository:
         data.repository || (data.type === "national" ? null : "france-local"),
       etablissements: data.etablissements,
@@ -23,11 +24,21 @@ function transformInstitutions(collection) {
   }, {})
 }
 
-function setDefaults(benefit, institution) {
-  const top = institution.type === "national" ? 1 : 5
+function setTop(benefit, institution) {
+  const default_top =
+    institution.top ||
+    (institution.type === "national"
+      ? 3
+      : benefit.source == "aides-velo"
+      ? 13
+      : 14)
 
+  return benefit.top || default_top
+}
+
+function setDefaults(benefit, institution) {
   benefit.id = benefit.id || benefit.slug
-  benefit.top = benefit.top || top
+  benefit.top = setTop(benefit, institution)
   benefit.floorAt = benefit.floorAt || 1
   return benefit
 }
@@ -51,7 +62,6 @@ function generate(
     : []
   aidesVeloBenefits.forEach((benefit) => {
     benefit.source = "aides-velo"
-    benefit.top = 8
   })
 
   let benefits = [

--- a/data/institutions/action_logement.yml
+++ b/data/institutions/action_logement.yml
@@ -1,3 +1,4 @@
 name: Action Logement
 imgSrc: img/logo_action_logement.png
 type: national
+top: 5

--- a/data/institutions/etat.yml
+++ b/data/institutions/etat.yml
@@ -1,3 +1,4 @@
 name: L’État français
 imgSrc: img/logo_etat_francais.png
 type: national
+top: 5

--- a/data/institutions/mutualite_sociale_agricole.yml
+++ b/data/institutions/mutualite_sociale_agricole.yml
@@ -2,3 +2,4 @@ name: Mutualité Sociale Agricole
 imgSrc: img/logo_mutualite_sociale_agricole.png
 type: national
 repository: france-local
+top: 10

--- a/data/institutions/pro_btp.yml
+++ b/data/institutions/pro_btp.yml
@@ -1,3 +1,4 @@
 name: Pro BTP
 imgSrc: img/logo_pro_btp.png
 type: national
+top: 10

--- a/data/institutions/sncf.yml
+++ b/data/institutions/sncf.yml
@@ -1,3 +1,4 @@
 name: SNCF
 imgSrc: img/logo_sncf.png
 type: national
+top: 10


### PR DESCRIPTION
Mise en place d'une heuristique au pifomètre pour un meilleur affichage des résultats.
En local, j'avais modifié la page de listing de toutes les aides pour faire les ajustements et juger des paramètres à mettre en place.


Un enjeu actuel, mettre en avant les aides au logement.

Détails sur les raisons de l'ordonnancement proposé dans cette PR (:warning: au pifomètre mais une amélioration par rapport à l'existant) :

- top1 mise en avant des aides au logement
- top2
  - mise en avant des dispositifs nationaux fondateurs du filet de sécurité social (rsa, ppa)
  - mise en avance du dispositif santé psy étudiant
- top2.5 mise en avant complémentaire santé solidaire
- top3 valeur de base pour les aides nationales
- top5 valeur de base pour les aides d'état et d'action logement
- top6 aides fonds de solidarité logement
- top10:
  - mise en retrait de dispositifs nationaux (CNFS, AIF, dispositifs MSA, Pro BTP, SNCF)
- top13 valeur de base pour les aides locales Vélo
- top14 valeur de base pour les autres aides locales
- top15 mise en retrait du logement_social_eligible
- top30 mise en retrait du livret_epargne_populaire_taux