### PR TITLE
Impose la présence d'un code SIREN

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -850,7 +850,7 @@ collections:
         required: false
         required_group: identifier
       - label: Code SIREN
-        hint: En l'absence de code INSEE
+        hint: En cas de doute, il est possible de rechercher sur https://annuaire-entreprises.data.gouv.fr
         name: code_siren
         widget: string
         required: false

--- a/data/institutions/action_logement.yml
+++ b/data/institutions/action_logement.yml
@@ -2,3 +2,4 @@ name: Action Logement
 imgSrc: img/logo_action_logement.png
 type: national
 top: 5
+code_siren: "824541148"

--- a/data/institutions/assurance_maladie.yml
+++ b/data/institutions/assurance_maladie.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_assurance_maladie.png
 type: national
 etablissements:
   - cpam
+code_siren: "180035024"

--- a/data/institutions/assurance_retraite.yml
+++ b/data/institutions/assurance_retraite.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_assurance_retraite.png
 type: national
 etablissements:
   - carsat
+code_siren: "180035032"

--- a/data/institutions/banque_de_france.yml
+++ b/data/institutions/banque_de_france.yml
@@ -1,3 +1,4 @@
 name: La Banque de France
 imgSrc: img/logo_banque_de_france.png
 type: national
+code_siren: "572104891"

--- a/data/institutions/caf.yml
+++ b/data/institutions/caf.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_caf.png
 type: national
 etablissements:
   - caf
+code_siren: "180035065"

--- a/data/institutions/cohesion_territoires.yml
+++ b/data/institutions/cohesion_territoires.yml
@@ -1,3 +1,4 @@
 name: Ministère de la Cohésion des territoires
 imgSrc: img/logo_ministere_cohesion_territoires.png
 type: national
+code_siren: "130026032"

--- a/data/institutions/collectivité-européenne-dalsace.yml
+++ b/data/institutions/collectivité-européenne-dalsace.yml
@@ -2,3 +2,4 @@ name: Collectivité Européenne d'Alsace
 imgSrc: img/logo-alsace.png
 type: autre
 code_insee: 6AE
+code_siren: "200094332"

--- a/data/institutions/departement_aisne.yml
+++ b/data/institutions/departement_aisne.yml
@@ -2,3 +2,4 @@ name: Département de l'Aisne
 imgSrc: img/logo_cd02.png
 type: departement
 code_insee: "02"
+code_siren: "220200026"

--- a/data/institutions/departement_bouches_du_rhone.yml
+++ b/data/institutions/departement_bouches_du_rhone.yml
@@ -2,3 +2,4 @@ name: Département des Bouches-du-Rhône
 imgSrc: img/logo_cd13.png
 type: departement
 code_insee: "13"
+code_siren: "221300015"

--- a/data/institutions/departement_cote_or.yml
+++ b/data/institutions/departement_cote_or.yml
@@ -2,3 +2,4 @@ name: Département Côte d'Or
 imgSrc: img/logo_cd21.png
 type: departement
 code_insee: "21"
+code_siren: "222100018"

--- a/data/institutions/departement_cotes_d_armor.yml
+++ b/data/institutions/departement_cotes_d_armor.yml
@@ -4,3 +4,4 @@ prefix: des
 repository: france-local
 type: departement
 code_insee: "22"
+code_siren: "222200016"

--- a/data/institutions/departement_de_la_charente.yml
+++ b/data/institutions/departement_de_la_charente.yml
@@ -2,3 +2,4 @@ name: Département de la Charente
 imgSrc: img/logo_charente.jpeg
 type: departement
 code_insee: "16"
+code_siren: "221600018"

--- a/data/institutions/departement_des_pyrenees_orientales.yml
+++ b/data/institutions/departement_des_pyrenees_orientales.yml
@@ -2,3 +2,4 @@ name: Département des Pyrénées-Orientales
 imgSrc: img/logo_pyrenees-orientales.jpeg
 type: departement
 code_insee: "66"
+code_siren: "226600013"

--- a/data/institutions/departement_du_haut_rhin.yml
+++ b/data/institutions/departement_du_haut_rhin.yml
@@ -2,3 +2,4 @@ name: Département du Haut-Rhin
 imgSrc: img/logo_haut-rhin.png
 type: departement
 code_insee: "68"
+code_siren: "226800019"

--- a/data/institutions/departement_eure_et_loir.yml
+++ b/data/institutions/departement_eure_et_loir.yml
@@ -2,3 +2,4 @@ name: Département de l’Eure-et-Loir
 imgSrc: img/logo_cd28.png
 type: departement
 code_insee: "28"
+code_siren: "222800013"

--- a/data/institutions/departement_finistere.yml
+++ b/data/institutions/departement_finistere.yml
@@ -2,3 +2,4 @@ name: Département du Finistère
 imgSrc: img/logo_cd29.png
 type: departement
 code_insee: "29"
+code_siren: "222900011"

--- a/data/institutions/departement_haute_saone.yml
+++ b/data/institutions/departement_haute_saone.yml
@@ -2,3 +2,4 @@ name: Département de la Haute-Saône
 imgSrc: img/logo_cd70.png
 type: departement
 code_insee: "70"
+code_siren: "227000015"

--- a/data/institutions/departement_herault.yml
+++ b/data/institutions/departement_herault.yml
@@ -2,3 +2,4 @@ name: Département de l'Hérault
 imgSrc: img/logo_cd34.png
 type: departement
 code_insee: "34"
+code_siren: "223400011"

--- a/data/institutions/departement_jura.yml
+++ b/data/institutions/departement_jura.yml
@@ -2,3 +2,4 @@ name: Département du Jura
 imgSrc: img/logo_cd39.png
 type: departement
 code_insee: "39"
+code_siren: "223900010"

--- a/data/institutions/departement_loire.yml
+++ b/data/institutions/departement_loire.yml
@@ -2,3 +2,4 @@ name: Département de la Loire
 imgSrc: img/logo_cd42.png
 type: departement
 code_insee: "42"
+code_siren: "224200014"

--- a/data/institutions/departement_loire_atlantique.yml
+++ b/data/institutions/departement_loire_atlantique.yml
@@ -2,3 +2,4 @@ name: Département de loire Atlantique
 imgSrc: img/logo_cd44.png
 type: departement
 code_insee: "44"
+code_siren: "224400028"

--- a/data/institutions/departement_lot.yml
+++ b/data/institutions/departement_lot.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_cd46.png
 prefix: le
 type: departement
 code_insee: "46"
+code_siren: "224600015"

--- a/data/institutions/departement_mayenne.yml
+++ b/data/institutions/departement_mayenne.yml
@@ -2,3 +2,4 @@ name: Département de la Mayenne
 imgSrc: img/logo_departement_mayenne.png
 type: departement
 code_insee: "53"
