### PR TITLE
N'affiche pas 0€ pour les valeurs non-calculables

### DIFF
--- a/lib/benefits/details.ts
+++ b/lib/benefits/details.ts
@@ -44,6 +44,7 @@ interface droitEstimeLayout {
   value: any
   unit: any
   icon?: any
+  uncomputability: boolean
 }
 function formatDroitEstime(droit, parameters) {
   const droitEstime: droitEstimeLayout = {

--- a/lib/benefits/details.ts
+++ b/lib/benefits/details.ts
@@ -54,6 +54,7 @@ function formatDroitEstime(droit, parameters) {
     value: droit.montant || 1,
     unit: droit.unit || "€",
     icon: undefined,
+    uncomputability: typeof droit.montant === "string",
   }
   switch (droit.type) {
     case "float":

--- a/src/components/droit-estime.vue
+++ b/src/components/droit-estime.vue
@@ -9,25 +9,41 @@
   >
     <div>
       <template v-if="isBenefitTypeNumber || isBenefitTypeString">
-        <span>
-          <span class="aj-droit-estime-label font-normal font-base">
-            {{ droitEstime.label }}
+        <template v-if="droitEstime.uncomputability">
+          <span>
+            <span class="aj-droit-estime-label font-normal font-base">
+              {{ droitEstime.label }}
+            </span>
+            <br />
+            <span
+              class="aj-droit-estime-value font-bold"
+              data-testid="droit-estime-value"
+            >
+              Inconnu
+            </span>
           </span>
-          <br />
+        </template>
+        <template v-else>
+          <span>
+            <span class="aj-droit-estime-label font-normal font-base">
+              {{ droitEstime.label }}
+            </span>
+            <br />
+            <span
+              class="aj-droit-estime-value font-bold"
+              data-testid="droit-estime-value"
+            >
+              {{ droitEstime.value }}
+            </span>
+          </span>
           <span
-            class="aj-droit-estime-value font-bold"
-            data-testid="droit-estime-value"
+            v-if="droitEstime.legend"
+            class="aj-droit-estime-legend"
+            data-testid="droit-estime-legend"
           >
-            {{ droitEstime.value }}
+            {{ droitEstime.legend }}
           </span>
-        </span>
-        <span
-          v-if="droitEstime.legend"
-          class="aj-droit-estime-legend"
-          data-testid="droit-estime-legend"
-        >
-          {{ droitEstime.legend }}
-        </span>
+        </template>
       </template>
     </div>
     <div class="aj-droit-estime-inattendu">


### PR DESCRIPTION
Correction du bug remonté par @alizeeeeeee  : https://mattermost.incubateur.net/betagouv/pl/s8q39wo843b3tg3nwdm4chjbuw
![image](https://user-images.githubusercontent.com/65901733/179730996-e5f6c8db-95de-46dc-bda2-d0cdecb848f0.png)

# Investigations
## 1ère itération
Après investigation j'en ai déduit que le bug venait du fait que la variable `aide_logement_non_calculable` est égale à `locataire_foyer` malgré le fait que `aide_logement` est une valeur.

``` "aide_logement": {
"2022-07": 114.61
},
"aide_logement_non_calculable": {
"2022-07": "locataire_foyer"
},
```

La partie du code en question : https://github.com/betagouv/aides-jeunes/blob/72b91ac15e1b1027866236082b0c1f589262f540/lib/benefits/compute.js#L107-L121

Etant donné que `aide_logement_non_calculable` est égale à `locataire_foyer` il ne récupère pas la valeur dans `aide_logement` mais reste dans `droitsEligibles` car `value = locataire_foyer`

Ensuite remplacé `locataire_foyer` pour afficher `0 €` https://github.com/betagouv/aides-jeunes/blob/72b91ac15e1b1027866236082b0c1f589262f540/lib/benefits/details.js#L67-L76

Ma solution est de mettre l'aide dans `droitsNonEligibles` lorsque l'aide est `non_calculable`.

## 2ème itération
En regardant les tests il semblerait que c'est un comportement normal.
Néanmoins afficher un montant de 0€ est trompeur, malgré le message d'alerte qui est visible uniquement sur la page de détails (pas la liste, ni la page de suivi).
Ma proposition est de mettre un montant inconnu :
![image](https://user-images.githubusercontent.com/65901733/179762571-9c18c9f8-a398-4bee-8d80-3e67bda742a3.png)

Amélioration possible : ajouter un bouton `?` à coté du montant inconnu pour afficher le message d'alerte