### PR TITLE
Ajoute les ressources fiscales dans le récapitulatif

### DIFF
--- a/src/views/simulation/recapitulatif.vue
+++ b/src/views/simulation/recapitulatif.vue
@@ -73,6 +73,7 @@ import { RecapPropertyLine, Step } from "@lib/types/property"
 import { computed, ComputedRef } from "vue"
 import { useProgress } from "@/composables/progress"
 import { useStore } from "@/stores"
+import { categoriesRnc } from "@lib/resources"
 
 const store = useStore()
 const route = useRoute()
@@ -93,49 +94,21 @@ const showResultButton = computed(() => {
 })
 
 const addIndividuQuestions = (questions, individuLabel, data, path) => {
-  questions.push(
-    {
-      rowClass: "row-space",
-      label: individuLabel,
-      labelClass: "individu-title",
-      hideEdit: true,
-    },
-    {
-      label: "Revenus d'activité connus",
-      value: data.salaire_imposable,
-      path,
-    },
-    {
-      label: "Autre revenus imposables",
-      value: data.chomage_imposable,
-      path,
-    },
-    {
-      label: "Pensions, retraite, rente",
-      value: data.retraite_imposable,
-      path,
-    },
-    {
-      label: "Frais réels déductibles",
-      value: data.frais_reels,
-      path,
-    },
-    {
-      label: "Pensions alimentaires reçues",
-      value: data.pensions_alimentaires_percues,
-      path,
-    },
-    {
-      label: "Pensions alimentaires versées",
-      value: data.pensions_alimentaires_versees,
-      path,
-    },
-    {
-      label: "Revenus fonciers nets",
-      value: data.revenus_locatifs,
-      path,
+  questions.push({
+    rowClass: "row-space",
+    label: individuLabel,
+    labelClass: "individu-title",
+    hideEdit: true,
+  })
+  categoriesRnc.forEach((category) => {
+    if (data[category.id]) {
+      questions.push({
+        label: category.label,
+        value: `${data[category.id]} €`,
+        path,
+      })
     }
-  )
+  })
 }
 
 const addFiscalResourcesResChapter = (resChapters) => {


### PR DESCRIPTION
[Tâche Trello](https://trello.com/c/ppKKEYHg/947-ajouter-les-ressources-fiscales-au-r%C3%A9capitulatif)

Ajoute la liste des ressources fiscales du demandeur et de chacun de ses enfants. La liste est générée dynamiquement et cette logique spécifique pourrait être déplacée dans un autre fichier pour laisser le fichier Recapitulatif.vue avec de la logique plus générique.

Lien direct avec [la PR sur l'ajout du patrimoine dans le récapitulatif](https://github.com/betagouv/aides-jeunes/pull/3339)