+code_siren: "225300011"

--- a/data/institutions/departement_nord.yml
+++ b/data/institutions/departement_nord.yml
@@ -2,3 +2,4 @@ name: Département du Nord
 imgSrc: img/logo_cd59.png
 type: departement
 code_insee: "59"
+code_siren: "225900018"

--- a/data/institutions/departement_oise.yml
+++ b/data/institutions/departement_oise.yml
@@ -2,3 +2,4 @@ name: Département de l'Oise
 imgSrc: img/logo_cd60.png
 type: departement
 code_insee: "60"
+code_siren: "226000016"

--- a/data/institutions/departement_puy_de_dome.yml
+++ b/data/institutions/departement_puy_de_dome.yml
@@ -2,3 +2,4 @@ name: Département du Puy-de-Dôme
 imgSrc: img/logo_cd63.png
 type: departement
 code_insee: "63"
+code_siren: "226300010"

--- a/data/institutions/departement_saone_et_loire.yml
+++ b/data/institutions/departement_saone_et_loire.yml
@@ -2,3 +2,4 @@ name: Département de Saône-et-Loire
 imgSrc: img/logo_cd71.png
 type: departement
 code_insee: "71"
+code_siren: "227100013"

--- a/data/institutions/departement_seine_maritime.yml
+++ b/data/institutions/departement_seine_maritime.yml
@@ -2,3 +2,4 @@ name: Département de Seine-Maritime
 imgSrc: img/logo_cd76.png
 type: departement
 code_insee: "76"
+code_siren: "227605409"

--- a/data/institutions/departement_seine_saint_denis.yml
+++ b/data/institutions/departement_seine_saint_denis.yml
@@ -2,3 +2,4 @@ name: Département de Seine-Saint-Denis
 imgSrc: img/logo_cd93.png
 type: departement
 code_insee: "93"
+code_siren: "229300082"

--- a/data/institutions/departement_somme.yml
+++ b/data/institutions/departement_somme.yml
@@ -2,3 +2,4 @@ name: Département de la Somme
 imgSrc: img/logo_cd80.png
 type: departement
 code_insee: "80"
+code_siren: "228000014"

--- a/data/institutions/departement_val_d_oise.yml
+++ b/data/institutions/departement_val_d_oise.yml
@@ -2,3 +2,4 @@ name: Département du Val-d'Oise
 imgSrc: img/logo_cd95.png
 type: departement
 code_insee: "95"
+code_siren: "229501275"

--- a/data/institutions/departement_vendee.yml
+++ b/data/institutions/departement_vendee.yml
@@ -2,3 +2,4 @@ name: Département de la Vendée
 imgSrc: img/logo_cd85.png
 type: departement
 code_insee: "85"
+code_siren: "228500013"

--- a/data/institutions/departements.yml
+++ b/data/institutions/departements.yml
@@ -7,3 +7,4 @@ etablissements:
   - edas
   - sdsei
 type: national
+code_siren: "999999999"

--- a/data/institutions/departements_et_metropoles.yml
+++ b/data/institutions/departements_et_metropoles.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_etat_francais.png
 repository: france-local
 prefix: les
 type: national
+code_siren: "999999999"

--- a/data/institutions/education_nationale.yml
+++ b/data/institutions/education_nationale.yml
@@ -1,3 +1,4 @@
 name: Éducation nationale
 imgSrc: img/logo_education_nationale.png
 type: national
+code_siren: "110043015"

--- a/data/institutions/etat.yml
+++ b/data/institutions/etat.yml
@@ -2,3 +2,4 @@ name: L’État français
 imgSrc: img/logo_etat_francais.png
 type: national
 top: 5
+code_siren: "999999999"

--- a/data/institutions/grand_est.yml
+++ b/data/institutions/grand_est.yml
@@ -2,3 +2,4 @@ name: Grand Est
 imgSrc: img/logo_grandest.png
 type: region
 code_insee: "44"
+code_siren: "200052264"

--- a/data/institutions/guadeloupe.yml
+++ b/data/institutions/guadeloupe.yml
@@ -2,3 +2,4 @@ name: Guadeloupe
 imgSrc: img/logo_guadeloupe.png
 type: region
 code_insee: "01"
+code_siren: "239710015"

--- a/data/institutions/guyane.yml
+++ b/data/institutions/guyane.yml
@@ -2,3 +2,4 @@ name: Guyane
 imgSrc: img/logo-guyane.jpeg
 type: region
 code_insee: "03"
+code_siren: "200052678"

--- a/data/institutions/hauts_de_france.yml
+++ b/data/institutions/hauts_de_france.yml
@@ -2,3 +2,4 @@ name: Hauts de France
 imgSrc: img/logo_hauts_de_france.png
 type: region
 code_insee: "32"
+code_siren: "200053742"

--- a/data/institutions/martinique.yml
+++ b/data/institutions/martinique.yml
@@ -2,3 +2,4 @@ name: Martinique
 imgSrc: img/logo_martinique.png
 type: region
 code_insee: "02"
+code_siren: "200055507"

--- a/data/institutions/mutualite_sociale_agricole.yml
+++ b/data/institutions/mutualite_sociale_agricole.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_mutualite_sociale_agricole.png
 type: national
 repository: france-local
 top: 10
+code_siren: "302990445"

--- a/data/institutions/paris.yml
+++ b/data/institutions/paris.yml
@@ -4,3 +4,4 @@ prefix: de la
 repository: paris
 type: commune
 code_insee: "75056"
+code_siren: "217500016"

--- a/data/institutions/pole_emploi.yml
+++ b/data/institutions/pole_emploi.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_pole_emploi.png
 etablissements:
   - pole_emploi
 type: national
+code_siren: "130005481"

--- a/data/institutions/pro_btp.yml
+++ b/data/institutions/pro_btp.yml
@@ -2,3 +2,4 @@ name: Pro BTP
 imgSrc: img/logo_pro_btp.png
 type: national
 top: 10
+code_siren: "394164966"

--- a/data/institutions/region_auvergne_rhone_alpes.yml
+++ b/data/institutions/region_auvergne_rhone_alpes.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_auvergne_rhone_alpes.jpg
 repository: france-local
 type: region
 code_insee: "84"
+code_siren: "200053767"

--- a/data/institutions/region_bourgogne_franche_comte.yml
+++ b/data/institutions/region_bourgogne_franche_comte.yml
@@ -2,3 +2,4 @@ name: Bourgogne-Franche-Comté
 imgSrc: img/logo_bourgogne_franche_comte.png
 type: region
 code_insee: "27"
+code_siren: "200053726"

--- a/data/institutions/region_bretagne.yml
+++ b/data/institutions/region_bretagne.yml
@@ -2,3 +2,4 @@ name: Bretagne
 imgSrc: img/logo_bretagne.png
 type: region
 code_insee: "53"
