### PR TITLE
Bugfix: hide le bouton SendRecapEmailButton si pas d'aide

### DIFF
--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -10,7 +10,7 @@
       </div>
     </div>
     <SendRecapEmailButton
-      v-if="DroitsList"
+      v-if="shouldDisplayResults && hasDroits"
       class="recap-email-button outline"
       text="Recevoir les résultats par email"
     ></SendRecapEmailButton>
@@ -22,11 +22,12 @@ import Chapters from "@lib/chapters"
 import MenuButton from "@/components/buttons/menu-button.vue"
 import SendRecapEmailButton from "@/components/buttons/send-recap-email-button.vue"
 import { useStore } from "@/stores"
-import DroitsList from "@/components/droits-list.vue"
+import ResultatsMixin from "@/mixins/resultats"
 
 export default {
   name: "TitreChapitre",
   components: { SendRecapEmailButton, MenuButton },
+  mixins: [ResultatsMixin],
   setup() {
     return {
       store: useStore(),

--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -10,6 +10,7 @@
       </div>
     </div>
     <SendRecapEmailButton
+      v-if="DroitsList"
       class="recap-email-button outline"
       text="Recevoir les résultats par email"
     ></SendRecapEmailButton>
@@ -21,6 +22,7 @@ import Chapters from "@lib/chapters"
 import MenuButton from "@/components/buttons/menu-button.vue"
 import SendRecapEmailButton from "@/components/buttons/send-recap-email-button.vue"
 import { useStore } from "@/stores"
+import DroitsList from "@/components/droits-list.vue"
 
 export default {
   name: "TitreChapitre",

--- a/src/mixins/resultats.js
+++ b/src/mixins/resultats.js
@@ -5,6 +5,9 @@ export default {
     droits() {
       return this.resultats?.droitsEligibles
     },
+    hasDroits() {
+      return this.droits.length > 0
+    },
     resultatsId() {
       return this.resultats?._id || "???"
     },


### PR DESCRIPTION
[Bugfix](https://trello.com/c/x1huG1YW/958-le-bouton-recevoir-les-r%C3%A9sultats-par-email-saffiche-sans-%C3%AAtre-fonctionnel-si-la-simulation-na-pas-calcul%C3%A9-daide) : 

ne pas afficher le bouton "Recevoir les résultats par email" s'il n'y a pas d'aides.

Aperçu: 
<img width="813" alt="Capture d’écran 2022-09-26 à 12 44 22" src="https://user-images.githubusercontent.com/52297439/192257612-db8bffa2-b046-4e31-8ec5-6388aceeac23.png">
