### PR TITLE
Change le label d'une aide BAFA pour permettre un retour à la ligne automatique

### DIFF
--- a/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
+++ b/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
@@ -1,5 +1,4 @@
-label:
-  Aides au BAFA et BAFD pour une formation générale, d'approfondissement ou
+label: Aides au BAFA et BAFD pour une formation générale, d'approfondissement ou
   de qualification
 institution: caf_ille_et_vilaine
 description: L'aide à la formation au BAFD est une aide locale mise à


### PR DESCRIPTION
## Détails

Suite à un retour RGAA, change le nom d'une aide qui ne permettait pas de retour à la ligne. À noter qu'une propriété CSS devra être adapté en conséquence pour éviter un problème similaire dans le future