### PR TITLE
Supprimer les modèles Pages et Contributions de l'outil de contribution

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -862,39 +862,3 @@ collections:
         name: repository
         widget: hidden
         required: false
-  - name: contribution-pages
-    label: Pages
-    label_singular: page
-    create: true
-    delete: false
-    files:
-      - label: Accueil
-        name: home
-        file: "contribuer/content/home.md"
-        fields:
-          - { label: Titre, name: title, widget: string }
-          - { label: Corps, name: body, widget: markdown }
-          - label: Contributions
-            name: categories
-            widget: list
-            fields:
-              - { label: Nom, name: name, widget: string }
-              - label: Idées
-                name: ideas
-                widget: list
-                field: { label: Nom, name: name, widget: string }
-  - name: tasks
-    label: Contributions
-    label_singular: contribution
-    folder: "contribuer/content/tasks"
-    create: true
-    delete: false
-    slug: "{{slug}}"
-    fields:
-      - { label: Nom, name: title, widget: string }
-      - {
-          label: Description,
-          name: "body",
-          widget: "markdown",
-          required: false,
-        }


### PR DESCRIPTION
Suppression :

- lignes du fichier `https://github.com/betagouv/aides-jeunes/blob/master/contribuer/public/admin/config.yml#L871-L906`