### PR TITLE
Désactiver l'appel à l'API missingBenefits sur la production

### DIFF
--- a/src/views/home.vue
+++ b/src/views/home.vue
@@ -75,7 +75,7 @@ export default {
     next: function () {
       this.$store.dispatch("openFiscaParameters")
       // we only want to look for benefit variables in preview mode
-      if (process.env.VUE_APP_CONTEXT === "deploy-preview") {
+      if (process.env.VUE_APP_CONTEXT !== "production") {
         this.$store.dispatch("verifyBenefitVariables")
       }
       this.$push()


### PR DESCRIPTION
S'assurer que :
- l'appel API ne se fait plus en mode production, mais se fait toujours en local, en preview et sur la CI