+code_siren: "233500016"

--- a/data/institutions/region_centre_val_de_loire.yml
+++ b/data/institutions/region_centre_val_de_loire.yml
@@ -2,3 +2,4 @@ name: Centre-Val de Loire
 imgSrc: img/logo_centre_val_de_loire.png
 type: region
 code_insee: "24"
+code_siren: "234500023"

--- a/data/institutions/region_corse.yml
+++ b/data/institutions/region_corse.yml
@@ -2,3 +2,4 @@ name: Région Corse
 imgSrc: img/logo_region_corse.png
 type: region
 code_insee: "94"
+code_siren: "200076958"

--- a/data/institutions/region_ile_de_france.yml
+++ b/data/institutions/region_ile_de_france.yml
@@ -2,3 +2,4 @@ name: Île-de-France
 imgSrc: img/logo_ile_de_france.png
 type: region
 code_insee: "11"
+code_siren: "237500079"

--- a/data/institutions/region_la_reunion.yml
+++ b/data/institutions/region_la_reunion.yml
@@ -2,3 +2,4 @@ name: La Réunion
 imgSrc: img/logo_la_reunion.jpeg
 type: region
 code_insee: "04"
+code_siren: "239740012"

--- a/data/institutions/region_normandie.yml
+++ b/data/institutions/region_normandie.yml
@@ -2,3 +2,4 @@ name: Normandie
 imgSrc: img/logo_normandie.png
 type: region
 code_insee: "28"
+code_siren: "200053403"

--- a/data/institutions/region_nouvelle_aquitaine.yml
+++ b/data/institutions/region_nouvelle_aquitaine.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_nouvelle_aquitaine.png
 repository: france-local
 type: region
 code_insee: "75"
+code_siren: "200053759"

--- a/data/institutions/region_occitanie.yml
+++ b/data/institutions/region_occitanie.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_occitanie.png
 repository: france-local
 type: region
 code_insee: "76"
+code_siren: "200053791"

--- a/data/institutions/region_pays_de_la_loire.yml
+++ b/data/institutions/region_pays_de_la_loire.yml
@@ -2,3 +2,4 @@ name: Pays de la Loire
 imgSrc: img/logo_pays_de_la_loire.png
 type: region
 code_insee: "52"
+code_siren: "234400034"

--- a/data/institutions/region_provence_alpes_cote_azur.yml
+++ b/data/institutions/region_provence_alpes_cote_azur.yml
@@ -2,3 +2,4 @@ name: Provence-Alpes-Côte d'Azur
 imgSrc: img/logo_provence_alpes_cote_azur.jpg
 type: region
 code_insee: "93"
+code_siren: "231300021"

--- a/data/institutions/sncf.yml
+++ b/data/institutions/sncf.yml
@@ -2,3 +2,4 @@ name: SNCF
 imgSrc: img/logo_sncf.png
 type: national
 top: 10
+code_siren: "552049447"

--- a/data/institutions/ville_aix_les_bains.yml
+++ b/data/institutions/ville_aix_les_bains.yml
@@ -2,3 +2,4 @@ name: Ville d’Aix-les-Bains
 imgSrc: img/logo_aix_les_bains.png
 type: commune
 code_insee: "73008"
+code_siren: "217300086"

--- a/data/institutions/ville_alfortville.yml
+++ b/data/institutions/ville_alfortville.yml
@@ -4,3 +4,4 @@ prefix: d’
 repository: france-local
 type: commune
 code_insee: "94002"
+code_siren: "219400025"

--- a/data/institutions/ville_arcachon.yml
+++ b/data/institutions/ville_arcachon.yml
@@ -2,3 +2,4 @@ name: Ville d'Arcachon
 imgSrc: img/logo_arcachon.png
 type: commune
 code_insee: "33009"
+code_siren: "213300098"

--- a/data/institutions/ville_aubiere.yml
+++ b/data/institutions/ville_aubiere.yml
@@ -2,3 +2,4 @@ name: Ville d’Aubière
 imgSrc: img/logo_aubiere.png
 type: commune
 code_insee: "63014"
+code_siren: "216300145"

--- a/data/institutions/ville_avesnes_sur_helpe.yml
+++ b/data/institutions/ville_avesnes_sur_helpe.yml
@@ -2,3 +2,4 @@ name: Ville d’Avesnes-sur-Helpe
 imgSrc: img/logo_avesnes_sur_helpe.png
 type: commune
 code_insee: "59036"
+code_siren: "215900366"

--- a/data/institutions/ville_baisieux.yml
+++ b/data/institutions/ville_baisieux.yml
@@ -2,3 +2,4 @@ name: Ville de Baisieux
 imgSrc: img/logo_baisieux.png
 type: commune
 code_insee: "59044"
+code_siren: "215900440"

--- a/data/institutions/ville_bar_le_duc.yml
+++ b/data/institutions/ville_bar_le_duc.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_bar_le_duc.png
 prefix: de la
 type: commune
 code_insee: "55029"
+code_siren: "215500299"

--- a/data/institutions/ville_betheny.yml
+++ b/data/institutions/ville_betheny.yml
@@ -2,3 +2,4 @@ name: Ville de Bétheny
 imgSrc: img/logo_betheny.png
 type: commune
 code_insee: "51055"
+code_siren: "215100504"

--- a/data/institutions/ville_bethune.yml
+++ b/data/institutions/ville_bethune.yml
@@ -2,3 +2,4 @@ name: Ville de Béthune
 imgSrc: img/logo_bethune.png
 type: commune
 code_insee: "62119"
+code_siren: "216209106"

--- a/data/institutions/ville_billy_berclau.yml
+++ b/data/institutions/ville_billy_berclau.yml
@@ -2,3 +2,4 @@ name: Ville de Billy-Berclau
 imgSrc: img/logo_billy_berclau.png
 type: commune
 code_insee: "62132"
+code_siren: "216201327"

--- a/data/institutions/ville_bonningues_les_calais.yml
+++ b/data/institutions/ville_bonningues_les_calais.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_bonningues_les_calais.png
 prefix: de la
 type: commune
 code_insee: "62156"
+code_siren: "216201566"

--- a/data/institutions/ville_bourg_en_bresse.yml
+++ b/data/institutions/ville_bourg_en_bresse.yml
@@ -2,3 +2,4 @@ name: Ville de Bourg-en-Bresse
 imgSrc: img/logo_bourg_en_bresse.png
 type: commune
 code_insee: "01053"
+code_siren: "210100533"

--- a/data/institutions/ville_caen.yml
+++ b/data/institutions/ville_caen.yml
@@ -2,3 +2,4 @@ name: Ville de Caen
 imgSrc: img/logo_caen.png
 type: commune
 code_insee: "14118"
