### PR TITLE
Ajoute une action de déploiement de préprod

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,14 +1,14 @@
 name: "Continuous Deployment"
 on:
   push:
-    branches: [master,dev]
+    branches: [master, dev]
 env:
   SSH_HOST: solstice.mes-aides.1jeune1solution.beta.gouv.fr
   SSH_USER: root
 
 jobs:
   deploy_production:
-    if: github.ref == 'refs/heads/master' 
+    if: github.ref == 'refs/heads/master'
     name: Production deployment
     runs-on: ubuntu-20.04
     steps:
@@ -20,7 +20,7 @@ jobs:
           chmod 600 ~/.ssh/deployment.key
           ssh -o StrictHostKeyChecking=no ${{ env.SSH_USER }}@${{ env.SSH_HOST }} -i ~/.ssh/deployment.key
   deploy_preproduction:
-    if: github.ref == 'refs/heads/dev' 
+    if: github.ref == 'refs/heads/dev'
     name: Preproduction Deployment
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
## Description

Afin de permettre le déploiement  automatique de la branche dev en preprod il est nécessaire de mettre à jour la github action de la CD.

Run de déploiement de la préprod : https://github.com/betagouv/aides-jeunes/actions/runs/3513355289