### PR TITLE
Ajout d'écriture inclusive sur la question "Enceinte"

### DIFF
--- a/lib/properties/individu-properties.ts
+++ b/lib/properties/individu-properties.ts
@@ -281,7 +281,7 @@ export default {
       return `${
         individu._role === "demandeur"
           ? "Êtes-vous enceint·e ?"
-          : "Est-ce que votre partenaire est enceint·e ?
+          : "Est-ce que votre partenaire est enceint·e ?"
       }`
     },
     questionType: "enum",


### PR DESCRIPTION
## Description

Suite à retour de test utilisateur, ajoute le terme "Enceint·e" et "Conjoint·e"