+code_siren: "211401187"

--- a/data/institutions/ville_cambrai.yml
+++ b/data/institutions/ville_cambrai.yml
@@ -2,3 +2,4 @@ name: Ville de Cambrai
 imgSrc: img/logo_cambrai.png
 type: commune
 code_insee: "59122"
+code_siren: "215901224"

--- a/data/institutions/ville_camon.yml
+++ b/data/institutions/ville_camon.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_camon.jpg
 prefix: de la
 type: commune
 code_insee: "80164"
+code_siren: "218001576"

--- a/data/institutions/ville_carpiquet.yml
+++ b/data/institutions/ville_carpiquet.yml
@@ -2,3 +2,4 @@ name: Ville de Carpiquet
 imgSrc: img/logo_carpiquet.png
 type: commune
 code_insee: "14137"
+code_siren: "211401377"

--- a/data/institutions/ville_carvin.yml
+++ b/data/institutions/ville_carvin.yml
@@ -2,3 +2,4 @@ name: Ville de Carvin
 imgSrc: img/logo_carvin.png
 type: commune
 code_insee: "62215"
+code_siren: "216202150"

--- a/data/institutions/ville_cebazat.yml
+++ b/data/institutions/ville_cebazat.yml
@@ -2,3 +2,4 @@ name: Ville de Cébazat
 imgSrc: img/logo_cebazat.png
 type: commune
 code_insee: "63063"
+code_siren: "216300632"

--- a/data/institutions/ville_chalette_sur_loing.yml
+++ b/data/institutions/ville_chalette_sur_loing.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_chalette_sur_loing.png
 prefix: de la
 type: commune
 code_insee: "45068"
+code_siren: "214500688"

--- a/data/institutions/ville_charenton_le_pont.yml
+++ b/data/institutions/ville_charenton_le_pont.yml
@@ -2,3 +2,4 @@ name: Ville de Charenton-le-Pont
 imgSrc: img/logo_charenton_le_pont.png
 type: commune
 code_insee: "94018"
+code_siren: "219400181"

--- a/data/institutions/ville_colmar.yml
+++ b/data/institutions/ville_colmar.yml
@@ -2,3 +2,4 @@ name: Ville de Colmar
 imgSrc: img/logo_colmar.png
 type: commune
 code_insee: "68066"
+code_siren: "216800664"

--- a/data/institutions/ville_combloux.yml
+++ b/data/institutions/ville_combloux.yml
@@ -2,3 +2,4 @@ name: Ville de Combloux
 imgSrc: img/logo_combloux.png
 type: commune
 code_insee: "74083"
+code_siren: "217400837"

--- a/data/institutions/ville_comines.yml
+++ b/data/institutions/ville_comines.yml
@@ -2,3 +2,4 @@ name: Ville de Comines
 imgSrc: img/logo_comines.png
 type: commune
 code_insee: "59152"
+code_siren: "215901521"

--- a/data/institutions/ville_cormelles_le_royal.yml
+++ b/data/institutions/ville_cormelles_le_royal.yml
@@ -2,3 +2,4 @@ name: Ville de Cormelles le Royal
 imgSrc: img/logo_cormelles_le_royal.png
 type: commune
 code_insee: "14181"
+code_siren: "211401815"

--- a/data/institutions/ville_correze.yml
+++ b/data/institutions/ville_correze.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_correze.png
 prefix: de la
 type: commune
 code_insee: "19062"
+code_siren: "211906201"

--- a/data/institutions/ville_courbevoie.yml
+++ b/data/institutions/ville_courbevoie.yml
@@ -2,3 +2,4 @@ name: Ville de Courbevoie
 imgSrc: img/logo_courbevoie.png
 type: commune
 code_insee: "92026"
+code_siren: "219200268"

--- a/data/institutions/ville_cournon_auvergne.yml
+++ b/data/institutions/ville_cournon_auvergne.yml
@@ -2,3 +2,4 @@ name: Ville de Cournon-d’Auvergne
 imgSrc: img/logo_cournon_auvergne.png
 type: commune
 code_insee: "63124"
+code_siren: "216301242"

--- a/data/institutions/ville_crolles.yml
+++ b/data/institutions/ville_crolles.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_crolles.png
 prefix: de la
 type: commune
 code_insee: "38140"
+code_siren: "213801400"

--- a/data/institutions/ville_d_amiens.yml
+++ b/data/institutions/ville_d_amiens.yml
@@ -2,3 +2,4 @@ name: Ville d'Amiens
 imgSrc: img/logo_amiens.png
 type: commune
 code_insee: "80021"
+code_siren: "218000198"

--- a/data/institutions/ville_d_elbeuf.yml
+++ b/data/institutions/ville_d_elbeuf.yml
@@ -2,3 +2,4 @@ name: Ville d’Elbeuf
 imgSrc: img/logo_ville_elbeuf.jpg
 type: commune
 code_insee: "76231"
+code_siren: "217602317"

--- a/data/institutions/ville_daix.yml
+++ b/data/institutions/ville_daix.yml
@@ -2,3 +2,4 @@ name: Ville de Daix
 imgSrc: img/logo_daix.png
 type: commune
 code_insee: "21223"
+code_siren: "212102230"

--- a/data/institutions/ville_dardilly.yml
+++ b/data/institutions/ville_dardilly.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_dardilly.png
 prefix: de la
 type: commune
 code_insee: "69072"
+code_siren: "216900720"

--- a/data/institutions/ville_de_barentin.yml
+++ b/data/institutions/ville_de_barentin.yml
@@ -2,3 +2,4 @@ name: Ville de Barentin
 imgSrc: img/logo_barentin.jpg
 type: commune
 code_insee: "76057"
+code_siren: "217600576"

--- a/data/institutions/ville_de_blacé.yml
+++ b/data/institutions/ville_de_blacé.yml
@@ -2,3 +2,4 @@ name: Ville de Blacé
 imgSrc: img/logo_blace.png
 type: commune
 code_insee: "69023"
+code_siren: "216900233"

--- a/data/institutions/ville_de_drumettaz_clarafond.yml
+++ b/data/institutions/ville_de_drumettaz_clarafond.yml
@@ -2,3 +2,4 @@ name: Ville de Drumettaz-Clarafond
 imgSrc: img/logo_drumettaz.jpg
 type: commune
 code_insee: "73103"
+code_siren: "217301035"

--- a/data/institutions/ville_de_guichen_pont_rean.yml
+++ b/data/institutions/ville_de_guichen_pont_rean.yml
@@ -2,3 +2,4 @@ name: Ville de Guichen Pont-Réan
 imgSrc: img/logo_guichen_pont_rean.png
 type: commune
 code_insee: "35126"
+code_siren: "213501265"

