### PR TITLE
Corrige le titre HTML des pages lorsque l'aide est manquante

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -290,12 +290,14 @@ const router = createRouter({
             ),
           meta: {
             headTitle: (params) => {
-              const droitLabel = `${benefits[params.droitId].label}`
-              return benefits[params.droitId]?.label
-                ? droitLabel.charAt(0).toUpperCase() +
-                    droitLabel.slice(1) +
-                    ` - Ma simulation d'aides ${context.name}`
-                : process.env.VUE_APP_TITLE
+              if (benefits[params.droitId]) {
+                const droitLabel = `${benefits[params.droitId].label}`
+                return `${droitLabel.charAt(0).toUpperCase()}${droitLabel.slice(
+                  1
+                )} - Ma simulation d'aides ${context.name}`
+              } else {
+                return process.env.VUE_APP_TITLE
+              }
             },
           },
         },


### PR DESCRIPTION
# Détails

Corrige le bug listé par sentry : [TypeError getTitleMeta(src/router)](https://sentry.incubateur.net/organizations/betagouv/issues/2978/?project=18&query=is%3Aunresolved)

Pour le reproduire il faut effectuer une simulation permettant l'obtention du FSL et aller sur la page détail de l'aide FSL en fin de simulation.