### PR TITLE
Ajout du lien des CGU dans l'iframe

### DIFF
--- a/src/components/iframe-layout.vue
+++ b/src/components/iframe-layout.vue
@@ -5,6 +5,12 @@
     <a href="https://www.1jeune1solution.gouv.fr/" target="_blank">
       la plateforme 1jeune1solution
     </a>
+    <p>Accédez à nos&nbsp;</p
+    ><a href="https://mes-aides.1jeune1solution.beta.gouv.fr/cgu">CGU</a>
+  </div>
+  <div id="iframe-footer">
+    <p>Accédez à nos&nbsp;</p
+    ><a href="https://mes-aides.1jeune1solution.beta.gouv.fr/cgu">CGU</a>
   </div>
 </template>
 

--- a/src/components/iframe-layout.vue
+++ b/src/components/iframe-layout.vue
@@ -5,8 +5,6 @@
     <a href="https://www.1jeune1solution.gouv.fr/" target="_blank">
       la plateforme 1jeune1solution
     </a>
-    <p>Accédez à nos&nbsp;</p
-    ><a href="https://mes-aides.1jeune1solution.beta.gouv.fr/cgu">CGU</a>
   </div>
   <div id="iframe-footer">
     <p>Accédez à nos&nbsp;</p

--- a/src/components/iframe-layout.vue
+++ b/src/components/iframe-layout.vue
@@ -1,12 +1,12 @@
 <template>
   <slot />
-  <div id="iframe-footer">
+  <div class="iframe-footer">
     <p>Simulateur propulsé par&nbsp;</p>
     <a href="https://www.1jeune1solution.gouv.fr/" target="_blank">
       la plateforme 1jeune1solution
     </a>
   </div>
-  <div id="iframe-footer">
+  <div class="iframe-footer">
     <p>Accédez à nos&nbsp;</p
     ><a href="https://mes-aides.1jeune1solution.beta.gouv.fr/cgu">CGU</a>
   </div>
@@ -24,7 +24,7 @@ body {
   height: unset !important;
 }
 
-#iframe-footer {
+.iframe-footer {
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
[Tâche Trello](https://trello.com/c/MxzGco7O/998-int%C3%A9grer-un-lien-vers-les-cgu-dans-la-page-diframe-pour-r%C3%A9pondre-%C3%A0-la-demande-de-ouest-france)

Avant : 
<img width="1438" alt="Capture d’écran 2022-10-26 à 09 54 38" src="https://user-images.githubusercontent.com/52297439/197967548-e8dc2283-fb21-4864-a3c6-d84b9249cb06.png">

Après : 
<img width="1432" alt="Capture d’écran 2022-10-26 à 09 55 23" src="https://user-images.githubusercontent.com/52297439/197967753-a0cd2e26-b54c-4031-8aed-a8cb68fc0b08.png">
