### PR TITLE
[WIP] Réduction des consoles logs dans les tests unitaires

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
       "jest-serializer-vue"
     ],
     "testMatch": [
-      "**/tests/(integration|unit)/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)"
+      "**/tests/(integration|unit)/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.spec.(js|jsx|ts|tsx)"
     ],
     "testURL": "http://localhost/",
     "watchPlugins": [

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
       "jest-serializer-vue"
     ],
     "testMatch": [
-      "**/tests/(integration|unit)/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.spec.(js|jsx|ts|tsx)"
+      "**/tests/(integration|unit)/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)"
     ],
     "testURL": "http://localhost/",
     "watchPlugins": [

--- a/tools/test-benefits-geographical-constraint-consistency.ts
+++ b/tools/test-benefits-geographical-constraint-consistency.ts
@@ -9,13 +9,13 @@ benefits.all
     )
   })
   .forEach((benefit) => {
-    const result = testGeographicalRelevancy(benefit)
-    if (!result?.isValid) {
+    const { conditionFound, isValid, conditions } =
+      testGeographicalRelevancy(benefit)
+    if (conditionFound && !isValid) {
       console.log("================================")
       console.log(`Benefit : ${benefit.id}`)
       console.log(`Insee code : ${benefit.institution.code_insee}`)
-      console.log("potentially incompatible with conditions :")
-      console.log(result?.conditions)
+      console.log("potentially incompatible with conditions :", conditions)
     }
   })
 
@@ -30,6 +30,7 @@ function testGeographicalRelevancy(benefit) {
   })
   if (conditionGeo) {
     return {
+      conditionFound: true,
       isValid:
         conditionGeo.values.length == 1 &&
         conditionGeo.values[0] === benefit.institution.code_insee &&
@@ -37,6 +38,7 @@ function testGeographicalRelevancy(benefit) {
       conditions: conditionGeo,
     }
   }
+  return { conditionFound: false, isValid: false, conditions: null }
 }
 
 export default testGeographicalRelevancy


### PR DESCRIPTION
[Ticket](https://trello.com/c/ATZQkjKr/907-nettoyer-les-consolelog-dans-les-tests)

Les TU génèrent des logs en cas d'erreurs pour certains types de conditions_generales.

Le problème est que de nouveaux types ont été créé entre temps et les logs s'affichent pour ces nouveau types quoi qu'il arrive