--- a/data/institutions/ville_de_larcay.yml
+++ b/data/institutions/ville_de_larcay.yml
@@ -2,3 +2,4 @@ name: Ville de Larçay
 imgSrc: img/logo_ville_larcay.png
 type: commune
 code_insee: "37124"
+code_siren: "213701246"

--- a/data/institutions/ville_de_lescar.yml
+++ b/data/institutions/ville_de_lescar.yml
@@ -2,3 +2,4 @@ name: Ville de Lescar
 imgSrc: img/logo_lescar.jpg
 type: commune
 code_insee: "64335"
+code_siren: "216403352"

--- a/data/institutions/ville_de_louvigny.yml
+++ b/data/institutions/ville_de_louvigny.yml
@@ -2,3 +2,4 @@ name: Ville de Louvigny
 imgSrc: img/logo-louvigny.png
 type: commune
 code_insee: "14383"
+code_siren: "211403837"

--- a/data/institutions/ville_de_pavilly.yml
+++ b/data/institutions/ville_de_pavilly.yml
@@ -2,3 +2,4 @@ name: Ville de Pavilly
 imgSrc: img/logo_pavilly.png
 type: commune
 code_insee: "76495"
+code_siren: "217604958"

--- a/data/institutions/ville_de_rueil-malmaison.yml
+++ b/data/institutions/ville_de_rueil-malmaison.yml
@@ -2,3 +2,4 @@ name: Ville de Rueil-Malmaison
 imgSrc: img/logo_rueil_malmaison.png
 type: commune
 code_insee: "92063"
+code_siren: "219200631"

--- a/data/institutions/ville_de_sainghin_en_melantois.yml
+++ b/data/institutions/ville_de_sainghin_en_melantois.yml
@@ -2,3 +2,4 @@ name: Ville de Sainghin en Melantois
 imgSrc: img/logo_sainghin_en_melantois.png
 type: commune
 code_insee: "59523"
+code_siren: "215905233"

--- a/data/institutions/ville_de_saint_jean_de_vedas.yml
+++ b/data/institutions/ville_de_saint_jean_de_vedas.yml
@@ -2,3 +2,4 @@ name: Ville de Saint-Jean-de-Védas
 imgSrc: img/logo_saint_jean_de_vedas.png
 type: commune
 code_insee: "34270"
+code_siren: "213402704"

--- a/data/institutions/ville_de_saint_remy.yml
+++ b/data/institutions/ville_de_saint_remy.yml
@@ -2,3 +2,4 @@ name: Ville de Saint-Rémy
 imgSrc: img/logo_saint_remy.png
 type: commune
 code_insee: "71475"
+code_siren: "217104751"

--- a/data/institutions/ville_de_voglans.yml
+++ b/data/institutions/ville_de_voglans.yml
@@ -2,3 +2,4 @@ name: Ville de Voglans
 imgSrc: img/logo_voglans.png
 type: commune
 code_insee: "73329"
+code_siren: "217303296"

--- a/data/institutions/ville_deauville.yml
+++ b/data/institutions/ville_deauville.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_deauville.png
 prefix: de la
 type: commune
 code_insee: "14220"
+code_siren: "211402201"

--- a/data/institutions/ville_divonne_les_bains.yml
+++ b/data/institutions/ville_divonne_les_bains.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_divonne_les_bains.png
 prefix: de la
 type: commune
 code_insee: "01143"
+code_siren: "210101432"

--- a/data/institutions/ville_drancy.yml
+++ b/data/institutions/ville_drancy.yml
@@ -2,3 +2,4 @@ name: Ville de Drancy
 imgSrc: img/logo_drancy.png
 type: commune
 code_insee: "93029"
+code_siren: "219300290"

--- a/data/institutions/ville_dunkerque.yml
+++ b/data/institutions/ville_dunkerque.yml
@@ -2,3 +2,4 @@ name: Ville de Dunkerque
 imgSrc: img/logo_dunkerque.png
 type: commune
 code_insee: "59183"
+code_siren: "200027159"

--- a/data/institutions/ville_entzheim.yml
+++ b/data/institutions/ville_entzheim.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_entzheim.jpg
 prefix: de la
 type: commune
 code_insee: "67124"
+code_siren: "216701243"

--- a/data/institutions/ville_epernay.yml
+++ b/data/institutions/ville_epernay.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_epernay.png
 prefix: de la
 type: commune
 code_insee: "51230"
+code_siren: "215102120"

--- a/data/institutions/ville_evian_les_bains.yml
+++ b/data/institutions/ville_evian_les_bains.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_evian_les_bains.png
 prefix: de la
 type: commune
 code_insee: "74119"
+code_siren: "217401199"

--- a/data/institutions/ville_faches_thumesnil.yml
+++ b/data/institutions/ville_faches_thumesnil.yml
@@ -2,3 +2,4 @@ name: Ville de Faches-Thumesnil
 imgSrc: img/logo_faches_thumesnil.png
 type: commune
 code_insee: "59220"
+code_siren: "215902206"

--- a/data/institutions/ville_figeac.yml
+++ b/data/institutions/ville_figeac.yml
@@ -2,3 +2,4 @@ name: Ville de Figeac
 imgSrc: img/logo_figeac.png
 type: commune
 code_insee: "46102"
+code_siren: "214601023"

--- a/data/institutions/ville_fontenay_sous_bois.yml
+++ b/data/institutions/ville_fontenay_sous_bois.yml
@@ -2,3 +2,4 @@ name: Ville de Fontenay-sous-Bois
 imgSrc: img/logo_fontenay_sous_bois.png
 type: commune
 code_insee: "94033"
+code_siren: "219400330"

--- a/data/institutions/ville_frejus.yml
+++ b/data/institutions/ville_frejus.yml
@@ -2,3 +2,4 @@ name: Ville de Fréjus
 imgSrc: img/logo_frejus.png
 type: commune
 code_insee: "83061"
+code_siren: "218300614"

--- a/data/institutions/ville_geispolsheim.yml
+++ b/data/institutions/ville_geispolsheim.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_geispolsheim.png
 prefix: de la
 type: commune
 code_insee: "67152"
+code_siren: "216701524"

--- a/data/institutions/ville_genneviliers.yml
+++ b/data/institutions/ville_genneviliers.yml
@@ -2,3 +2,4 @@ name: Ville de Genneviliers
 imgSrc: img/logo_gennevilliers.png
 type: commune
 code_insee: "92036"
+code_siren: "219200367"

--- a/data/institutions/ville_gouesnou.yml
+++ b/data/institutions/ville_gouesnou.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_gouesnou.png
 prefix: de la
 type: commune
 code_insee: "29061"
+code_siren: "212900617"

--- a/data/institutions/ville_grande_synthe.yml
+++ b/data/institutions/ville_grande_synthe.yml
@@ -2,3 +2,4 @@ name: Ville de Grande Synthe
 imgSrc: img/logo_grande_synthe.png
 type: commune
 code_insee: "59271"
