### PR TITLE
Footer affiché plus bas sur les pages

### DIFF
--- a/src/styles/partials/desktop/_simulation.scss
+++ b/src/styles/partials/desktop/_simulation.scss
@@ -3,6 +3,7 @@ html {
     .aj-simulation {
       background: linear-gradient(90deg, transparent 50%, #f2f5f9 50%);
       flex-grow: 1;
+      display: contents;
     }
   }
 }

--- a/src/styles/partials/desktop/_ui-kit.scss
+++ b/src/styles/partials/desktop/_ui-kit.scss
@@ -44,6 +44,7 @@ html {
           flex-direction: row-reverse;
           flex: 1 1 auto;
           width: 100%;
+        min-height: 100vh;
         }
 
         .aj-text-container {

--- a/src/styles/partials/desktop/_ui-kit.scss
+++ b/src/styles/partials/desktop/_ui-kit.scss
@@ -39,7 +39,7 @@ html {
         display: flex;
         flex-direction: column;
         flex: 1 0 auto;
-        height: 100vh;
+        min-height: 100vh;
 
         .aj-layout-container {
           flex-direction: row-reverse;

--- a/src/styles/partials/desktop/_ui-kit.scss
+++ b/src/styles/partials/desktop/_ui-kit.scss
@@ -44,7 +44,7 @@ html {
           flex-direction: row-reverse;
           flex: 1 1 auto;
           width: 100%;
-        min-height: 100vh;
+          min-height: 100vh;
         }
 
         .aj-text-container {

--- a/src/styles/partials/desktop/_ui-kit.scss
+++ b/src/styles/partials/desktop/_ui-kit.scss
@@ -39,12 +39,12 @@ html {
         display: flex;
         flex-direction: column;
         flex: 1 0 auto;
+        height: 100vh;
 
         .aj-layout-container {
           flex-direction: row-reverse;
           flex: 1 1 auto;
           width: 100%;
-          min-height: 100vh;
         }
 
         .aj-text-container {


### PR DESCRIPTION
L'objectif ici est d'avoir à scroll pour voir le footer plutôt que le voir par défaut.
[Le ticket Trello](https://trello.com/c/hxfMutFc/863-emp%C3%AAcher-le-footer-d%C3%AAtre-affich%C3%A9-trop-haut-sur-les-pages).

Avant: 

<img width="1439" alt="Capture d’écran 2022-08-02 à 15 28 55" src="https://user-images.githubusercontent.com/52297439/182386549-738a13b3-4854-4b1b-ba0a-2b335cc5245e.png">

Après:

<img width="1430" alt="Capture d’écran 2022-08-02 à 15 30 46" src="https://user-images.githubusercontent.com/52297439/182386936-519eabdf-b708-4aa4-bd8a-7027c74c3b98.png">


