### PR TITLE
[974] corrige les aides définies comme undefined dans les messages de sondage

### DIFF
--- a/backend/lib/mattermost-bot/poll-result.ts
+++ b/backend/lib/mattermost-bot/poll-result.ts
@@ -22,7 +22,7 @@ function postPollResult(simulation, answers) {
   }
 
   const orderedAnswers: any[] = []
-  for (let answer of answers) {
+  for (const answer of answers) {
     const answerDetails =
       simulation.benefits.filter((benefit) => {
         return answer["id"] == benefit["id"]


### PR DESCRIPTION
## Détails

[Carte trello](https://trello.com/c/2PUGXP3p/974-les-r%C3%A9sultats-de-sondage-utilisateur-ne-saffiche-pas-correctement-pour-les-aides-nexistant-plus)