### PR TITLE
Correction bug simulation sans depcom

### DIFF
--- a/lib/benefits/compute.ts
+++ b/lib/benefits/compute.ts
@@ -117,8 +117,8 @@ export function computeAides(situation, id, openfiscaResponse, showPrivate) {
 
       const dest = value ? result.droitsEligibles : result.droitsNonEligibles
       const customization =
-        benefit.customization?.[customizationIds[1]] ||
-        benefit.customization?.[customizationIds[0]]
+        benefit.customization?.[customizationIds?.[1]] ||
+        benefit.customization?.[customizationIds?.[0]]
       const institution = customization?.institution
         ? {
             ...benefit.institution,


### PR DESCRIPTION
Suite à la migration ESM https://github.com/betagouv/aides-jeunes/commit/8a430ffae39c6a9bdf803409d11719c9377fa229
la fonction compute ne fonctionne plus si `depcom` n'est pas renseigné.