### PR TITLE
[FIX] ajoute le flag _interetBafa pour les aides bafa ne l'ayant pas

### DIFF
--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
@@ -19,6 +19,7 @@ conditions_generales:
     period: month
     floor: 800
 profils: []
+interestFlag: _interetBafa
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.
 type: float

--- a/data/benefits/javascript/caf-mayenne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-mayenne-aide-bafa-approfondissement.yml
@@ -12,6 +12,7 @@ conditions_generales:
     values:
       - "53"
 profils: []
+interestFlag: _interetBafa
 link: https://www.caf.fr/allocataires/caf-de-la-mayenne/offre-de-service/enfance-et-jeunesse/bafabafd-votre-caf-vous-aide
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres
 instructions: https://www.caf.fr/allocataires/caf-de-la-mayenne/offre-de-service/enfance-et-jeunesse/bafabafd-votre-caf-vous-aide

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
@@ -17,6 +17,7 @@ conditions_generales:
     period: month
     floor: 800
 profils: []
+interestFlag: _interetBafa
 link: https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/enfance-et-jeunesse/la-caf-peut-participer-au-financement-de-la-formation-au-bafa-ou-au-bafd
 instructions: https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/enfance-et-jeunesse/la-caf-peut-participer-au-financement-de-la-formation-au-bafa-ou-au-bafd
 prefix: l’


### PR DESCRIPTION
## Détails

Certaines aides pour le bafa n'avait pas l'indicateur `interestFlag: _interetBafa` et apparaissait indépendamment de l'intérêt de l'utilisateur