+code_siren: "215902719"

--- a/data/institutions/ville_granville.yml
+++ b/data/institutions/ville_granville.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_granville.png
 prefix: de la
 type: commune
 code_insee: "50218"
+code_siren: "215002189"

--- a/data/institutions/ville_grentheville.yml
+++ b/data/institutions/ville_grentheville.yml
@@ -2,3 +2,4 @@ name: Ville de Grentheville
 imgSrc: img/logo_grentheville.png
 type: commune
 code_insee: "14319"
+code_siren: "211403191"

--- a/data/institutions/ville_gruson.yml
+++ b/data/institutions/ville_gruson.yml
@@ -2,3 +2,4 @@ name: Ville de Gruson
 imgSrc: img/logo_gruson.png
 type: commune
 code_insee: "59275"
+code_siren: "215902750"

--- a/data/institutions/ville_hangenbieten.yml
+++ b/data/institutions/ville_hangenbieten.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_hangenbieten.png
 prefix: de la
 type: commune
 code_insee: "67182"
+code_siren: "216701821"

--- a/data/institutions/ville_hem.yml
+++ b/data/institutions/ville_hem.yml
@@ -2,3 +2,4 @@ name: Ville de Hem
 imgSrc: img/logo_hem.png
 type: commune
 code_insee: "59299"
+code_siren: "215902990"

--- a/data/institutions/ville_herouville_saint_clair.yml
+++ b/data/institutions/ville_herouville_saint_clair.yml
@@ -2,3 +2,4 @@ name: Ville d’Hérouville Saint-Clair
 imgSrc: img/logo_herouville_saint_clair.png
 type: commune
 code_insee: "14327"
+code_siren: "211403274"

--- a/data/institutions/ville_ifs.yml
+++ b/data/institutions/ville_ifs.yml
@@ -2,3 +2,4 @@ name: Ville d’Ifs
 imgSrc: img/logo_ifs.png
 type: commune
 code_insee: "14341"
+code_siren: "211403415"

--- a/data/institutions/ville_illkirch_graffenstaden.yml
+++ b/data/institutions/ville_illkirch_graffenstaden.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_illkirch.png
 prefix: de la
 type: commune
 code_insee: "67218"
+code_siren: "216702183"

--- a/data/institutions/ville_istres.yml
+++ b/data/institutions/ville_istres.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_istres.png
 prefix: de la
 type: commune
 code_insee: "13047"
+code_siren: "211300470"

--- a/data/institutions/ville_iwuy.yml
+++ b/data/institutions/ville_iwuy.yml
@@ -2,3 +2,4 @@ name: Ville de Iwuy
 imgSrc: img/logo_iwuy.jpg
 type: commune
 code_insee: "59322"
+code_siren: "215903220"

--- a/data/institutions/ville_la_madeleine.yml
+++ b/data/institutions/ville_la_madeleine.yml
@@ -2,3 +2,4 @@ name: Ville de La Madeleine
 imgSrc: img/logo_la_madeleine.png
 type: commune
 code_insee: "59368"
+code_siren: "215903683"

--- a/data/institutions/ville_la_motte_servolex.yml
+++ b/data/institutions/ville_la_motte_servolex.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_la_motte_servolex.png
 prefix: de la
 type: commune
 code_insee: "73179"
+code_siren: "217301795"

--- a/data/institutions/ville_le_bourget_du_lac.yml
+++ b/data/institutions/ville_le_bourget_du_lac.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_le_bourget_du_lac.png
 prefix: de la
 type: commune
 code_insee: "73051"
+code_siren: "217300516"

--- a/data/institutions/ville_le_cateau.yml
+++ b/data/institutions/ville_le_cateau.yml
@@ -2,3 +2,4 @@ name: Ville de Le Cateau-Cambrésis
 imgSrc: img/logo_le_cateau.png
 type: commune
 code_insee: "59136"
+code_siren: "215901364"

--- a/data/institutions/ville_lempdes.yml
+++ b/data/institutions/ville_lempdes.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_lempdes.png
 prefix: de la
 type: commune
 code_insee: "63193"
+code_siren: "216301937"

--- a/data/institutions/ville_les_rues_des_vignes.yml
+++ b/data/institutions/ville_les_rues_des_vignes.yml
@@ -2,3 +2,4 @@ name: Ville de Les Rues-des-Vignes
 imgSrc: img/logo_les_rues_des_vignes.png
 type: commune
 code_insee: "59517"
+code_siren: "215905175"

--- a/data/institutions/ville_lezennes.yml
+++ b/data/institutions/ville_lezennes.yml
@@ -2,3 +2,4 @@ name: Ville de Lezennes
 imgSrc: img/logo_lezennes.png
 type: commune
 code_insee: "59346"
+code_siren: "215903469"

--- a/data/institutions/ville_lievin.yml
+++ b/data/institutions/ville_lievin.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_lievin.png
 prefix: de la
 type: commune
 code_insee: "62510"
+code_siren: "216205104"

--- a/data/institutions/ville_mandelieu_la_napoule.yml
+++ b/data/institutions/ville_mandelieu_la_napoule.yml
@@ -2,3 +2,4 @@ name: Ville de Mandelieu-La Napoule
 imgSrc: img/logo_mandelieu_la_napoule.png
 type: commune
 code_insee: "06079"
+code_siren: "210600797"

--- a/data/institutions/ville_marignier.yml
+++ b/data/institutions/ville_marignier.yml
@@ -2,3 +2,4 @@ name: Ville de Marignier
 imgSrc: img/logo_marignier.png
 type: commune
 code_insee: "74164"
+code_siren: "217401645"

--- a/data/institutions/ville_marquette_lez_lille.yml
+++ b/data/institutions/ville_marquette_lez_lille.yml
@@ -2,3 +2,4 @@ name: Ville de Marquette-lez-Lille
 imgSrc: img/logo_marquette_lez_lille.png
 type: commune
 code_insee: "59386"
+code_siren: "215903865"

--- a/data/institutions/ville_martigues.yml
+++ b/data/institutions/ville_martigues.yml
@@ -2,3 +2,4 @@ name: Ville de Martigues
 imgSrc: img/logo_martigues.png
 type: commune
 code_insee: "13056"
+code_siren: "211300561"

--- a/data/institutions/ville_mer.yml
+++ b/data/institutions/ville_mer.yml
@@ -2,3 +2,4 @@ name: Ville de Mer
 imgSrc: img/logo_mer.png
 type: commune
 code_insee: "41136"
+code_siren: "214101362"

--- a/data/institutions/ville_merignac.yml
+++ b/data/institutions/ville_merignac.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_merignac.png
 prefix: de la
 type: commune
 code_insee: "33281"
