### PR TITLE
[964] Fix: corrige l'invocation du module feedback lorsque le droit associé n'est pas chargé

### DIFF
--- a/src/views/simulation/resultats-detail.vue
+++ b/src/views/simulation/resultats-detail.vue
@@ -27,7 +27,7 @@
     </div>
 
     <div class="aj-box normal-padding-bottom aj-results-details-feedback-box">
-      <Feedback />
+      <Feedback v-if="droit" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Détails

[Carte trello](https://trello.com/c/oIq4iArm/964-erreur-sur-le-module-feedback)

Ce bug se produit lorsqu'un utilisateur arrive sur la page de résultat et ouvre le détail d'une aide dans un nouvel onglet. Celui-ci se charge mais le module `Feedback` était affiché alors que le détail de l'aide n'était pas encore chargé, remontant une erreur à Sentry (sans impact pour l'utilisateur)

## Erreurs Sentry
https://sentry.incubateur.net/organizations/betagouv/issues/7707/?project=18&query=is%3Aunresolved
https://sentry.incubateur.net/organizations/betagouv/issues/7704/?project=18&query=is%3Aunresolved
https://sentry.incubateur.net/organizations/betagouv/issues/7709/?project=18&query=is%3Aunresolved
https://sentry.incubateur.net/organizations/betagouv/issues/7708/?project=18&query=is%3Aunresolved
https://sentry.incubateur.net/organizations/betagouv/issues/7523/?project=18&query=is%3Aunresolved
https://sentry.incubateur.net/organizations/betagouv/issues/7522/?project=18&query=is%3Aunresolved
https://sentry.incubateur.net/organizations/betagouv/issues/7705/?project=18&query=is%3Aunresolved
https://sentry.incubateur.net/organizations/betagouv/issues/7527/?project=18&query=is%3Aunresolved