### PR TITLE
Désactive le preventDefault du scroll sur les input de type number

### DIFF
--- a/src/components/input-number.vue
+++ b/src/components/input-number.vue
@@ -12,7 +12,6 @@
       :max="max"
       :step="step"
       :data-type="dataType"
-      :onWheel="(e) => e.preventDefault()"
     />
     <div v-if="error" class="text-red input-number-error">
       Ce champ n'est pas valide.


### PR DESCRIPTION
Désactive le preventDefault du scroll sur les input de type number. Testé sur navigateur Chromiun, Waterfox et Safari