### PR TITLE
fix: corrige le lien de contact dans le footer

### DIFF
--- a/src/components/footer-1j1s.vue
+++ b/src/components/footer-1j1s.vue
@@ -105,7 +105,6 @@ export default {
         {
           label: "Nous contacter",
           href: "/contact",
-          class: "aj-1j1s-footer__internal-link--email",
         },
       ],
       externalLinks: [


### PR DESCRIPTION
## Description

Le lien actuel de contact dans le footer est un `mailto` vers une adresse de 1jeune1solution