### PR TITLE
fix: downgrade ts-jest pour éviter un conflit de dépendances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "mustache": "^4.2.0",
         "prettier": "^2.5.1",
         "pretty-quick": "^3.1.2",
-        "ts-jest": "^28.0.5",
+        "ts-jest": "^27.1.4",
         "typescript": "^4.7.4",
         "webpack": "^5.64.3",
         "webpack-bundle-analyzer": "^4.5.0"
@@ -1196,17 +1196,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jest/schemas": {
-      "version": "28.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.23.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
     "node_modules/@jest/source-map": {
       "version": "27.4.0",
       "dev": true,
@@ -1318,7 +1307,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -1334,7 +1322,6 @@
       "version": "4.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1350,7 +1337,6 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1359,7 +1345,6 @@
       "version": "7.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1767,11 +1752,6 @@
         "vue-router": "3.x || 4.x"
       }
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.23.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "dev": true,
@@ -1969,6 +1949,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "peer": true
+    },
     "node_modules/@types/node": {
       "version": "17.0.34",
       "license": "MIT"
@@ -2065,7 +2051,6 @@
       "version": "16.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -8666,7 +8651,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "^27.5.1",
         "@types/node": "*",
@@ -8683,7 +8667,6 @@
       "version": "4.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -8698,14 +8681,12 @@
     "node_modules/jest-util/node_modules/ci-info": {
       "version": "3.2.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-util/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8714,7 +8695,6 @@
       "version": "7.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -12263,33 +12243,38 @@
       "license": "MIT"
     },
     "node_modules/ts-jest": {
-      "version": "28.0.5",
+      "version": "27.1.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.5.tgz",
+      "integrity": "sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
-        "jest-util": "^28.0.0",
-        "json5": "^2.2.1",
+        "jest-util": "^27.0.0",
+        "json5": "2.x",
         "lodash.memoize": "4.x",
         "make-error": "1.x",
         "semver": "7.x",
-        "yargs-parser": "^21.0.1"
+        "yargs-parser": "20.x"
       },
       "bin": {
         "ts-jest": "cli.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "babel-jest": "^28.0.0",
-        "jest": "^28.0.0",
-        "typescript": ">=4.3"
+        "@types/jest": "^27.0.0",
+        "babel-jest": ">=27.0.0 <28",
+        "jest": "^27.0.0",
+        "typescript": ">=3.8 <5.0"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
+          "optional": true
+        },
+        "@types/jest": {
           "optional": true
         },
         "babel-jest": {
@@ -12298,74 +12283,6 @@
         "esbuild": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ts-jest/node_modules/@jest/types": {
-      "version": "28.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^28.0.2",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/ts-jest/node_modules/@types/yargs": {
-      "version": "17.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/ts-jest/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ts-jest/node_modules/ci-info": {
-      "version": "3.3.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ts-jest/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ts-jest/node_modules/jest-util": {
-      "version": "28.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^28.1.1",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
     "node_modules/ts-jest/node_modules/lru-cache": {
@@ -12393,29 +12310,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/ts-jest/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ts-jest/node_modules/yallist": {
       "version": "4.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ts-jest/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/tsconfig": {
       "version": "7.0.0",
@@ -14403,13 +14301,6 @@
         }
       }
     },
-    "@jest/schemas": {
-      "version": "28.0.2",
-      "dev": true,
-      "requires": {
-        "@sinclair/typebox": "^0.23.3"
-      }
-    },
     "@jest/source-map": {
       "version": "27.4.0",
       "dev": true,
@@ -14491,7 +14382,6 @@
     "@jest/types": {
       "version": "27.5.1",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -14503,7 +14393,6 @@
         "chalk": {
           "version": "4.1.2",
           "dev": true,
-          "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -14511,13 +14400,11 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "dev": true,
-          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -14821,10 +14708,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "@sinclair/typebox": {
-      "version": "0.23.4",
-      "dev": true
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "dev": true,
@@ -14993,6 +14876,12 @@
       "version": "3.0.5",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "peer": true
+    },
     "@types/node": {
       "version": "17.0.34"
     },
@@ -15075,7 +14964,6 @@
     "@types/yargs": {
       "version": "16.0.4",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -19219,7 +19107,6 @@
     "jest-util": {
       "version": "27.5.1",
       "dev": true,
-      "peer": true,
       "requires": {
         "@jest/types": "^27.5.1",
         "@types/node": "*",
@@ -19232,7 +19119,6 @@
         "chalk": {
           "version": "4.1.2",
           "dev": true,
-          "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -19240,18 +19126,15 @@
         },
         "ci-info": {
           "version": "3.2.0",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "dev": true,
-          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -21596,66 +21479,21 @@
       "version": "0.0.3"
     },
     "ts-jest": {
-      "version": "28.0.5",
+      "version": "27.1.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.5.tgz",
+      "integrity": "sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
-        "jest-util": "^28.0.0",
-        "json5": "^2.2.1",
+        "jest-util": "^27.0.0",
+        "json5": "2.x",
         "lodash.memoize": "4.x",
         "make-error": "1.x",
         "semver": "7.x",
-        "yargs-parser": "^21.0.1"
+        "yargs-parser": "20.x"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "28.1.1",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^28.0.2",
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^17.0.8",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "17.0.10",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "ci-info": {
-          "version": "3.3.2",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "jest-util": {
-          "version": "28.1.1",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^28.1.1",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "ci-info": "^3.2.0",
-            "graceful-fs": "^4.2.9",
-            "picomatch": "^2.2.3"
-          }
-        },
         "lru-cache": {
           "version": "6.0.0",
           "dev": true,
@@ -21670,19 +21508,8 @@
             "lru-cache": "^6.0.0"
           }
         },
-        "supports-color": {
-          "version": "7.2.0",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
         "yallist": {
           "version": "4.0.0",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "21.0.1",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "mustache": "^4.2.0",
     "prettier": "^2.5.1",
     "pretty-quick": "^3.1.2",
-    "ts-jest": "^28.0.5",
+    "ts-jest": "^27.1.4",
     "typescript": "^4.7.4",
     "webpack": "^5.64.3",
     "webpack-bundle-analyzer": "^4.5.0"


### PR DESCRIPTION
## Description

La version de npm sur la CI échoue à installer plusieurs versions de `ts-jest` :  
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @vue/vue3-jest@27.0.0
npm ERR! Found: ts-jest@28.0.5
npm ERR! node_modules/ts-jest
npm ERR!   dev ts-jest@"^28.0.5" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peerOptional ts-jest@"27.x" from @vue/vue3-jest@27.0.0
npm ERR! node_modules/@vue/vue3-jest
npm ERR!   dev @vue/vue3-jest@"^27.0.0" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: ts-jest@27.1.5
npm ERR! node_modules/ts-jest
npm ERR!   peerOptional ts-jest@"27.x" from @vue/vue3-jest@27.0.0
npm ERR!   node_modules/@vue/vue3-jest
npm ERR!     dev @vue/vue3-jest@"^27.0.0" from the root project
```

Pour éviter d'avoir à restreindre la version de npm à nouveau je propose de revenir à une version précédente de ts-jest.