### PR TITLE
Ajoute un email de suivi permettant la capture l'utilité de la simulation via deux liens oui/non contenus dans l'email

### DIFF
--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -149,18 +149,21 @@ export function updateWasUseful(req: ajRequest, res: Response) {
       value: req.params.wasuseful,
     },
   ]
-  req.followup.updateSurvey("simulation-usefulness", answers).then(async () => {
-    const { followup } = req
-    let survey = followup.surveys.find(
-      (survey) => survey.type === "benefit-action"
-    )
-    if (!survey) {
-      console.log('creating survey "benefit-action"')
-      survey = await followup.createSurvey("benefit-action")
-      followup.surveys.push(survey)
-    }
-    followup.save().then(() => {
+  const { followup } = req
+  followup
+    .updateSurvey("simulation-usefulness", answers)
+    .then(() => {
+      let survey = followup.surveys.find(
+        (survey) => survey.type === "benefit-action"
+      )
+      if (survey) {
+        return res.redirect(`${config.baseURL}${followup.surveyPath}`)
+      }
+      return followup.createSurvey("benefit-action")
+    })
+    .then((survey) => followup.surveys.push(survey))
+    .then(() => followup.save())
+    .then(() => {
       res.redirect(`${config.baseURL}${followup.surveyPath}`)
     })
-  })
 }

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -139,7 +139,7 @@ export function postSurvey(req: ajRequest, res: Response) {
   req.followup.updateSurvey("benefit-action", req.body).then(() => {
     res.sendStatus(201)
   })
-  pollResult.postPollResult(followup, req.body)
+  pollResult.postPollResult(req.followup, req.body)
 }
 
 export function updateWasUseful(req: ajRequest, res: Response) {

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -153,16 +153,17 @@ export function updateWasUseful(req: ajRequest, res: Response) {
   followup
     .updateSurvey("simulation-usefulness", answers)
     .then(() => {
-      const survey = followup.surveys.find(
+      let survey = followup.surveys.find(
         (survey) => survey.type === "benefit-action"
       )
       if (survey) {
-        return res.redirect(`${config.baseURL}${followup.surveyPath}`)
+        return
       }
-      return followup.createSurvey("benefit-action")
+      return followup
+        .createSurvey("benefit-action")
+        .then((survey) => followup.surveys.push(survey))
+        .then(() => followup.save())
     })
-    .then((survey) => followup.surveys.push(survey))
-    .then(() => followup.save())
     .then(() => {
       res.redirect(`${config.baseURL}${followup.surveyPath}`)
     })

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -151,8 +151,14 @@ export function updateWasUseful(req: ajRequest, res: Response) {
   ]
   req.followup.updateSurvey("simulation-usefulness", answers).then(async () => {
     const { followup } = req
-    const survey = await followup.createSurvey("benefit-action")
-    followup.surveys.push(survey)
+    let survey = followup.surveys.find(
+      (survey) => survey.type === "benefit-action"
+    )
+    if (!survey) {
+      console.log('creating survey "benefit-action"')
+      survey = await followup.createSurvey("benefit-action")
+      followup.surveys.push(survey)
+    }
     followup.save().then(() => {
       res.redirect(`${config.baseURL}${followup.surveyPath}`)
     })

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -64,9 +64,8 @@ export function persist(req: ajRequest, res: Response) {
     })
 }
 
-export function showFromSurvey(req: ajRequest, res: Response) {
-  // TODO remove unecessary OR condition when tokens are widely used
-  Followup.findOne({ accessToken: req.params.surveyId }).then((followup) => {
+export function findFollowupByAccessToken(req: ajRequest, res: Response) {
+  Followup.findOne({ accessToken: req.params.accessToken }).then((followup) => {
     if (!followup) return res.sendStatus(404)
     res.send(followup)
   })

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -65,10 +65,7 @@ export function persist(req: ajRequest, res: Response) {
 }
 
 export function findFollowupByAccessToken(req: ajRequest, res: Response) {
-  Followup.findOne({ accessToken: req.params.accessToken }).then((followup) => {
-    if (!followup) return res.sendStatus(404)
-    res.send(followup)
-  })
+  res.send(req.followup)
 }
 
 export function showSurveyResult(req: ajRequest, res: Response) {

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -64,7 +64,7 @@ export function persist(req: ajRequest, res: Response) {
     })
 }
 
-export function findFollowupByAccessToken(req: ajRequest, res: Response) {
+export function getFollowup(req: ajRequest, res: Response) {
   res.send(req.followup)
 }
 
@@ -119,7 +119,7 @@ export function showSimulation(req: ajRequest, res: Response) {
     })
 }
 
-export async function getFollowup(
+export async function followupByAccessToken(
   req: ajRequest,
   res: Response,
   next: NextFunction,

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -153,7 +153,7 @@ export function updateWasUseful(req: ajRequest, res: Response) {
   followup
     .updateSurvey("simulation-usefulness", answers)
     .then(() => {
-      let survey = followup.surveys.find(
+      const survey = followup.surveys.find(
         (survey) => survey.type === "benefit-action"
       )
       if (survey) {

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -134,23 +134,21 @@ export async function getFollowup(
   next()
 }
 
-export async function postAnswersSurvey(req: ajRequest, res: Response) {
-  try {
-    await req.followup.addSurvey(req.body, "benefit-action")
+export function postSurvey(req: ajRequest, res: Response) {
+  req.followup.updateSurvey("benefit-action", req.body).then(() => {
     res.sendStatus(201)
-    pollResult.postPollResult(followup, req.body)
-  } catch (err) {
-    console.error(err)
-    res.sendStatus(400)
-  }
+  })
+  pollResult.postPollResult(followup, req.body)
 }
 
-export async function updateWasUseful(req: ajRequest, res: Response) {
-  try {
-    await req.followup.setWasUseful(req.params.wasuseful)
+export function updateWasUseful(req: ajRequest, res: Response) {
+  const answers = [
+    {
+      id: "wasUseful",
+      value: req.params.wasuseful,
+    },
+  ]
+  req.followup.updateSurvey("simulation-usefulness", answers).then(() => {
     res.sendStatus(200)
-  } catch (err) {
-    console.error(err)
-    res.sendStatus(400)
-  }
+  })
 }

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -150,7 +150,7 @@ export async function updateWasUseful(req: ajRequest, res: Response) {
   ]
   const { followup } = req
   await followup.updateSurvey("simulation-usefulness", answers)
-  let survey = followup.surveys.find(
+  const survey = followup.surveys.find(
     (survey) => survey.type === "benefit-action"
   )
   if (!survey) {

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -5,6 +5,7 @@ import pollResult from "../lib/mattermost-bot/poll-result"
 import simulationController from "./simulation"
 import { Response, NextFunction } from "express"
 import { ajRequest } from "../types/express"
+import config from "../config/index"
 
 // TODO next line is to be updated once tokens are used globally
 const excludeFields = ["accessToken", "surveys.accessToken"]
@@ -148,7 +149,12 @@ export function updateWasUseful(req: ajRequest, res: Response) {
       value: req.params.wasuseful,
     },
   ]
-  req.followup.updateSurvey("simulation-usefulness", answers).then(() => {
-    res.sendStatus(200)
+  req.followup.updateSurvey("simulation-usefulness", answers).then(async () => {
+    const { followup } = req
+    const survey = await followup.createSurvey("benefit-action")
+    followup.surveys.push(survey)
+    followup.save().then(() => {
+      res.redirect(`${config.baseURL}${followup.surveyPath}`)
+    })
   })
 }

--- a/backend/followups.ts
+++ b/backend/followups.ts
@@ -1,6 +1,5 @@
 import express from "express"
 import { followup, resultRedirect } from "./controllers/followups"
-import { ajRequest } from "./types/express"
 
 // Setup Express
 const app = express()

--- a/backend/followups.ts
+++ b/backend/followups.ts
@@ -15,22 +15,6 @@ if (app.get("env") === "development") {
       .renderSimulationResultsEmail()
       .then((render: any) => res.send(render.html))
   })
-  router.get(
-    "/:followupId/simulation-usefulness-survey.html",
-    (req: ajRequest, res) => {
-      req.followup
-        .renderSimulationUsefulnessSurveyEmail({ returnPath: "/returnPath" })
-        .then((render: any) => res.send(render.html))
-    }
-  )
-  router.get(
-    "/:followupId/benefit-action-survey.html",
-    (req: ajRequest, res) => {
-      req.followup
-        .renderBenefitActionSurveyEmail({ returnPath: "/returnPath" })
-        .then((render: any) => res.send(render.html))
-    }
-  )
 }
 app.use(router)
 

--- a/backend/followups.ts
+++ b/backend/followups.ts
@@ -8,30 +8,6 @@ const router = express.Router()
 
 router.param("followupId", followup)
 router.get("/:followupId", resultRedirect)
-
-if (app.get("env") === "development") {
-  router.get("/:followupId/simulation-results.html", (req: ajRequest, res) => {
-    req.followup
-      .renderSimulationResultsEmail()
-      .then((render: any) => res.send(render.html))
-  })
-  router.get(
-    "/:followupId/simulation-usefulness-survey.html",
-    (req: ajRequest, res) => {
-      req.followup
-        .renderSimulationUsefulnessSurveyEmail({ returnPath: "/returnPath" })
-        .then((render: any) => res.send(render.html))
-    }
-  )
-  router.get(
-    "/:followupId/benefit-action-survey.html",
-    (req: ajRequest, res) => {
-      req.followup
-        .renderBenefitActionSurveyEmail({ returnPath: "/returnPath" })
-        .then((render: any) => res.send(render.html))
-    }
-  )
-}
 app.use(router)
 
 export default app

--- a/backend/followups.ts
+++ b/backend/followups.ts
@@ -16,6 +16,14 @@ if (app.get("env") === "development") {
       .then((render: any) => res.send(render.html))
   })
   router.get(
+    "/:followupId/simulation-usefulness-survey.html",
+    (req: ajRequest, res) => {
+      req.followup
+        .renderSimulationUsefulnessSurveyEmail({ returnPath: "/returnPath" })
+        .then((render: any) => res.send(render.html))
+    }
+  )
+  router.get(
     "/:followupId/benefit-action-survey.html",
     (req: ajRequest, res) => {
       req.followup

--- a/backend/followups.ts
+++ b/backend/followups.ts
@@ -15,6 +15,22 @@ if (app.get("env") === "development") {
       .renderSimulationResultsEmail()
       .then((render: any) => res.send(render.html))
   })
+  router.get(
+    "/:followupId/simulation-usefulness-survey.html",
+    (req: ajRequest, res) => {
+      req.followup
+        .renderSimulationUsefulnessSurveyEmail({ returnPath: "/returnPath" })
+        .then((render: any) => res.send(render.html))
+    }
+  )
+  router.get(
+    "/:followupId/benefit-action-survey.html",
+    (req: ajRequest, res) => {
+      req.followup
+        .renderBenefitActionSurveyEmail({ returnPath: "/returnPath" })
+        .then((render: any) => res.send(render.html))
+    }
+  )
 }
 app.use(router)
 

--- a/backend/lib/email.ts
+++ b/backend/lib/email.ts
@@ -103,7 +103,7 @@ function processSend(args) {
         return Promise.all(
           list.map(function (followup) {
             return followup
-              .sendSurvey()
+              .sendSurvey("benefit-action")
               .then(function (result) {
                 return { ok: result._id }
               })

--- a/backend/lib/email.ts
+++ b/backend/lib/email.ts
@@ -75,11 +75,14 @@ function processSend(args) {
             return followup.sendSurvey(surveyType)
           }
           default:
-            throw new Error("Unknown type")
+            throw new Error(`Unknown email type: ${emailType}`)
         }
       })
+      .then((e) => {
+        console.log("log!", e)
+      })
       .catch((error) => {
-        console.error("error!", error)
+        console.error("error!", error, error.traceback)
       })
       .finally(() => {
         console.log("done")

--- a/backend/lib/email.ts
+++ b/backend/lib/email.ts
@@ -7,6 +7,7 @@ import mongooseConfig from "../config/mongoose"
 mongooseConfig(mongoose, config)
 
 import Followup from "../models/followup"
+import { SurveyType } from "../types/survey"
 
 const parser = new ArgumentParser({
   add_help: true,
@@ -29,7 +30,14 @@ const send_simulation_results = send_types.add_parser("simulation-results")
 const send_benefit_action_survey = send_types.add_parser(
   "benefit-action-survey"
 )
-const senders = [send_simulation_results, send_benefit_action_survey]
+const send_simulation_usefulness_survey = send_types.add_parser(
+  "simulation-usefulness-survey"
+)
+const senders = [
+  send_simulation_results,
+  send_benefit_action_survey,
+  send_simulation_usefulness_survey,
+]
 senders.forEach((send) => {
   send.add_argument("--id", {
     help: "Followup Id",
@@ -38,7 +46,6 @@ senders.forEach((send) => {
     action: "store_true",
     help: "Do not send emails",
   })
-
   send.add_argument("--multiple", {
     help: "Number of emails to send",
   })
@@ -54,37 +61,35 @@ reply.add_argument("--id", {
 })
 
 function processSend(args) {
-  if (args.id) {
-    Followup.findByIdOrOldId(args.id)
-      .then((f) => {
-        switch (args.type) {
+  const { id, type: emailType, multiple } = args
+
+  if (id) {
+    Followup.findByIdOrOldId(id)
+      .then((followup) => {
+        switch (emailType) {
           case "simulation-results":
-            return f.sendSimulationResultsEmail()
+            return followup.sendSimulationResultsEmail()
           case "benefit-action-survey":
-            if (args.mock) {
-              return f.mock()
-            } else {
-              return f.sendSurvey()
-            }
+          case "simulation-usefulness-survey": {
+            const surveyType: SurveyType = emailType.slice(0, -"-survey".length)
+            return followup.sendSurvey(surveyType)
+          }
           default:
-            return
+            throw new Error("Unknown type")
         }
       })
-      .then((e) => {
-        console.log("log!", e)
-      })
-      .catch((e) => {
-        console.error("error!", e.traceback)
+      .catch((error) => {
+        console.error("error!", error)
       })
       .finally(() => {
         console.log("done")
         process.exit(0)
       })
-  } else if (args.multiple) {
-    if (args.type !== "benefit-action-survey") {
+  } else if (multiple) {
+    if (emailType !== "benefit-action-survey") {
       process.exit(0)
     }
-    const limit = parseInt(args.multiple) || 1
+    const limit = parseInt(multiple) || 1
     Followup.find({
       surveys: { $size: 0 },
       sentAt: {

--- a/backend/lib/mes-aides/emails/simulation-usefulness-survey.ts
+++ b/backend/lib/mes-aides/emails/simulation-usefulness-survey.ts
@@ -46,7 +46,6 @@ function renderAsHtml(followup) {
 export default function render(followup) {
   return Promise.all([renderAsText(followup), renderAsHtml(followup)]).then(
     function (values) {
-      console.log("************** followup **********", followup)
       return {
         subject: `[${
           followup.simulation?._id || followup.simulation

--- a/backend/lib/mes-aides/emails/simulation-usefulness-survey.ts
+++ b/backend/lib/mes-aides/emails/simulation-usefulness-survey.ts
@@ -1,0 +1,59 @@
+import fs from "fs"
+import path from "path"
+import consolidate from "consolidate"
+
+const mustache = consolidate.mustache
+import config from "../../../config/index"
+import { mjml } from "./index"
+
+const textTemplate = fs.readFileSync(
+  path.join(__dirname, "templates/simulation-usefulness-survey.txt"),
+  "utf8"
+)
+const mjmlTemplate = fs.readFileSync(
+  path.join(__dirname, "templates/simulation-usefulness-survey.mjml"),
+  "utf8"
+)
+
+function renderAsText(followup) {
+  const data = {
+    ctaLink: `${config.baseURL}${followup.surveyPath}`,
+    returnURL: `${config.baseURL}${followup.returnPath}`,
+    wasUsefulLinkYes: `${config.baseURL}${followup.surveyPath}${followup.wasUsefulPath}`,
+    wasUsefulLinkNo: `${config.baseURL}${followup.surveyPath}${followup.wasNotUsefulPath}`,
+  }
+
+  return mustache.render(textTemplate, data)
+}
+
+function renderAsHtml(followup) {
+  const data = {
+    ctaLink: `${config.baseURL}${followup.surveyPath}`,
+    baseURL: config.baseURL,
+    returnURL: `${config.baseURL}${followup.returnPath}`,
+    wasUsefulLinkYes: `${config.baseURL}${followup.surveyPath}${followup.wasUsefulPath}`,
+    wasUsefulLinkNo: `${config.baseURL}${followup.surveyPath}${followup.wasNotUsefulPath}`,
+  }
+
+  return mustache.render(mjmlTemplate, data).then(function (templateString) {
+    const output = mjml(templateString)
+    return {
+      html: output.html,
+    }
+  })
+}
+
+export default function render(followup) {
+  return Promise.all([renderAsText(followup), renderAsHtml(followup)]).then(
+    function (values) {
+      console.log("************** followup **********", followup)
+      return {
+        subject: `[${
+          followup.simulation?._id || followup.simulation
+        }] Votre simulation sur 1jeune1solution.gouv.fr vous a-t-elle été utile ?`,
+        text: values[0],
+        html: values[1].html,
+      }
+    }
+  )
+}

--- a/backend/lib/mes-aides/emails/simulation-usefulness-survey.ts
+++ b/backend/lib/mes-aides/emails/simulation-usefulness-survey.ts
@@ -19,8 +19,8 @@ function renderAsText(followup) {
   const data = {
     ctaLink: `${config.baseURL}${followup.surveyPath}`,
     returnURL: `${config.baseURL}${followup.returnPath}`,
-    wasUsefulLinkYes: `${config.baseURL}${followup.surveyPath}${followup.wasUsefulPath}`,
-    wasUsefulLinkNo: `${config.baseURL}${followup.surveyPath}${followup.wasNotUsefulPath}`,
+    wasUsefulLinkYes: `${config.baseURL}${followup.wasUsefulPath}`,
+    wasUsefulLinkNo: `${config.baseURL}${followup.wasNotUsefulPath}`,
   }
 
   return mustache.render(textTemplate, data)
@@ -31,8 +31,8 @@ function renderAsHtml(followup) {
     ctaLink: `${config.baseURL}${followup.surveyPath}`,
     baseURL: config.baseURL,
     returnURL: `${config.baseURL}${followup.returnPath}`,
-    wasUsefulLinkYes: `${config.baseURL}${followup.surveyPath}${followup.wasUsefulPath}`,
-    wasUsefulLinkNo: `${config.baseURL}${followup.surveyPath}${followup.wasNotUsefulPath}`,
+    wasUsefulLinkYes: `${config.baseURL}${followup.wasUsefulPath}`,
+    wasUsefulLinkNo: `${config.baseURL}${followup.wasNotUsefulPath}`,
   }
 
   return mustache.render(mjmlTemplate, data).then(function (templateString) {

--- a/backend/lib/mes-aides/emails/templates/simulation-usefulness-survey.mjml
+++ b/backend/lib/mes-aides/emails/templates/simulation-usefulness-survey.mjml
@@ -1,0 +1,105 @@
+<mjml>
+  <mj-head>
+    <mj-attributes>
+      <mj-text color="#555" line-height="22px" font-size="14px" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body>
+    <mj-section>
+      <mj-column width="40%">
+        <mj-image
+          alt="Logo Marianne de la République Française"
+          src="{{&baseURL}}/img/logo_rf.png"
+        />
+      </mj-column>
+      <mj-column width="40%">
+        <mj-image
+          alt="Logo de 1jeune1solution.gouv.fr"
+          src="{{&baseURL}}/img/logo1j1s-france-relance.png"
+        />
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-text>
+          <p align="justify">
+            <span
+              >Vous avez fait il y a quelques jours une simulation sur
+              <a href="https://mes-aides.1jeune1solution.beta.gouv.fr/"
+                >1jeune1solution.gouv.fr</a
+              >.</span
+            >
+            <br />
+            <span
+              >Nous aimerions savoir si cette simulation vous a été utile, et si
+              elle vous a permis de demander voire de bénéficier de nouvelles
+              aides : cela nous permettra de continuer à améliorer le simulateur
+              !</span
+            >
+          </p>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-text align="center" font-size="20px">
+        Votre simulation a-t-elle été utile ?
+      </mj-text>
+    </mj-section>
+    <mj-section>
+      <mj-column align="center">
+        <mj-button
+          width="100px"
+          background-color="#5770be"
+          color="white"
+          href="{{&wasUsefulLinkYes}}"
+          align="right"
+        >
+          Oui
+        </mj-button>
+      </mj-column>
+      <mj-column>
+        <mj-button
+          width="100px"
+          background-color="#5770be"
+          color="white"
+          href="{{&wasUsefulLinkNo}}"
+          align="left"
+        >
+          Non
+        </mj-button>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-text>
+          <span
+            >Retrouvez les détails de votre simulation en cliquant
+            <a href="{{&returnURL}}" target="_blank">ici</a>.</span
+          >
+          <br />
+          <span
+            >Nous améliorons ce simulateur en continu, et vous pouvez nous y
+            aider.</span
+          >
+          <br />
+          <span
+            >Vous pouvez toujours nous contacter à l'adresse suivante&nbsp;:
+            <a href="mailto:aides-jeunes@beta.gouv.fr"
+              >aides-jeunes@beta.gouv.fr</a
+            ></span
+          >
+        </mj-text>
+        <mj-text>
+          <span>Bonne journée,</span>
+          <br />
+          <span
+            >L'équipe du
+            <a href="https://mes-aides.1jeune1solution.beta.gouv.fr/"
+              >simulateur de 1jeune1solution.gouv.fr</a
+            ></span
+          >
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/backend/lib/mes-aides/emails/templates/simulation-usefulness-survey.txt
+++ b/backend/lib/mes-aides/emails/templates/simulation-usefulness-survey.txt
@@ -1,0 +1,16 @@
+Bonjour,
+
+Vous avez fait il y a quelques jours une simulation sur 1jeune1solution.gouv.fr.
+
+Nous aimerions savoir si cette simulation vous a été utile. Si cela a été le cas, merci de nous l'indiquer en cliquant sur le lien suivant :
+{{&wasUsefulLinkYes}}
+
+Sinon vous pouvez l'indiquer en cliquant sur le lien suivant : 
+{{&wasUsefulLinkNo}}
+
+Dans tous les cas, nous vous inviterons à remplir un formulaire qui vous prendra moins de 30 secondes. Cela nous permettra de continuer à améliorer le simulateur.
+
+Pour toute question ou remarque, vous pouvez également nous contacter à l'adresse suivante : aides-jeunes@beta.gouv.fr
+
+Bonne journée,
+L'équipe du simulateur de 1jeune1solution.gouv.fr

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -98,7 +98,7 @@ FollowupSchema.method("renderSurveyEmail", function (surveyType) {
     case "simulation-usefulness":
       return renderSimulationUsefulnessSurvey(this)
     default:
-      return Promise.reject(new Error("Unknown email type"))
+      return Promise.reject(new Error(`Unknown survey type: ${surveyType}`))
   }
 })
 

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -1,36 +1,16 @@
 import mongoose from "mongoose"
-import { find } from "lodash"
 import validator from "validator"
 
 import { SendSmtpEmail, sendEmail } from "../lib/send-in-blue"
 import utils from "../lib/utils"
 
-import { SurveyLayout } from "../types/survey"
+import { SurveyLayout, SurveyType } from "../types/survey"
 
 import renderSimulationResults from "../lib/mes-aides/emails/simulation-results"
+import renderSimulationUsefulnessSurvey from "../lib/mes-aides/emails/simulation-usefulness-survey"
 import renderBenefitActionSurvey from "../lib/mes-aides/emails/benefit-action-survey"
-
+import SurveySchema from "./survey-schema"
 import { MongooseLayout, FollowupModel } from "../types/models"
-
-const SurveySchema = new mongoose.Schema<MongooseLayout, FollowupModel>(
-  {
-    _oldId: { type: String },
-    accessToken: { type: String },
-    createdAt: { type: Date, default: Date.now },
-    messageId: { type: String },
-    repliedAt: { type: Date },
-    error: { type: Object },
-    answers: [
-      {
-        id: String,
-        value: String,
-        comments: String,
-      },
-    ],
-    type: { type: String },
-  },
-  { minimize: false, id: false }
-)
 
 const FollowupSchema = new mongoose.Schema(
   {
@@ -111,29 +91,36 @@ FollowupSchema.method("sendSimulationResultsEmail", function () {
     })
 })
 
-FollowupSchema.method("renderBenefitActionSurveyEmail", function (survey) {
-  return renderBenefitActionSurvey(survey)
+FollowupSchema.method("renderSurveyEmail", function (survey) {
+  switch (survey.type) {
+    case "benefit-action":
+      return renderBenefitActionSurvey(this)
+    case "simulation-usefulness":
+      return renderSimulationUsefulnessSurvey(this)
+    default:
+      return Promise.reject(new Error("Unknown email type"))
+  }
 })
 
-FollowupSchema.method("createSurvey", function (type) {
+FollowupSchema.method("createSurvey", function (type: SurveyType) {
   return Promise.resolve(
     this.surveys.create({
-      type: type,
+      type,
     })
   )
 })
 
-FollowupSchema.method("sendSurvey", function () {
+FollowupSchema.method("sendSurvey", function (surveyType: SurveyType) {
   const followup = this
-  return this.createSurvey("benefit-action").then((survey: SurveyLayout) => {
-    return this.renderBenefitActionSurveyEmail(followup)
+  return this.createSurvey(surveyType).then((survey: SurveyLayout) => {
+    return this.renderSurveyEmail(survey)
       .then((render) => {
         const email = new SendSmtpEmail()
         email.to = [{ email: followup.email }]
         email.subject = render.subject
         email.textContent = render.text
         email.htmlContent = render.html
-        email.tags = ["survey"]
+        email.tags = ["survey", surveyType]
         return sendEmail(email)
           .then((response) => {
             return response.messageId
@@ -168,20 +155,34 @@ FollowupSchema.method("mock", function () {
   })
 })
 
-FollowupSchema.method("updateSurvey", function (id, answers) {
-  const surveys: SurveyLayout[] = Array.from(this.surveys)
-  const survey = find(surveys, function (s: SurveyLayout) {
-    return s._id === id
-  })
-  if (typeof survey === "undefined") {
-    console.log("Could not find and update survey using its id")
-    return
-  }
-  Object.assign(survey, {
-    answers: answers,
+FollowupSchema.method("addSurvey", function (answers, type = null) {
+  this.surveys.push({
+    answers,
     repliedAt: Date.now(),
+    type,
   })
-  this.surveys = surveys
+  return this.save()
+})
+
+FollowupSchema.method("setWasUseful", function (wasUseful) {
+  const survey = this.surveys.find((survey) =>
+    survey.answers.find((answer) => answer.id === "wasUseful")
+  )
+  // if there is no survey with a "wasUseful" answer, create one
+  if (!survey) {
+    this.surveys.push({
+      answers: [
+        {
+          id: "wasUseful",
+          value: wasUseful,
+        },
+      ],
+      repliedAt: Date.now(),
+      type: "simulation-usefulness",
+    })
+  } else {
+    survey.answers.find((answer) => answer.id === "wasUseful").value = wasUseful
+  }
   return this.save()
 })
 
@@ -205,6 +206,14 @@ FollowupSchema.virtual("returnPath").get(function (this: any) {
 
 FollowupSchema.virtual("surveyPath").get(function (this: any) {
   return `/suivi?token=${this.accessToken}`
+})
+
+FollowupSchema.virtual("wasUsefulPath").get(function (this: any) {
+  return `&wasuseful=1`
+})
+
+FollowupSchema.virtual("wasNotUsefulPath").get(function (this: any) {
+  return `&wasuseful=0`
 })
 
 export default mongoose.model<MongooseLayout, FollowupModel>(

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -155,34 +155,27 @@ FollowupSchema.method("mock", function () {
   })
 })
 
+FollowupSchema.method("updateSurvey", function (type, answers) {
+  const surveys: SurveyLayout[] = Array.from(this.surveys)
+  const survey = surveys.find((s) => s.type === type)
+  if (typeof survey === "undefined") {
+    console.log("Could not find and update survey using its id")
+    return
+  }
+  Object.assign(survey, {
+    answers: answers,
+    repliedAt: Date.now(),
+  })
+  this.surveys = surveys
+  return this.save()
+})
+
 FollowupSchema.method("addSurvey", function (answers, type = null) {
   this.surveys.push({
     answers,
     repliedAt: Date.now(),
     type,
   })
-  return this.save()
-})
-
-FollowupSchema.method("setWasUseful", function (wasUseful) {
-  const survey = this.surveys.find((survey) =>
-    survey.answers.find((answer) => answer.id === "wasUseful")
-  )
-  // if there is no survey with a "wasUseful" answer, create one
-  if (!survey) {
-    this.surveys.push({
-      answers: [
-        {
-          id: "wasUseful",
-          value: wasUseful,
-        },
-      ],
-      repliedAt: Date.now(),
-      type: "simulation-usefulness",
-    })
-  } else {
-    survey.answers.find((answer) => answer.id === "wasUseful").value = wasUseful
-  }
   return this.save()
 })
 
@@ -209,11 +202,11 @@ FollowupSchema.virtual("surveyPath").get(function (this: any) {
 })
 
 FollowupSchema.virtual("wasUsefulPath").get(function (this: any) {
-  return `&wasuseful=1`
+  return `/api/followups/surveys/${this.accessToken}/wasuseful/1`
 })
 
 FollowupSchema.virtual("wasNotUsefulPath").get(function (this: any) {
-  return `&wasuseful=0`
+  return `/api/followups/surveys/${this.accessToken}/wasuseful/0`
 })
 
 export default mongoose.model<MongooseLayout, FollowupModel>(

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -170,15 +170,6 @@ FollowupSchema.method("updateSurvey", function (type, answers) {
   return this.save()
 })
 
-FollowupSchema.method("addSurvey", function (answers, type = null) {
-  this.surveys.push({
-    answers,
-    repliedAt: Date.now(),
-    type,
-  })
-  return this.save()
-})
-
 FollowupSchema.pre("save", async function (next) {
   if (!this.isNew) {
     return next()

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -91,8 +91,8 @@ FollowupSchema.method("sendSimulationResultsEmail", function () {
     })
 })
 
-FollowupSchema.method("renderSurveyEmail", function (survey) {
-  switch (survey.type) {
+FollowupSchema.method("renderSurveyEmail", function (surveyType) {
+  switch (surveyType) {
     case "benefit-action":
       return renderBenefitActionSurvey(this)
     case "simulation-usefulness":
@@ -113,7 +113,7 @@ FollowupSchema.method("createSurvey", function (type: SurveyType) {
 FollowupSchema.method("sendSurvey", function (surveyType: SurveyType) {
   const followup = this
   return this.createSurvey(surveyType).then((survey: SurveyLayout) => {
-    return this.renderSurveyEmail(survey)
+    return this.renderSurveyEmail(surveyType)
       .then((render) => {
         const email = new SendSmtpEmail()
         email.to = [{ email: followup.email }]

--- a/backend/models/survey-schema.ts
+++ b/backend/models/survey-schema.ts
@@ -1,0 +1,27 @@
+import mongoose from "mongoose"
+import { MongooseLayout, SurveyModel } from "../types/models"
+
+const SurveySchema = new mongoose.Schema<MongooseLayout, SurveyModel>(
+  {
+    _oldId: { type: String },
+    accessToken: { type: String },
+    createdAt: { type: Date, default: Date.now },
+    messageId: { type: String },
+    repliedAt: { type: Date },
+    error: { type: Object },
+    answers: [
+      {
+        id: String,
+        value: String,
+        comments: String,
+      },
+    ],
+    type: {
+      type: String,
+      enum: ["benefit-action", "simulation-usefulness"],
+    },
+  },
+  { minimize: false, id: false }
+)
+
+export default SurveySchema

--- a/backend/routes/followups.ts
+++ b/backend/routes/followups.ts
@@ -1,16 +1,18 @@
 import cookieParser from "cookie-parser"
 import {
   showFromSurvey,
-  postSurvey,
+  postAnswersSurvey,
   showSurveyResult,
   showSurveyResults,
   showSurveyResultByEmail,
+  getFollowup,
+  updateWasUseful,
 } from "../controllers/followups"
 import githubController from "../controllers/github"
 
 const followupsRoutes = function (api) {
   api.route("/followups/surveys/:surveyId").get(showFromSurvey)
-  api.route("/followups/surveys/:surveyId/answers").post(postSurvey)
+  api.route("/followups/surveys/:accessToken/answers").post(postAnswersSurvey)
   api
     .route("/followups/surveys")
     .get(cookieParser(), githubController.access)
@@ -23,5 +25,9 @@ const followupsRoutes = function (api) {
     .route("/followups/email/:email")
     .get(cookieParser(), githubController.access)
     .get(showSurveyResultByEmail)
+  api
+    .route("/followups/surveys/:accessToken/wasuseful/:wasuseful")
+    .patch(updateWasUseful)
+  api.param("accessToken", getFollowup)
 }
 export default followupsRoutes

--- a/backend/routes/followups.ts
+++ b/backend/routes/followups.ts
@@ -1,6 +1,6 @@
 import cookieParser from "cookie-parser"
 import {
-  showFromSurvey,
+  findFollowupByAccessToken,
   postSurvey,
   showSurveyResult,
   showSurveyResults,
@@ -11,7 +11,7 @@ import {
 import githubController from "../controllers/github"
 
 const followupsRoutes = function (api) {
-  api.route("/followups/surveys/:surveyId").get(showFromSurvey)
+  api.route("/followups/surveys/:accessToken").get(findFollowupByAccessToken)
   api.route("/followups/surveys/:accessToken/answers").post(postSurvey)
   api
     .route("/followups/surveys")

--- a/backend/routes/followups.ts
+++ b/backend/routes/followups.ts
@@ -1,18 +1,18 @@
 import cookieParser from "cookie-parser"
 import {
   showFromSurvey,
-  postAnswersSurvey,
   showSurveyResult,
   showSurveyResults,
   showSurveyResultByEmail,
   getFollowup,
   updateWasUseful,
+  postSurvey,
 } from "../controllers/followups"
 import githubController from "../controllers/github"
 
 const followupsRoutes = function (api) {
   api.route("/followups/surveys/:surveyId").get(showFromSurvey)
-  api.route("/followups/surveys/:accessToken/answers").post(postAnswersSurvey)
+  api.route("/followups/surveys/:accessToken/answers").post(postSurvey)
   api
     .route("/followups/surveys")
     .get(cookieParser(), githubController.access)
@@ -27,7 +27,7 @@ const followupsRoutes = function (api) {
     .get(showSurveyResultByEmail)
   api
     .route("/followups/surveys/:accessToken/wasuseful/:wasuseful")
-    .patch(updateWasUseful)
+    .get(updateWasUseful)
   api.param("accessToken", getFollowup)
 }
 export default followupsRoutes

--- a/backend/routes/followups.ts
+++ b/backend/routes/followups.ts
@@ -1,6 +1,6 @@
 import cookieParser from "cookie-parser"
 import {
-  findFollowupByAccessToken,
+  followupByAccessToken,
   postSurvey,
   showSurveyResult,
   showSurveyResults,

--- a/backend/routes/followups.ts
+++ b/backend/routes/followups.ts
@@ -1,12 +1,12 @@
 import cookieParser from "cookie-parser"
 import {
   showFromSurvey,
+  postSurvey,
   showSurveyResult,
   showSurveyResults,
   showSurveyResultByEmail,
   getFollowup,
   updateWasUseful,
-  postSurvey,
 } from "../controllers/followups"
 import githubController from "../controllers/github"
 

--- a/backend/routes/followups.ts
+++ b/backend/routes/followups.ts
@@ -11,7 +11,7 @@ import {
 import githubController from "../controllers/github"
 
 const followupsRoutes = function (api) {
-  api.route("/followups/surveys/:accessToken").get(findFollowupByAccessToken)
+  api.route("/followups/surveys/:accessToken").get(getFollowup)
   api.route("/followups/surveys/:accessToken/answers").post(postSurvey)
   api
     .route("/followups/surveys")
@@ -28,6 +28,6 @@ const followupsRoutes = function (api) {
   api
     .route("/followups/surveys/:accessToken/wasuseful/:wasuseful")
     .get(updateWasUseful)
-  api.param("accessToken", getFollowup)
+  api.param("accessToken", followupByAccessToken)
 }
 export default followupsRoutes

--- a/backend/types/models.d.ts
+++ b/backend/types/models.d.ts
@@ -7,9 +7,6 @@ export interface FollowupModel extends Model<MongooseLayout> {
   findByIdOrOldId(id: string): any
   findByEmail(id: string): any
 }
-export interface SurveyModel extends Model<MongooseLayout> {
-  findById(id: string): any
-}
 export interface SimulationModel extends Model<MongooseLayout> {
   cookiePrefix(): string
 }

--- a/backend/types/models.d.ts
+++ b/backend/types/models.d.ts
@@ -3,8 +3,12 @@ export interface MongooseLayout {
   [id: string]: any
 }
 export interface FollowupModel extends Model<MongooseLayout> {
+  setWasUseful(wasUseful: string): unknown
   findByIdOrOldId(id: string): any
   findByEmail(id: string): any
+}
+export interface SurveyModel extends Model<MongooseLayout> {
+  findById(id: string): any
 }
 export interface SimulationModel extends Model<MongooseLayout> {
   cookiePrefix(): string

--- a/backend/types/models.d.ts
+++ b/backend/types/models.d.ts
@@ -3,7 +3,6 @@ export interface MongooseLayout {
   [id: string]: any
 }
 export interface FollowupModel extends Model<MongooseLayout> {
-  setWasUseful(wasUseful: string): unknown
   findByIdOrOldId(id: string): any
   findByEmail(id: string): any
 }

--- a/backend/types/survey.d.ts
+++ b/backend/types/survey.d.ts
@@ -1,7 +1,13 @@
+export enum SurveyType {
+  benefitAction = "benefit-action",
+  simulationUsefulness = "simulation-usefulness",
+}
+
 export interface SurveyLayout {
   _id: string
   answers: any
   repliedAt?: string
   messageId?: string
   error?: any
+  type: SurveyType
 }

--- a/tools/mjml.ts
+++ b/tools/mjml.ts
@@ -42,16 +42,18 @@ app.route("/mjml/:id/:type").get(function (req, res) {
     .populate("simulation")
     .exec(function (err, followup) {
       let p = {}
+      const survey = followup.surveys.find((s) =>
+        req.params.type.includes(s.type)
+      )
       if (req.params.type == "simulation-results") {
         p = renderSimulationResults(followup)
-      } else if (req.params.type == "simulation-usefulness-survey") {
+      } else if (
+        req.params.type == "simulation-usefulness-survey" ||
+        req.params.type == "benefit-action-survey"
+      ) {
         p = followup
-          .createSurvey()
-          .then(() => followup.renderSimulationUsefulnessSurveyEmail(followup))
-      } else if (req.params.type == "benefit-action-survey") {
-        p = followup
-          .createSurvey()
-          .then(() => followup.renderBenefitActionSurveyEmail(followup))
+          .createSurvey("benefit-action")
+          .then(() => followup.renderSurveyEmail(survey))
       }
       if (p instanceof Promise) {
         p.then(function (result) {

--- a/tools/views/index.html
+++ b/tools/views/index.html
@@ -24,10 +24,12 @@
                 >Résultats de simulation :
               </span>
               <span v-else-if="typeKey === 'benefit-action-survey'"
-                >Mail de sondage (V1) :
+                >Mail de sondage de la prise d'action suite aux résultats de la
+                simulation (benefit-action) :
               </span>
               <span v-else-if="typeKey === 'simulation-usefulness-survey'"
-                >Mail de sondage (V2) :
+                >Mail de sondage d'utilité de la simulation
+                (simulation-usefulness) :
               </span>
               &nbsp;
               <a

--- a/tools/views/index.html
+++ b/tools/views/index.html
@@ -21,9 +21,14 @@
           <ul v-for="typeKey in typeKeys">
             <li>
               <span v-if="typeKey === 'simulation-results'"
-                >Mail initial :
+                >Résultats de simulation :
               </span>
-              <span v-else>Résultats simulation : </span>
+              <span v-else-if="typeKey === 'benefit-action-survey'"
+                >Mail de sondage (V1) :
+              </span>
+              <span v-else-if="typeKey === 'simulation-usefulness-survey'"
+                >Mail de sondage (V2) :
+              </span>
               &nbsp;
               <a
                 :href="`mjml/${followup._id}/${typeKey}?mode=html`"


### PR DESCRIPTION
[Tâche Trello](https://trello.com/c/M8iVFvKi/1004-reformuler-lemail-de-sondage-pour-obtenir-plus-de-retours)

Suite au point avec Thomas du 19 décembre 2022, liste des tâches à réaliser pour la prochain itération :

- [x] Créer un nouveau template de survey
- [x] Ajouter une variable aléatoire pour faire de l'A/B testing sur les deux templates d'email de sondage (ancien / nouveau)
- [x] Nouveau modèle survey
- [x] Refactoring des routes
- [x] Depuis le mail avec le template en version 2 : enregistrer la réponse oui/non dans le survey dans le tableau `answers`, puis rediriger l'utilisateur vers la page du sondage avec l'ID du survey nouvellement créé
- [x] Si un id survey est fourni et existant, patcher le nouveau survey avec les réponses en mettant à jour les valeur sans altérer la valeur de wasUsefull
------------------------------------
- [x] refacto `backend/controllers/followups.ts`: refacto ligne 151 à 153 (Faire un req.followup sur la fin?)
- [x] refacto f.sendSurvey(random) par le type
- [x] remplacer templateSruvey par le nom du type de survey => créer un nouveau type de survey simulation-usefullness avec 1 réponse possible
- [x] faire 2 survey différents au lieu d'un (1 avec le wasUsefull et 1 avec les réponses)
- [x] mutualiser les routes pour get survey
