### PR TITLE
Fix: typage app express

### DIFF
--- a/mock.ts
+++ b/mock.ts
@@ -40,7 +40,7 @@ const ID = function () {
   return `_${Math.random().toString(36).substr(2, 9)}`
 }
 
-function mock({ app }) {
+function mock(app: express.Application) {
   app.use(express.json())
 
   const cache = {}


### PR DESCRIPTION
Lors du lancement de `npm run front`le type de app dans le fichier mock.ts empêchait le lancement du front en local