+code_siren: "213302813"

--- a/data/institutions/ville_meyreuil.yml
+++ b/data/institutions/ville_meyreuil.yml
@@ -2,3 +2,4 @@ name: Ville de Meyreuil
 imgSrc: img/logo_meyreuil.png
 type: commune
 code_insee: "13060"
+code_siren: "211300603"

--- a/data/institutions/ville_mondeville.yml
+++ b/data/institutions/ville_mondeville.yml
@@ -2,3 +2,4 @@ name: Ville de Mondeville
 imgSrc: img/logo_mondeville.png
 type: commune
 code_insee: "14437"
+code_siren: "211404371"

--- a/data/institutions/ville_mons_en_baroeul.yml
+++ b/data/institutions/ville_mons_en_baroeul.yml
@@ -2,3 +2,4 @@ name: Ville de Mons-en-Barœul
 imgSrc: img/logo_mons_en_baroeul.png
 type: commune
 code_insee: "59410"
+code_siren: "215904103"

--- a/data/institutions/ville_montbeliard.yml
+++ b/data/institutions/ville_montbeliard.yml
@@ -2,3 +2,4 @@ name: Ville de Montbéliard
 imgSrc: img/logo_montbeliard.png
 type: commune
 code_insee: "25388"
+code_siren: "212503882"

--- a/data/institutions/ville_montlouis_sur_loire.yml
+++ b/data/institutions/ville_montlouis_sur_loire.yml
@@ -2,3 +2,4 @@ name: Ville de Montlouis-sur-Loire
 imgSrc: img/logo_montlouis_sur_loire.png
 type: commune
 code_insee: "37156"
+code_siren: "213701568"

--- a/data/institutions/ville_montval_sur_loir.yml
+++ b/data/institutions/ville_montval_sur_loir.yml
@@ -2,3 +2,4 @@ name: Ville de Montval-sur-Loir
 imgSrc: img/logo_chateau_du_loir.png
 type: commune
 code_insee: "72071"
+code_siren: "200063196"

--- a/data/institutions/ville_mornant.yml
+++ b/data/institutions/ville_mornant.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_mornant.png
 prefix: de la
 type: commune
 code_insee: "69141"
+code_siren: "216901413"

--- a/data/institutions/ville_mougins.yml
+++ b/data/institutions/ville_mougins.yml
@@ -2,3 +2,4 @@ name: Ville de Mougins
 imgSrc: img/logo_mougins.png
 type: commune
 code_insee: "06085"
+code_siren: "210600854"

--- a/data/institutions/ville_nanterre.yml
+++ b/data/institutions/ville_nanterre.yml
@@ -2,3 +2,4 @@ name: Ville de Nanterre
 imgSrc: img/logo_nanterre.png
 type: commune
 code_insee: "92050"
+code_siren: "219200508"

--- a/data/institutions/ville_ouistreham_riva_bella.yml
+++ b/data/institutions/ville_ouistreham_riva_bella.yml
@@ -2,3 +2,4 @@ name: Ville de Ouistreham Riva-Bella
 imgSrc: img/logo_ouistreham_riva_bella.png
 type: commune
 code_insee: "14488"
+code_siren: "211404884"

--- a/data/institutions/ville_pantin.yml
+++ b/data/institutions/ville_pantin.yml
@@ -2,3 +2,4 @@ name: Ville de Pantin
 imgSrc: img/logo_pantin.png
 type: commune
 code_insee: "93055"
+code_siren: "219300555"

--- a/data/institutions/ville_perros_guirec.yml
+++ b/data/institutions/ville_perros_guirec.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_perros_guirec.png
 prefix: de la
 type: commune
 code_insee: "22168"
+code_siren: "212201685"

--- a/data/institutions/ville_plobsheim.yml
+++ b/data/institutions/ville_plobsheim.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_plobsheim.jpg
 prefix: de la
 type: commune
 code_insee: "67378"
+code_siren: "216703785"

--- a/data/institutions/ville_ploemeur.yml
+++ b/data/institutions/ville_ploemeur.yml
@@ -2,3 +2,4 @@ name: Ville de Ploemeur
 imgSrc: img/logo_ploemeur.png
 type: commune
 code_insee: "56162"
+code_siren: "215601626"

--- a/data/institutions/ville_plougastel_daoulas.yml
+++ b/data/institutions/ville_plougastel_daoulas.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_plougastel_daoulas.jpg
 prefix: de la
 type: commune
 code_insee: "29189"
+code_siren: "212901896"

--- a/data/institutions/ville_plouzane.yml
+++ b/data/institutions/ville_plouzane.yml
@@ -2,3 +2,4 @@ name: Ville de Plouzané
 imgSrc: img/logo_plouzane.png
 type: commune
 code_insee: "29212"
+code_siren: "212902126"

--- a/data/institutions/ville_quesnoy_sur_deule.yml
+++ b/data/institutions/ville_quesnoy_sur_deule.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_quesnoy_sur_deule.png
 prefix: de la
 type: commune
 code_insee: "59482"
+code_siren: "215904822"

--- a/data/institutions/ville_queven.yml
+++ b/data/institutions/ville_queven.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_queven.png
 prefix: de la
 type: commune
 code_insee: "56185"
+code_siren: "215601857"

--- a/data/institutions/ville_reims.yml
+++ b/data/institutions/ville_reims.yml
@@ -2,3 +2,4 @@ name: Ville de Reims
 imgSrc: img/logo_reims.png
 type: commune
 code_insee: "51454"
+code_siren: "215104217"

--- a/data/institutions/ville_rivery.yml
+++ b/data/institutions/ville_rivery.yml
@@ -2,3 +2,4 @@ name: Ville de Rivery
 imgSrc: img/logo_rivery.png
 type: commune
 code_insee: "80674"
+code_siren: "218006344"

--- a/data/institutions/ville_romagnat.yml
+++ b/data/institutions/ville_romagnat.yml
@@ -2,3 +2,4 @@ name: Ville de Romagnat
 imgSrc: img/logo_romagnat.png
 type: commune
 code_insee: "63307"
+code_siren: "216303073"

--- a/data/institutions/ville_ronchin.yml
+++ b/data/institutions/ville_ronchin.yml
@@ -2,3 +2,4 @@ name: Ville de Ronchin
 imgSrc: img/logo_ronchin.png
 type: commune
 code_insee: "59507"
+code_siren: "215905076"

--- a/data/institutions/ville_sable_sur_sarthe.yml
+++ b/data/institutions/ville_sable_sur_sarthe.yml
@@ -2,3 +2,4 @@ name: Ville de Sablé-sur-Sarthe
 imgSrc: img/logo_sable_sur_sarthe.png
 type: commune
 code_insee: "72264"
+code_siren: "217202647"

