### PR TITLE
normalise les slugs pour les fichiers d'aides

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -12,6 +12,10 @@ backend:
 media_folder: public/img
 public_folder: img
 
+slug:
+  encoding: ascii
+  clean_accents: true
+
 # local_backend: true
 publish_mode: editorial_workflow
 


### PR DESCRIPTION
## Détails

Netlify permet de normaliser les noms des fichiers d'aides en ne permettant que l'utilisation de caractères ascii et en transformant automatiquement les caractères accentués en leur équivalence non accentuée

[Lien vers la documentation Netlify CMS](https://www.netlifycms.org/docs/configuration-options/#slug-type).