### PR TITLE
chore: supprime variable affichée

### DIFF
--- a/src/views/simulation/resultats/lieux-generiques.vue
+++ b/src/views/simulation/resultats/lieux-generiques.vue
@@ -6,8 +6,6 @@
       >
     </router-link>
 
-    {{ store.situation }}
-
     <p v-show="updating">
       <i class="fa fa-spinner fa-spin" aria-hidden="true" /> Récupération en
       cours…


### PR DESCRIPTION
## Description

Un objet était affichée directement sur une page : 
![image](https://user-images.githubusercontent.com/16650011/183865830-3086518e-7895-477a-adcd-60e021ede669.png)