--- a/data/institutions/ville_saint_germain_la_blanche_herbe.yml
+++ b/data/institutions/ville_saint_germain_la_blanche_herbe.yml
@@ -2,3 +2,4 @@ name: Ville de Saint-Germain la Blanche Herbe
 imgSrc: img/logo_saint_germain_la_blanche_herbe.png
 type: commune
 code_insee: "14587"
+code_siren: "211405873"

--- a/data/institutions/ville_saint_jacques_de_la_lande.yml
+++ b/data/institutions/ville_saint_jacques_de_la_lande.yml
@@ -2,3 +2,4 @@ name: Ville de Saint-Jacques de la Lande
 imgSrc: img/logo_saint_jacques_de-_la_lande.png
 type: commune
 code_insee: "35281"
+code_siren: "213502818"

--- a/data/institutions/ville_saint_louis.yml
+++ b/data/institutions/ville_saint_louis.yml
@@ -2,3 +2,4 @@ name: Ville de Saint-Louis
 imgSrc: img/logo_ville_saint_louis.jpg
 type: commune
 code_insee: "97414"
+code_siren: "219740149"

--- a/data/institutions/ville_saint_martin_de_crau.yml
+++ b/data/institutions/ville_saint_martin_de_crau.yml
@@ -2,3 +2,4 @@ name: Ville de Saint-Martin-de-Crau
 imgSrc: img/logo_saint_martin_de_crau.png
 type: commune
 code_insee: "13097"
+code_siren: "211300975"

--- a/data/institutions/ville_saint_pol_de_leon.yml
+++ b/data/institutions/ville_saint_pol_de_leon.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_saint_pol_de_leon.png
 prefix: de la
 type: commune
 code_insee: "29259"
+code_siren: "212902597"

--- a/data/institutions/ville_sainte_foy_les_lyon.yml
+++ b/data/institutions/ville_sainte_foy_les_lyon.yml
@@ -2,3 +2,4 @@ name: Ville de Sainte Foy-Lès-Lyon
 imgSrc: img/logo_sainte_foy_les_lyon.png
 type: commune
 code_insee: "69202"
+code_siren: "216902023"

--- a/data/institutions/ville_sarlat.yml
+++ b/data/institutions/ville_sarlat.yml
@@ -2,3 +2,4 @@ name: Ville de Sarlat
 imgSrc: img/logo_sarlat.png
 type: commune
 code_insee: "24520"
+code_siren: "212405203"

--- a/data/institutions/ville_talant.yml
+++ b/data/institutions/ville_talant.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_talant.png
 prefix: de la
 type: commune
 code_insee: "21617"
+code_siren: "212106173"

--- a/data/institutions/ville_thiais.yml
+++ b/data/institutions/ville_thiais.yml
@@ -2,3 +2,4 @@ name: Ville de Thiais
 imgSrc: img/logo_thiais.png
 type: commune
 code_insee: "94073"
+code_siren: "219400736"

--- a/data/institutions/ville_thionville.yml
+++ b/data/institutions/ville_thionville.yml
@@ -2,3 +2,4 @@ name: Ville de Thionville
 imgSrc: img/logo_thionville.png
 type: commune
 code_insee: "57672"
+code_siren: "215706722"

--- a/data/institutions/ville_trouville_sur_mer.yml
+++ b/data/institutions/ville_trouville_sur_mer.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_trouville_sur_mer.png
 prefix: de la
 type: commune
 code_insee: "14715"
+code_siren: "211407150"

--- a/data/institutions/ville_unieux.yml
+++ b/data/institutions/ville_unieux.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_unieux.jpg
 prefix: de la
 type: commune
 code_insee: "42316"
+code_siren: "214203168"

--- a/data/institutions/ville_vaucresson.yml
+++ b/data/institutions/ville_vaucresson.yml
@@ -2,3 +2,4 @@ name: Ville de Vaucresson
 imgSrc: img/ville_vaucresson.png
 type: commune
 code_insee: "92076"
+code_siren: "219200763"

--- a/data/institutions/ville_vauvert.yml
+++ b/data/institutions/ville_vauvert.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_vauvert.png
 prefix: de la
 type: commune
 code_insee: "30341"
+code_siren: "213003411"

--- a/data/institutions/ville_vendenheim.yml
+++ b/data/institutions/ville_vendenheim.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_vendenheim.jpg
 prefix: de la
 type: commune
 code_insee: "67506"
+code_siren: "216705061"

--- a/data/institutions/ville_verson.yml
+++ b/data/institutions/ville_verson.yml
@@ -2,3 +2,4 @@ name: Ville de Verson
 imgSrc: img/logo_verson.png
 type: commune
 code_insee: "14738"
+code_siren: "211407382"

--- a/data/institutions/ville_vif.yml
+++ b/data/institutions/ville_vif.yml
@@ -2,3 +2,4 @@ name: Ville de Vif
 imgSrc: img/logo_vif.png
 type: commune
 code_insee: "38545"
+code_siren: "213805450"

--- a/data/institutions/ville_wasquehal.yml
+++ b/data/institutions/ville_wasquehal.yml
@@ -2,3 +2,4 @@ name: Ville de Wasquehal
 imgSrc: img/logo_wasquehal.png
 type: commune
 code_insee: "59646"
+code_siren: "215906462"

--- a/data/institutions/ville_wasselonne.yml
+++ b/data/institutions/ville_wasselonne.yml
@@ -3,3 +3,4 @@ imgSrc: img/logo_ville_wasselonne.png
 prefix: de la
 type: commune
 code_insee: "67520"
+code_siren: "216705202"

--- a/tests/integration/benefits-description.spec.js
+++ b/tests/integration/benefits-description.spec.js
@@ -39,6 +39,11 @@ describe("benefit descriptions", function () {
             institution.code_insee
           )
         })
+
+        it("should have a code_siren", function () {
+          expect(typeof institution.code_siren).toBe("string")
+          expect(institution.code_siren).toMatch(/^(1|2){1}[0-9]{8}$/)
+        })
       } else if (institution.type == "epci") {
         it("should have a code_siren", function () {
           expect(typeof institution.code_siren).toBe("string")
@@ -50,7 +55,7 @@ describe("benefit descriptions", function () {
             institution.code_siren
           )
         })
-      } else if (institution.type == "caf") {
+      } else {
         it("should have a code_siren", function () {
           expect(typeof institution.code_siren).toBe("string")
           expect(institution.code_siren).toMatch(/^[1-9]{1}[0-9]{8}$/)


### PR DESCRIPTION
- J'ai mis à jour la config de l'outil de contrib mais sans imposer la présence du code SIREN (pour permettre l'enregistrement des autres infos saisies)
- j'ai pas trouvé de vrais SIRENS pour 3 institutions (état, départements, départements et métropoles)
