### PR TITLE
Fix : config.yml ancre definie 2 fois

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -750,7 +750,7 @@ fields:
     label: Liens vers des formulaires de demande de l'aide
     name: forms
     widget: hidden
-  field_benefit_participation: &field_benefit_forms
+  field_benefit_participation: &field_benefit_participation
     label: Liens vers des formulaires de demande de l'aide
     name: forms
     widget: hidden


### PR DESCRIPTION
- Le fichier [contribuer/public/admin/config.yml](https://github.com/betagouv/aides-jeunes/compare/fix/config-double-ancre?expand=1#diff-8fd8fca48753315e30e7243a411e4719656bff43c15b02c297e7c3efaf5661a9) contient une double définiton d'ancre, voici une proposition pour régler le problème.