### PR TITLE
Refacto nom quotient_familial[floor] -> quotient_familial[cap]

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -189,7 +189,7 @@ fields:
     widget: object
     fields:
       - label: Plafond
-        name: cap
+        name: floor
         widget: number
         step: -1
       - label: Période

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -189,7 +189,7 @@ fields:
     widget: object
     fields:
       - label: Plafond
-        name: floor
+        name: ceiling
         widget: number
         step: -1
       - label: Période

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -189,7 +189,7 @@ fields:
     widget: object
     fields:
       - label: Plafond
-        name: floor
+        name: cap
         widget: number
         step: -1
       - label: Période

--- a/data/benefits/javascript/bourgogne-franche-comte-dynastage.yml
+++ b/data/benefits/javascript/bourgogne-franche-comte-dynastage.yml
@@ -11,7 +11,7 @@ conditions_generales:
       - "27"
   - type: quotient_familial
     period: year
-    floor: 25830
+    ceiling: 25830
 profils:
   - type: apprenti
 link: https://www.bourgognefranchecomte.fr/node/332

--- a/data/benefits/javascript/bourgogne-franche-comte-dynastage.yml
+++ b/data/benefits/javascript/bourgogne-franche-comte-dynastage.yml
@@ -11,7 +11,7 @@ conditions_generales:
       - "27"
   - type: quotient_familial
     period: year
-    floor: 25830
+    cap: 25830
 profils:
   - type: apprenti
 link: https://www.bourgognefranchecomte.fr/node/332

--- a/data/benefits/javascript/bourgogne-franche-comte-dynastage.yml
+++ b/data/benefits/javascript/bourgogne-franche-comte-dynastage.yml
@@ -11,7 +11,7 @@ conditions_generales:
       - "27"
   - type: quotient_familial
     period: year
-    cap: 25830
+    floor: 25830
 profils:
   - type: apprenti
 link: https://www.bourgognefranchecomte.fr/node/332

--- a/data/benefits/javascript/bretagne-jeune-international.yml
+++ b/data/benefits/javascript/bretagne-jeune-international.yml
@@ -12,7 +12,7 @@ conditions_generales:
       - "53"
   - type: quotient_familial
     period: year
-    floor: 25000
+    cap: 25000
 profils:
   - type: enseignement_superieur
 link: https://www.bretagne.bzh/aides/fiches/bourse-jeunes-a-linternational-etudiants-des-universites/

--- a/data/benefits/javascript/bretagne-jeune-international.yml
+++ b/data/benefits/javascript/bretagne-jeune-international.yml
@@ -12,7 +12,7 @@ conditions_generales:
       - "53"
   - type: quotient_familial
     period: year
-    floor: 25000
+    ceiling: 25000
 profils:
   - type: enseignement_superieur
 link: https://www.bretagne.bzh/aides/fiches/bourse-jeunes-a-linternational-etudiants-des-universites/

--- a/data/benefits/javascript/bretagne-jeune-international.yml
+++ b/data/benefits/javascript/bretagne-jeune-international.yml
@@ -12,7 +12,7 @@ conditions_generales:
       - "53"
   - type: quotient_familial
     period: year
-    cap: 25000
+    floor: 25000
 profils:
   - type: enseignement_superieur
 link: https://www.bretagne.bzh/aides/fiches/bourse-jeunes-a-linternational-etudiants-des-universites/

--- a/data/benefits/javascript/caf-allier-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-allier-aide-bafa-session-generale.yml
@@ -19,7 +19,7 @@ conditions_generales:
     values:
       - "03"
   - type: quotient_familial
-    floor: 1000
+    cap: 1000
     period: month
 profils: []
 link: https://caf.fr/allocataires/caf-de-l-allier/offre-de-service/vie-professionnelle/le-bafa-brevet-d-aptitude-aux-fonctions-d-animateur

--- a/data/benefits/javascript/caf-allier-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-allier-aide-bafa-session-generale.yml
@@ -19,7 +19,7 @@ conditions_generales:
     values:
       - "03"
   - type: quotient_familial
-    floor: 1000
+    ceiling: 1000
     period: month
 profils: []
 link: https://caf.fr/allocataires/caf-de-l-allier/offre-de-service/vie-professionnelle/le-bafa-brevet-d-aptitude-aux-fonctions-d-animateur

--- a/data/benefits/javascript/caf-allier-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-allier-aide-bafa-session-generale.yml
@@ -19,7 +19,7 @@ conditions_generales:
     values:
       - "03"
   - type: quotient_familial
-    cap: 1000
+    floor: 1000
     period: month
 profils: []
 link: https://caf.fr/allocataires/caf-de-l-allier/offre-de-service/vie-professionnelle/le-bafa-brevet-d-aptitude-aux-fonctions-d-animateur

--- a/data/benefits/javascript/caf-alpes-maritimes-aide-autonomie-jeunes.yml
+++ b/data/benefits/javascript/caf-alpes-maritimes-aide-autonomie-jeunes.yml
@@ -8,7 +8,7 @@ conditions_generales:
     values:
       - "06"
   - type: quotient_familial
-    cap: 800
+    floor: 800
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-alpes-maritimes-aide-autonomie-jeunes.yml
+++ b/data/benefits/javascript/caf-alpes-maritimes-aide-autonomie-jeunes.yml
@@ -8,7 +8,7 @@ conditions_generales:
     values:
       - "06"
   - type: quotient_familial
-    floor: 800
+    cap: 800
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-alpes-maritimes-aide-autonomie-jeunes.yml
+++ b/data/benefits/javascript/caf-alpes-maritimes-aide-autonomie-jeunes.yml
@@ -8,7 +8,7 @@ conditions_generales:
     values:
       - "06"
   - type: quotient_familial
-    floor: 800
+    ceiling: 800
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-aube-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-aube-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "10"
   - type: quotient_familial
     period: month
-    floor: 1456
+    ceiling: 1456
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de ses parents.

--- a/data/benefits/javascript/caf-aube-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-aube-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "10"
   - type: quotient_familial
     period: month
-    floor: 1456
+    cap: 1456
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de ses parents.

--- a/data/benefits/javascript/caf-aube-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-aube-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "10"
   - type: quotient_familial
     period: month
-    cap: 1456
+    floor: 1456
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de ses parents.

--- a/data/benefits/javascript/caf-aube-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-aube-aide-bafa-generale.yml
@@ -13,7 +13,7 @@ conditions_generales:
       - "10"
   - type: quotient_familial
     period: month
-    cap: 1456
+    floor: 1456
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-aube-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-aube-aide-bafa-generale.yml
@@ -13,7 +13,7 @@ conditions_generales:
       - "10"
   - type: quotient_familial
     period: month
-    floor: 1456
+    cap: 1456
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-aube-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-aube-aide-bafa-generale.yml
@@ -13,7 +13,7 @@ conditions_generales:
       - "10"
   - type: quotient_familial
     period: month
-    floor: 1456
+    ceiling: 1456
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-aube-bafd.yml
+++ b/data/benefits/javascript/caf-aube-bafd.yml
@@ -9,7 +9,7 @@ conditions_generales:
     operator: ">="
     value: 18
   - type: quotient_familial
-    floor: 1456
+    ceiling: 1456
     period: month
   - type: departements
     values:

--- a/data/benefits/javascript/caf-aube-bafd.yml
+++ b/data/benefits/javascript/caf-aube-bafd.yml
@@ -9,7 +9,7 @@ conditions_generales:
     operator: ">="
     value: 18
   - type: quotient_familial
-    floor: 1456
+    cap: 1456
     period: month
   - type: departements
     values:

--- a/data/benefits/javascript/caf-aube-bafd.yml
+++ b/data/benefits/javascript/caf-aube-bafd.yml
@@ -9,7 +9,7 @@ conditions_generales:
     operator: ">="
     value: 18
   - type: quotient_familial
-    cap: 1456
+    floor: 1456
     period: month
   - type: departements
     values:

--- a/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "13"
   - type: quotient_familial
     period: month
-    cap: 1200
+    floor: 1200
 profils: []
 conditions:
   - Effectuer votre stage en France.

--- a/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "13"
   - type: quotient_familial
     period: month
-    floor: 1200
+    ceiling: 1200
 profils: []
 conditions:
   - Effectuer votre stage en France.

--- a/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "13"
   - type: quotient_familial
     period: month
-    floor: 1200
+    cap: 1200
 profils: []
 conditions:
   - Effectuer votre stage en France.

--- a/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "13"
   - type: quotient_familial
     period: month
-    floor: 1200
+    ceiling: 1200
 profils: []
 conditions:
   - Effectuer votre stage en France.

--- a/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "13"
   - type: quotient_familial
     period: month
-    cap: 1200
+    floor: 1200
 profils: []
 conditions:
   - Effectuer votre stage en France.

--- a/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-bouches-du-rhone-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "13"
   - type: quotient_familial
     period: month
-    floor: 1200
+    cap: 1200
 profils: []
 conditions:
   - Effectuer votre stage en France.

--- a/data/benefits/javascript/caf-calvados-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-calvados-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "14"
   - type: quotient_familial
     period: month
-    floor: 850
+    ceiling: 850
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-calvados-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-calvados-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "14"
   - type: quotient_familial
     period: month
-    floor: 850
+    cap: 850
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-calvados-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-calvados-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "14"
   - type: quotient_familial
     period: month
-    cap: 850
+    floor: 850
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-calvados-aide-bafa-générale.yml
+++ b/data/benefits/javascript/caf-calvados-aide-bafa-générale.yml
@@ -13,7 +13,7 @@ conditions_generales:
       - "14"
   - type: quotient_familial
     period: month
-    floor: 850
+    ceiling: 850
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-calvados-aide-bafa-générale.yml
+++ b/data/benefits/javascript/caf-calvados-aide-bafa-générale.yml
@@ -13,7 +13,7 @@ conditions_generales:
       - "14"
   - type: quotient_familial
     period: month
-    floor: 850
+    cap: 850
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-calvados-aide-bafa-générale.yml
+++ b/data/benefits/javascript/caf-calvados-aide-bafa-générale.yml
@@ -13,7 +13,7 @@ conditions_generales:
       - "14"
   - type: quotient_familial
     period: month
-    cap: 850
+    floor: 850
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-calvados-bafd.yml
+++ b/data/benefits/javascript/caf-calvados-bafd.yml
@@ -9,7 +9,7 @@ conditions_generales:
     values:
       - "14"
   - type: quotient_familial
-    floor: 1000
+    cap: 1000
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-calvados-bafd.yml
+++ b/data/benefits/javascript/caf-calvados-bafd.yml
@@ -9,7 +9,7 @@ conditions_generales:
     values:
       - "14"
   - type: quotient_familial
-    cap: 1000
+    floor: 1000
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-calvados-bafd.yml
+++ b/data/benefits/javascript/caf-calvados-bafd.yml
@@ -9,7 +9,7 @@ conditions_generales:
     values:
       - "14"
   - type: quotient_familial
-    floor: 1000
+    ceiling: 1000
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-charente-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-charente-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "16"
   - type: quotient_familial
     period: month
-    floor: 1200
+    cap: 1200
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-charente-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-charente-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "16"
   - type: quotient_familial
     period: month
-    cap: 1200
+    floor: 1200
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-charente-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-charente-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "16"
   - type: quotient_familial
     period: month
-    floor: 1200
+    ceiling: 1200
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-charente-maritime-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-charente-maritime-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "17"
   - type: quotient_familial
     period: month
-    floor: 760
+    ceiling: 760
 profils: []
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de ses parents.

--- a/data/benefits/javascript/caf-charente-maritime-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-charente-maritime-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "17"
   - type: quotient_familial
     period: month
-    cap: 760
+    floor: 760
 profils: []
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de ses parents.

--- a/data/benefits/javascript/caf-charente-maritime-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-charente-maritime-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "17"
   - type: quotient_familial
     period: month
-    floor: 760
+    cap: 760
 profils: []
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de ses parents.

--- a/data/benefits/javascript/caf-charente-maritime-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-charente-maritime-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "17"
   - type: quotient_familial
     period: month
-    floor: 760
+    cap: 760
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-charente-maritime-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-charente-maritime-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "17"
   - type: quotient_familial
     period: month
-    cap: 760
+    floor: 760
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-charente-maritime-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-charente-maritime-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "17"
   - type: quotient_familial
     period: month
-    floor: 760
+    ceiling: 760
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-charente-maritime-bafd.yml
+++ b/data/benefits/javascript/caf-charente-maritime-bafd.yml
@@ -8,7 +8,7 @@ conditions_generales:
     values:
       - "17"
   - type: quotient_familial
-    cap: 760
+    floor: 760
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-charente-maritime-bafd.yml
+++ b/data/benefits/javascript/caf-charente-maritime-bafd.yml
@@ -8,7 +8,7 @@ conditions_generales:
     values:
       - "17"
   - type: quotient_familial
-    floor: 760
+    ceiling: 760
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-charente-maritime-bafd.yml
+++ b/data/benefits/javascript/caf-charente-maritime-bafd.yml
@@ -8,7 +8,7 @@ conditions_generales:
     values:
       - "17"
   - type: quotient_familial
-    floor: 760
+    cap: 760
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf-correze-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-correze-aide-bafa-generale.yml
@@ -25,7 +25,7 @@ conditions_generales:
       - "19"
   - type: quotient_familial
     period: month
-    cap: 1200
+    floor: 1200
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-correze/offre-de-service/enfance-et-jeunesse/le-bafa
 instructions: https://www.caf.fr/allocataires/caf-de-la-correze/offre-de-service/enfance-et-jeunesse/le-bafa

--- a/data/benefits/javascript/caf-correze-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-correze-aide-bafa-generale.yml
@@ -25,7 +25,7 @@ conditions_generales:
       - "19"
   - type: quotient_familial
     period: month
-    floor: 1200
+    cap: 1200
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-correze/offre-de-service/enfance-et-jeunesse/le-bafa
 instructions: https://www.caf.fr/allocataires/caf-de-la-correze/offre-de-service/enfance-et-jeunesse/le-bafa

--- a/data/benefits/javascript/caf-correze-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-correze-aide-bafa-generale.yml
@@ -25,7 +25,7 @@ conditions_generales:
       - "19"
   - type: quotient_familial
     period: month
-    floor: 1200
+    ceiling: 1200
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-correze/offre-de-service/enfance-et-jeunesse/le-bafa
 instructions: https://www.caf.fr/allocataires/caf-de-la-correze/offre-de-service/enfance-et-jeunesse/le-bafa

--- a/data/benefits/javascript/caf-creuse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-creuse-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "23"
   - type: quotient_familial
     period: month
-    floor: 1200
+    cap: 1200
 profils: []
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-creuse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-creuse-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "23"
   - type: quotient_familial
     period: month
-    cap: 1200
+    floor: 1200
 profils: []
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-creuse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-creuse-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "23"
   - type: quotient_familial
     period: month
-    floor: 1200
+    ceiling: 1200
 profils: []
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
@@ -19,7 +19,7 @@ conditions_generales:
       - "26"
   - type: quotient_familial
     period: month
-    floor: 750
+    cap: 750
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/jeune-de-11-a-25-ans/aide-pour-passer-le-bafa
 form: https://www.caf.fr/sites/default/files/caf/261/offre-de-service/enfance-jeunesse/aides-projets-jeunes-bafa/demande-aide-session-formation-generale-bafa2021.pdf

--- a/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
@@ -19,7 +19,7 @@ conditions_generales:
       - "26"
   - type: quotient_familial
     period: month
-    cap: 750
+    floor: 750
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/jeune-de-11-a-25-ans/aide-pour-passer-le-bafa
 form: https://www.caf.fr/sites/default/files/caf/261/offre-de-service/enfance-jeunesse/aides-projets-jeunes-bafa/demande-aide-session-formation-generale-bafa2021.pdf

--- a/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
@@ -19,7 +19,7 @@ conditions_generales:
       - "26"
   - type: quotient_familial
     period: month
-    floor: 750
+    ceiling: 750
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/jeune-de-11-a-25-ans/aide-pour-passer-le-bafa
 form: https://www.caf.fr/sites/default/files/caf/261/offre-de-service/enfance-jeunesse/aides-projets-jeunes-bafa/demande-aide-session-formation-generale-bafa2021.pdf

--- a/data/benefits/javascript/caf-eure-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-eure-aide-bafa-generale.yml
@@ -15,7 +15,7 @@ conditions_generales:
     values:
       - "27"
   - type: quotient_familial
-    floor: 600
+    ceiling: 600
     period: month
   - type: regime_securite_sociale
     includes:

--- a/data/benefits/javascript/caf-eure-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-eure-aide-bafa-generale.yml
@@ -15,7 +15,7 @@ conditions_generales:
     values:
       - "27"
   - type: quotient_familial
-    floor: 600
+    cap: 600
     period: month
   - type: regime_securite_sociale
     includes:

--- a/data/benefits/javascript/caf-eure-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-eure-aide-bafa-generale.yml
@@ -15,7 +15,7 @@ conditions_generales:
     values:
       - "27"
   - type: quotient_familial
-    cap: 600
+    floor: 600
     period: month
   - type: regime_securite_sociale
     includes:

--- a/data/benefits/javascript/caf-haute-marne-aide-equipement-informatique.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-equipement-informatique.yml
@@ -24,7 +24,7 @@ conditions_generales:
     values:
       - "52"
   - type: quotient_familial
-    floor: 800
+    ceiling: 800
     period: month
 profils: []
 link: https://clg-vincenot.monbureaunumerique.fr/lectureFichiergw.do?ID_FICHIER=5901#:~:text=La%20Caisse%20d'Allocations%20Familiales,vous%20soutenir%20dans%20cette%20acquisition.&text=Pour%20les%20allocataires%20avec%20un,aller%20jusqu'%C3%A0%20800%E2%82%AC.

--- a/data/benefits/javascript/caf-haute-marne-aide-equipement-informatique.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-equipement-informatique.yml
@@ -24,7 +24,7 @@ conditions_generales:
     values:
       - "52"
   - type: quotient_familial
-    cap: 800
+    floor: 800
     period: month
 profils: []
 link: https://clg-vincenot.monbureaunumerique.fr/lectureFichiergw.do?ID_FICHIER=5901#:~:text=La%20Caisse%20d'Allocations%20Familiales,vous%20soutenir%20dans%20cette%20acquisition.&text=Pour%20les%20allocataires%20avec%20un,aller%20jusqu'%C3%A0%20800%E2%82%AC.

--- a/data/benefits/javascript/caf-haute-marne-aide-equipement-informatique.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-equipement-informatique.yml
@@ -24,7 +24,7 @@ conditions_generales:
     values:
       - "52"
   - type: quotient_familial
-    floor: 800
+    cap: 800
     period: month
 profils: []
 link: https://clg-vincenot.monbureaunumerique.fr/lectureFichiergw.do?ID_FICHIER=5901#:~:text=La%20Caisse%20d'Allocations%20Familiales,vous%20soutenir%20dans%20cette%20acquisition.&text=Pour%20les%20allocataires%20avec%20un,aller%20jusqu'%C3%A0%20800%E2%82%AC.

--- a/data/benefits/javascript/caf-haute-marne-aide-parcours-jeunes.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-parcours-jeunes.yml
@@ -11,7 +11,7 @@ conditions:
 conditions_generales:
   - type: quotient_familial
     period: month
-    floor: 800
+    cap: 800
   - type: departements
     values:
       - "52"

--- a/data/benefits/javascript/caf-haute-marne-aide-parcours-jeunes.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-parcours-jeunes.yml
@@ -11,7 +11,7 @@ conditions:
 conditions_generales:
   - type: quotient_familial
     period: month
-    cap: 800
+    floor: 800
   - type: departements
     values:
       - "52"

--- a/data/benefits/javascript/caf-haute-marne-aide-parcours-jeunes.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-parcours-jeunes.yml
@@ -11,7 +11,7 @@ conditions:
 conditions_generales:
   - type: quotient_familial
     period: month
-    floor: 800
+    ceiling: 800
   - type: departements
     values:
       - "52"

--- a/data/benefits/javascript/caf-haute-vienne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-vienne-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "87"
   - type: quotient_familial
     period: month
-    cap: 1200
+    floor: 1200
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-haute-vienne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-vienne-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "87"
   - type: quotient_familial
     period: month
-    floor: 1200
+    ceiling: 1200
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-haute-vienne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-vienne-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "87"
   - type: quotient_familial
     period: month
-    floor: 1200
+    cap: 1200
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
@@ -15,7 +15,7 @@ conditions_generales:
       - "65"
   - type: quotient_familial
     period: month
-    cap: 750
+    floor: 750
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-hautes-pyrenees/offre-de-service/solidarite-et-insertion/vous-souhaitez-financer-votre-formation-d-animateur
 form: https://www.caf.fr/sites/default/files/caf/651/Images/Actualite/Plaquette%20social/FORMULAIRE%20DEMANDE%20AIDE%20EXCEPTIONNELLE%20A%20LA%20FORMATION%20BAFA%20proposition.pdf

--- a/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
@@ -15,7 +15,7 @@ conditions_generales:
       - "65"
   - type: quotient_familial
     period: month
-    floor: 750
+    ceiling: 750
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-hautes-pyrenees/offre-de-service/solidarite-et-insertion/vous-souhaitez-financer-votre-formation-d-animateur
 form: https://www.caf.fr/sites/default/files/caf/651/Images/Actualite/Plaquette%20social/FORMULAIRE%20DEMANDE%20AIDE%20EXCEPTIONNELLE%20A%20LA%20FORMATION%20BAFA%20proposition.pdf

--- a/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
@@ -15,7 +15,7 @@ conditions_generales:
       - "65"
   - type: quotient_familial
     period: month
-    floor: 750
+    cap: 750
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-hautes-pyrenees/offre-de-service/solidarite-et-insertion/vous-souhaitez-financer-votre-formation-d-animateur
 form: https://www.caf.fr/sites/default/files/caf/651/Images/Actualite/Plaquette%20social/FORMULAIRE%20DEMANDE%20AIDE%20EXCEPTIONNELLE%20A%20LA%20FORMATION%20BAFA%20proposition.pdf

--- a/data/benefits/javascript/caf-indre-et-loire-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-indre-et-loire-aide-bafa-approfondissement.yml
@@ -13,7 +13,7 @@ conditions_generales:
     values:
       - "37"
   - type: quotient_familial
-    floor: 830
+    cap: 830
     period: month
 profils: []
 interestFlag: _interetBafa

--- a/data/benefits/javascript/caf-indre-et-loire-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-indre-et-loire-aide-bafa-approfondissement.yml
@@ -13,7 +13,7 @@ conditions_generales:
     values:
       - "37"
   - type: quotient_familial
-    floor: 830
+    ceiling: 830
     period: month
 profils: []
 interestFlag: _interetBafa

--- a/data/benefits/javascript/caf-indre-et-loire-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-indre-et-loire-aide-bafa-approfondissement.yml
@@ -13,7 +13,7 @@ conditions_generales:
     values:
       - "37"
   - type: quotient_familial
-    cap: 830
+    floor: 830
     period: month
 profils: []
 interestFlag: _interetBafa

--- a/data/benefits/javascript/caf-indre-et-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-indre-et-loire-aide-bafa-generale.yml
@@ -12,7 +12,7 @@ conditions_generales:
     values:
       - "37"
   - type: quotient_familial
-    floor: 830
+    cap: 830
     period: month
 profils: []
 conditions:

--- a/data/benefits/javascript/caf-indre-et-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-indre-et-loire-aide-bafa-generale.yml
@@ -12,7 +12,7 @@ conditions_generales:
     values:
       - "37"
   - type: quotient_familial
-    cap: 830
+    floor: 830
     period: month
 profils: []
 conditions:

--- a/data/benefits/javascript/caf-indre-et-loire-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-indre-et-loire-aide-bafa-generale.yml
@@ -12,7 +12,7 @@ conditions_generales:
     values:
       - "37"
   - type: quotient_familial
-    floor: 830
+    ceiling: 830
     period: month
 profils: []
 conditions:

--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "41"
   - type: quotient_familial
     period: month
-    cap: 800
+    floor: 800
 profils: []
 interestFlag: _interetBafa
 conditions:

--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "41"
   - type: quotient_familial
     period: month
-    floor: 800
+    cap: 800
 profils: []
 interestFlag: _interetBafa
 conditions:

--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "41"
   - type: quotient_familial
     period: month
-    floor: 800
+    ceiling: 800
 profils: []
 interestFlag: _interetBafa
 conditions:

--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "41"
   - type: quotient_familial
     period: month
-    cap: 800
+    floor: 800
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "41"
   - type: quotient_familial
     period: month
-    floor: 800
+    cap: 800
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-loir-et-cher-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loir-et-cher-aide-bafa-generale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "41"
   - type: quotient_familial
     period: month
-    floor: 800
+    ceiling: 800
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
     value: 16
   - type: quotient_familial
     period: month
-    floor: 856
+    cap: 856
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/enfance-et-jeunesse/bafa
 form: https://www.caf.fr/sites/default/files/caf/471/Documents/offre_de_service/enfance_jeunesse/Demande%20Bafa.pdf

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
     value: 16
   - type: quotient_familial
     period: month
-    floor: 856
+    ceiling: 856
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/enfance-et-jeunesse/bafa
 form: https://www.caf.fr/sites/default/files/caf/471/Documents/offre_de_service/enfance_jeunesse/Demande%20Bafa.pdf

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
     value: 16
   - type: quotient_familial
     period: month
-    cap: 856
+    floor: 856
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/enfance-et-jeunesse/bafa
 form: https://www.caf.fr/sites/default/files/caf/471/Documents/offre_de_service/enfance_jeunesse/Demande%20Bafa.pdf

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "47"
   - type: quotient_familial
     period: month
-    cap: 856
+    floor: 856
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/enfance-et-jeunesse/bafa
 instructions: https://www.caf.fr/sites/default/files/caf/471/Bafa_conditions_2021.pdf

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "47"
   - type: quotient_familial
     period: month
-    floor: 856
+    cap: 856
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/enfance-et-jeunesse/bafa
 instructions: https://www.caf.fr/sites/default/files/caf/471/Bafa_conditions_2021.pdf

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "47"
   - type: quotient_familial
     period: month
-    floor: 856
+    ceiling: 856
 profils: []
 link: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/enfance-et-jeunesse/bafa
 instructions: https://www.caf.fr/sites/default/files/caf/471/Bafa_conditions_2021.pdf

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "54"
   - type: quotient_familial
     period: month
-    floor: 800
+    ceiling: 800
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "54"
   - type: quotient_familial
     period: month
-    floor: 800
+    cap: 800
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "54"
   - type: quotient_familial
     period: month
-    cap: 800
+    floor: 800
 profils: []
 conditions:
   - Etre allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-generale.yml
@@ -15,7 +15,7 @@ conditions_generales:
       - "54"
   - type: quotient_familial
     period: month
-    cap: 800
+    floor: 800
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/enfance-et-jeunesse/la-caf-peut-participer-au-financement-de-la-formation-au-bafa-ou-au-bafd
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres?codePrestation=DBAFA#prestation-DBAFA-cnaf

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-generale.yml
@@ -15,7 +15,7 @@ conditions_generales:
       - "54"
   - type: quotient_familial
     period: month
-    floor: 800
+    ceiling: 800
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/enfance-et-jeunesse/la-caf-peut-participer-au-financement-de-la-formation-au-bafa-ou-au-bafd
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres?codePrestation=DBAFA#prestation-DBAFA-cnaf

--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-generale.yml
@@ -15,7 +15,7 @@ conditions_generales:
       - "54"
   - type: quotient_familial
     period: month
-    floor: 800
+    cap: 800
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/enfance-et-jeunesse/la-caf-peut-participer-au-financement-de-la-formation-au-bafa-ou-au-bafd
 teleservice: https://wwwd.caf.fr/wps/portal/caffr/aidesetservices/lesservicesenligne/faireunedemandedeprestation#/autres?codePrestation=DBAFA#prestation-DBAFA-cnaf

--- a/data/benefits/javascript/caf-nord-aide-achat-equipement.yml
+++ b/data/benefits/javascript/caf-nord-aide-achat-equipement.yml
@@ -9,7 +9,7 @@ conditions_generales:
     values:
       - "59"
   - type: quotient_familial
-    floor: 700
+    cap: 700
     period: month
 profils: []
 conditions:

--- a/data/benefits/javascript/caf-nord-aide-achat-equipement.yml
+++ b/data/benefits/javascript/caf-nord-aide-achat-equipement.yml
@@ -9,7 +9,7 @@ conditions_generales:
     values:
       - "59"
   - type: quotient_familial
-    floor: 700
+    ceiling: 700
     period: month
 profils: []
 conditions:

--- a/data/benefits/javascript/caf-nord-aide-achat-equipement.yml
+++ b/data/benefits/javascript/caf-nord-aide-achat-equipement.yml
@@ -9,7 +9,7 @@ conditions_generales:
     values:
       - "59"
   - type: quotient_familial
-    cap: 700
+    floor: 700
     period: month
 profils: []
 conditions:

--- a/data/benefits/javascript/caf-sarthe-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-sarthe-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "72"
   - type: quotient_familial
     period: month
-    cap: 700
+    floor: 700
 profils: []
 conditions:
   - Être inscrit·e pour le troisième module de formation à une session

--- a/data/benefits/javascript/caf-sarthe-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-sarthe-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "72"
   - type: quotient_familial
     period: month
-    floor: 700
+    cap: 700
 profils: []
 conditions:
   - Être inscrit·e pour le troisième module de formation à une session

--- a/data/benefits/javascript/caf-sarthe-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-sarthe-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "72"
   - type: quotient_familial
     period: month
-    floor: 700
+    ceiling: 700
 profils: []
 conditions:
   - Être inscrit·e pour le troisième module de formation à une session

--- a/data/benefits/javascript/caf-sarthe-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-sarthe-aide-bafa-generale.yml
@@ -13,7 +13,7 @@ conditions_generales:
       - "72"
   - type: quotient_familial
     period: month
-    floor: 700
+    ceiling: 700
 profils: []
 conditions: []
 interestFlag: _interetBafa

--- a/data/benefits/javascript/caf-sarthe-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-sarthe-aide-bafa-generale.yml
@@ -13,7 +13,7 @@ conditions_generales:
       - "72"
   - type: quotient_familial
     period: month
-    floor: 700
+    cap: 700
 profils: []
 conditions: []
 interestFlag: _interetBafa

--- a/data/benefits/javascript/caf-sarthe-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-sarthe-aide-bafa-generale.yml
@@ -13,7 +13,7 @@ conditions_generales:
       - "72"
   - type: quotient_familial
     period: month
-    cap: 700
+    floor: 700
 profils: []
 conditions: []
 interestFlag: _interetBafa

--- a/data/benefits/javascript/caf-seine-maritime-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-seine-maritime-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "76"
   - type: quotient_familial
     period: month
-    floor: 850
+    ceiling: 850
 profils: []
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-seine-maritime-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-seine-maritime-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "76"
   - type: quotient_familial
     period: month
-    cap: 850
+    floor: 850
 profils: []
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-seine-maritime-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-seine-maritime-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "76"
   - type: quotient_familial
     period: month
-    floor: 850
+    cap: 850
 profils: []
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-tarn-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-tarn-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
     values:
       - "81"
   - type: quotient_familial
-    floor: 800
+    cap: 800
     period: month
 profils: []
 conditions:

--- a/data/benefits/javascript/caf-tarn-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-tarn-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
     values:
       - "81"
   - type: quotient_familial
-    floor: 800
+    ceiling: 800
     period: month
 profils: []
 conditions:

--- a/data/benefits/javascript/caf-tarn-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-tarn-aide-bafa-approfondissement.yml
@@ -14,7 +14,7 @@ conditions_generales:
     values:
       - "81"
   - type: quotient_familial
-    cap: 800
+    floor: 800
     period: month
 profils: []
 conditions:

--- a/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-approfondissement.yml
@@ -20,7 +20,7 @@ conditions_generales:
       - "82"
   - type: quotient_familial
     period: month
-    floor: 820
+    cap: 820
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-tarn-et-garonne/offre-de-service/enfance-et-jeunesse/la-formation-au-bafa
 form: https://www.caf.fr/sites/default/files/caf/821/Documents/BAFA%20imprime%20NB.pdf

--- a/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-approfondissement.yml
@@ -20,7 +20,7 @@ conditions_generales:
       - "82"
   - type: quotient_familial
     period: month
-    floor: 820
+    ceiling: 820
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-tarn-et-garonne/offre-de-service/enfance-et-jeunesse/la-formation-au-bafa
 form: https://www.caf.fr/sites/default/files/caf/821/Documents/BAFA%20imprime%20NB.pdf

--- a/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-approfondissement.yml
@@ -20,7 +20,7 @@ conditions_generales:
       - "82"
   - type: quotient_familial
     period: month
-    cap: 820
+    floor: 820
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-tarn-et-garonne/offre-de-service/enfance-et-jeunesse/la-formation-au-bafa
 form: https://www.caf.fr/sites/default/files/caf/821/Documents/BAFA%20imprime%20NB.pdf

--- a/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-generale.yml
@@ -20,7 +20,7 @@ conditions_generales:
       - "82"
   - type: quotient_familial
     period: month
-    floor: 820
+    cap: 820
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-tarn-et-garonne/offre-de-service/enfance-et-jeunesse/la-formation-au-bafa
 form: https://www.caf.fr/sites/default/files/caf/821/Documents/BAFA%20imprime%20NB.pdf

--- a/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-generale.yml
@@ -20,7 +20,7 @@ conditions_generales:
       - "82"
   - type: quotient_familial
     period: month
-    floor: 820
+    ceiling: 820
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-tarn-et-garonne/offre-de-service/enfance-et-jeunesse/la-formation-au-bafa
 form: https://www.caf.fr/sites/default/files/caf/821/Documents/BAFA%20imprime%20NB.pdf

--- a/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-tarn-et-garonne-aide-bafa-generale.yml
@@ -20,7 +20,7 @@ conditions_generales:
       - "82"
   - type: quotient_familial
     period: month
-    cap: 820
+    floor: 820
 profils: []
 link: https://www.caf.fr/allocataires/caf-de-tarn-et-garonne/offre-de-service/enfance-et-jeunesse/la-formation-au-bafa
 form: https://www.caf.fr/sites/default/files/caf/821/Documents/BAFA%20imprime%20NB.pdf

--- a/data/benefits/javascript/caf-var-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-var-aide-bafa-approfondissement.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "83"
   - type: quotient_familial
     period: month
-    cap: 1000
+    floor: 1000
 profils: []
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents, ou

--- a/data/benefits/javascript/caf-var-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-var-aide-bafa-approfondissement.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "83"
   - type: quotient_familial
     period: month
-    floor: 1000
+    ceiling: 1000
 profils: []
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents, ou

--- a/data/benefits/javascript/caf-var-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-var-aide-bafa-approfondissement.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "83"
   - type: quotient_familial
     period: month
-    floor: 1000
+    cap: 1000
 profils: []
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents, ou

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "84"
   - type: quotient_familial
     period: month
-    floor: 396
+    ceiling: 396
 profils: []
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "84"
   - type: quotient_familial
     period: month
-    cap: 396
+    floor: 396
 profils: []
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
@@ -17,7 +17,7 @@ conditions_generales:
       - "84"
   - type: quotient_familial
     period: month
-    floor: 396
+    cap: 396
 profils: []
 conditions:
   - Être allocataire ou rattaché·e au dossier allocataire de vos parents.

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
@@ -20,7 +20,7 @@ conditions_generales:
       - "84"
   - type: quotient_familial
     period: month
-    cap: 396
+    floor: 396
 profils: []
 link: https://www.caf.fr/partenaires/caf-de-vaucluse/partenaires-locaux/jeunesse/brevet-d-aptitude-aux-fonctions-d-animateurs-bafa-les-aides-de-la-caf#:~:text=La%20CAF%20de%20Vaucluse%20apporte,dans%20leur%20d%C3%A9marche%20de%20formation.&text=%3E%20L'organisme%20de%20formation%20doit,Administration%20est%20de%20198%20%E2%82%AC.
 instructions: https://www.caf.fr/partenaires/caf-de-vaucluse/partenaires-locaux/jeunesse/brevet-d-aptitude-aux-fonctions-d-animateurs-bafa-les-aides-de-la-caf#:~:text=La%20CAF%20de%20Vaucluse%20apporte,dans%20leur%20d%C3%A9marche%20de%20formation.&text=%3E%20L'organisme%20de%20formation%20doit,Administration%20est%20de%20198%20%E2%82%AC.

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
@@ -20,7 +20,7 @@ conditions_generales:
       - "84"
   - type: quotient_familial
     period: month
-    floor: 396
+    cap: 396
 profils: []
 link: https://www.caf.fr/partenaires/caf-de-vaucluse/partenaires-locaux/jeunesse/brevet-d-aptitude-aux-fonctions-d-animateurs-bafa-les-aides-de-la-caf#:~:text=La%20CAF%20de%20Vaucluse%20apporte,dans%20leur%20d%C3%A9marche%20de%20formation.&text=%3E%20L'organisme%20de%20formation%20doit,Administration%20est%20de%20198%20%E2%82%AC.
 instructions: https://www.caf.fr/partenaires/caf-de-vaucluse/partenaires-locaux/jeunesse/brevet-d-aptitude-aux-fonctions-d-animateurs-bafa-les-aides-de-la-caf#:~:text=La%20CAF%20de%20Vaucluse%20apporte,dans%20leur%20d%C3%A9marche%20de%20formation.&text=%3E%20L'organisme%20de%20formation%20doit,Administration%20est%20de%20198%20%E2%82%AC.

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
@@ -20,7 +20,7 @@ conditions_generales:
       - "84"
   - type: quotient_familial
     period: month
-    floor: 396
+    ceiling: 396
 profils: []
 link: https://www.caf.fr/partenaires/caf-de-vaucluse/partenaires-locaux/jeunesse/brevet-d-aptitude-aux-fonctions-d-animateurs-bafa-les-aides-de-la-caf#:~:text=La%20CAF%20de%20Vaucluse%20apporte,dans%20leur%20d%C3%A9marche%20de%20formation.&text=%3E%20L'organisme%20de%20formation%20doit,Administration%20est%20de%20198%20%E2%82%AC.
 instructions: https://www.caf.fr/partenaires/caf-de-vaucluse/partenaires-locaux/jeunesse/brevet-d-aptitude-aux-fonctions-d-animateurs-bafa-les-aides-de-la-caf#:~:text=La%20CAF%20de%20Vaucluse%20apporte,dans%20leur%20d%C3%A9marche%20de%20formation.&text=%3E%20L'organisme%20de%20formation%20doit,Administration%20est%20de%20198%20%E2%82%AC.

--- a/data/benefits/javascript/caf-vosges-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vosges-aide-bafa-generale.yml
@@ -19,7 +19,7 @@ conditions_generales:
       - "88"
   - type: quotient_familial
     period: month
-    floor: 670
+    ceiling: 670
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-vosges/offre-de-service/enfance-et-jeunesse/les-bourses-bafa-et-bafd
 instructions: https://www.caf.fr/allocataires/caf-des-vosges/offre-de-service/enfance-et-jeunesse/les-bourses-bafa-et-bafd

--- a/data/benefits/javascript/caf-vosges-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vosges-aide-bafa-generale.yml
@@ -19,7 +19,7 @@ conditions_generales:
       - "88"
   - type: quotient_familial
     period: month
-    floor: 670
+    cap: 670
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-vosges/offre-de-service/enfance-et-jeunesse/les-bourses-bafa-et-bafd
 instructions: https://www.caf.fr/allocataires/caf-des-vosges/offre-de-service/enfance-et-jeunesse/les-bourses-bafa-et-bafd

--- a/data/benefits/javascript/caf-vosges-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vosges-aide-bafa-generale.yml
@@ -19,7 +19,7 @@ conditions_generales:
       - "88"
   - type: quotient_familial
     period: month
-    cap: 670
+    floor: 670
 profils: []
 link: https://www.caf.fr/allocataires/caf-des-vosges/offre-de-service/enfance-et-jeunesse/les-bourses-bafa-et-bafd
 instructions: https://www.caf.fr/allocataires/caf-des-vosges/offre-de-service/enfance-et-jeunesse/les-bourses-bafa-et-bafd

--- a/data/benefits/javascript/caf_dordogne-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
+++ b/data/benefits/javascript/caf_dordogne-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
@@ -7,7 +7,7 @@ description: L'aide à la formation du BAFA est une aide locale mise à
 prefix: l’
 conditions_generales:
   - type: quotient_familial
-    cap: 622
+    floor: 622
     period: month
   - type: departements
     values:

--- a/data/benefits/javascript/caf_dordogne-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
+++ b/data/benefits/javascript/caf_dordogne-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
@@ -7,7 +7,7 @@ description: L'aide à la formation du BAFA est une aide locale mise à
 prefix: l’
 conditions_generales:
   - type: quotient_familial
-    floor: 622
+    cap: 622
     period: month
   - type: departements
     values:

--- a/data/benefits/javascript/caf_dordogne-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
+++ b/data/benefits/javascript/caf_dordogne-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
@@ -7,7 +7,7 @@ description: L'aide à la formation du BAFA est une aide locale mise à
 prefix: l’
 conditions_generales:
   - type: quotient_familial
-    floor: 622
+    ceiling: 622
     period: month
   - type: departements
     values:

--- a/data/benefits/javascript/caf_eure-aide-au-brevet-daptitude-aux-fonctions-de-directeur-bafd.yml
+++ b/data/benefits/javascript/caf_eure-aide-au-brevet-daptitude-aux-fonctions-de-directeur-bafd.yml
@@ -8,7 +8,7 @@ conditions_generales:
     operator: ">="
     value: 18
   - type: quotient_familial
-    floor: 600
+    ceiling: 600
     period: month
   - type: regime_securite_sociale
     includes:

--- a/data/benefits/javascript/caf_eure-aide-au-brevet-daptitude-aux-fonctions-de-directeur-bafd.yml
+++ b/data/benefits/javascript/caf_eure-aide-au-brevet-daptitude-aux-fonctions-de-directeur-bafd.yml
@@ -8,7 +8,7 @@ conditions_generales:
     operator: ">="
     value: 18
   - type: quotient_familial
-    floor: 600
+    cap: 600
     period: month
   - type: regime_securite_sociale
     includes:

--- a/data/benefits/javascript/caf_eure-aide-au-brevet-daptitude-aux-fonctions-de-directeur-bafd.yml
+++ b/data/benefits/javascript/caf_eure-aide-au-brevet-daptitude-aux-fonctions-de-directeur-bafd.yml
@@ -8,7 +8,7 @@ conditions_generales:
     operator: ">="
     value: 18
   - type: quotient_familial
-    cap: 600
+    floor: 600
     period: month
   - type: regime_securite_sociale
     includes:

--- a/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
+++ b/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "35"
   - type: quotient_familial
     period: month
-    floor: 750
+    cap: 750
 profils: []
 interestFlag: _interetBafa
 type: bool

--- a/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
+++ b/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "35"
   - type: quotient_familial
     period: month
-    floor: 750
+    ceiling: 750
 profils: []
 interestFlag: _interetBafa
 type: bool

--- a/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
+++ b/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
@@ -14,7 +14,7 @@ conditions_generales:
       - "35"
   - type: quotient_familial
     period: month
-    cap: 750
+    floor: 750
 profils: []
 interestFlag: _interetBafa
 type: bool

--- a/data/benefits/javascript/caf_isere-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
+++ b/data/benefits/javascript/caf_isere-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
@@ -13,7 +13,7 @@ conditions_generales:
     operator: <=
     value: 25
   - type: quotient_familial
-    floor: 800
+    ceiling: 800
     period: month
   - type: departements
     values:

--- a/data/benefits/javascript/caf_isere-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
+++ b/data/benefits/javascript/caf_isere-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
@@ -13,7 +13,7 @@ conditions_generales:
     operator: <=
     value: 25
   - type: quotient_familial
-    floor: 800
+    cap: 800
     period: month
   - type: departements
     values:

--- a/data/benefits/javascript/caf_isere-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
+++ b/data/benefits/javascript/caf_isere-aide-au-bafa-pour-une-session-de-formation-générale-et-dapprofondissement.yml
@@ -13,7 +13,7 @@ conditions_generales:
     operator: <=
     value: 25
   - type: quotient_familial
-    cap: 800
+    floor: 800
     period: month
   - type: departements
     values:

--- a/data/benefits/javascript/caf_pas_de_calais-aide-au-bafa-pour-une-session-de-formation-générale.yml
+++ b/data/benefits/javascript/caf_pas_de_calais-aide-au-bafa-pour-une-session-de-formation-générale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "62"
   - type: quotient_familial
     period: month
-    cap: 1000
+    floor: 1000
 profils: []
 conditions:
   - Effectuer votre formation en externat et en demi-pension.

--- a/data/benefits/javascript/caf_pas_de_calais-aide-au-bafa-pour-une-session-de-formation-générale.yml
+++ b/data/benefits/javascript/caf_pas_de_calais-aide-au-bafa-pour-une-session-de-formation-générale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "62"
   - type: quotient_familial
     period: month
-    floor: 1000
+    cap: 1000
 profils: []
 conditions:
   - Effectuer votre formation en externat et en demi-pension.

--- a/data/benefits/javascript/caf_pas_de_calais-aide-au-bafa-pour-une-session-de-formation-générale.yml
+++ b/data/benefits/javascript/caf_pas_de_calais-aide-au-bafa-pour-une-session-de-formation-générale.yml
@@ -16,7 +16,7 @@ conditions_generales:
       - "62"
   - type: quotient_familial
     period: month
-    floor: 1000
+    ceiling: 1000
 profils: []
 conditions:
   - Effectuer votre formation en externat et en demi-pension.

--- a/data/benefits/javascript/caf_pas_de_calais-aide-à-loutillage.yml
+++ b/data/benefits/javascript/caf_pas_de_calais-aide-à-loutillage.yml
@@ -15,7 +15,7 @@ conditions_generales:
     values:
       - "62"
   - type: quotient_familial
-    floor: 617
+    ceiling: 617
     period: year
 profils:
   - type: apprenti

--- a/data/benefits/javascript/caf_pas_de_calais-aide-à-loutillage.yml
+++ b/data/benefits/javascript/caf_pas_de_calais-aide-à-loutillage.yml
@@ -15,7 +15,7 @@ conditions_generales:
     values:
       - "62"
   - type: quotient_familial
-    cap: 617
+    floor: 617
     period: year
 profils:
   - type: apprenti

--- a/data/benefits/javascript/caf_pas_de_calais-aide-à-loutillage.yml
+++ b/data/benefits/javascript/caf_pas_de_calais-aide-à-loutillage.yml
@@ -15,7 +15,7 @@ conditions_generales:
     values:
       - "62"
   - type: quotient_familial
-    floor: 617
+    cap: 617
     period: year
 profils:
   - type: apprenti

--- a/data/benefits/javascript/caf_saone_et_loire-aide-à-lautonomie-des-jeunes.yml
+++ b/data/benefits/javascript/caf_saone_et_loire-aide-à-lautonomie-des-jeunes.yml
@@ -12,7 +12,7 @@ conditions_generales:
     values:
       - "71"
   - type: quotient_familial
-    cap: 1200
+    floor: 1200
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf_saone_et_loire-aide-à-lautonomie-des-jeunes.yml
+++ b/data/benefits/javascript/caf_saone_et_loire-aide-à-lautonomie-des-jeunes.yml
@@ -12,7 +12,7 @@ conditions_generales:
     values:
       - "71"
   - type: quotient_familial
-    floor: 1200
+    ceiling: 1200
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/caf_saone_et_loire-aide-à-lautonomie-des-jeunes.yml
+++ b/data/benefits/javascript/caf_saone_et_loire-aide-à-lautonomie-des-jeunes.yml
@@ -12,7 +12,7 @@ conditions_generales:
     values:
       - "71"
   - type: quotient_familial
-    floor: 1200
+    cap: 1200
     period: month
   - type: age
     operator: ">="

--- a/data/benefits/javascript/hauts-de-france-bourse-mobilite-mermoz.yml
+++ b/data/benefits/javascript/hauts-de-france-bourse-mobilite-mermoz.yml
@@ -17,7 +17,7 @@ conditions_generales:
     values:
       - "32"
   - type: quotient_familial
-    cap: 30000
+    floor: 30000
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/hauts-de-france-bourse-mobilite-mermoz.yml
+++ b/data/benefits/javascript/hauts-de-france-bourse-mobilite-mermoz.yml
@@ -17,7 +17,7 @@ conditions_generales:
     values:
       - "32"
   - type: quotient_familial
-    floor: 30000
+    cap: 30000
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/hauts-de-france-bourse-mobilite-mermoz.yml
+++ b/data/benefits/javascript/hauts-de-france-bourse-mobilite-mermoz.yml
@@ -17,7 +17,7 @@ conditions_generales:
     values:
       - "32"
   - type: quotient_familial
-    floor: 30000
+    ceiling: 30000
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/region-bourgogne-franche-comte-etudes-etranger-aquisis.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-etudes-etranger-aquisis.yml
@@ -13,7 +13,7 @@ conditions_generales:
     values:
       - "27"
   - type: quotient_familial
-    floor: 25830
+    cap: 25830
     period: year
 profils:
   - type: apprenti

--- a/data/benefits/javascript/region-bourgogne-franche-comte-etudes-etranger-aquisis.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-etudes-etranger-aquisis.yml
@@ -13,7 +13,7 @@ conditions_generales:
     values:
       - "27"
   - type: quotient_familial
-    floor: 25830
+    ceiling: 25830
     period: year
 profils:
   - type: apprenti

--- a/data/benefits/javascript/region-bourgogne-franche-comte-etudes-etranger-aquisis.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-etudes-etranger-aquisis.yml
@@ -13,7 +13,7 @@ conditions_generales:
     values:
       - "27"
   - type: quotient_familial
-    cap: 25830
+    floor: 25830
     period: year
 profils:
   - type: apprenti

--- a/data/benefits/javascript/region-bretagne-bourse-international-bts-dut.yml
+++ b/data/benefits/javascript/region-bretagne-bourse-international-bts-dut.yml
@@ -15,7 +15,7 @@ conditions_generales:
     values:
       - "53"
   - type: quotient_familial
-    floor: 25000
+    cap: 25000
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/region-bretagne-bourse-international-bts-dut.yml
+++ b/data/benefits/javascript/region-bretagne-bourse-international-bts-dut.yml
@@ -15,7 +15,7 @@ conditions_generales:
     values:
       - "53"
   - type: quotient_familial
-    floor: 25000
+    ceiling: 25000
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/region-bretagne-bourse-international-bts-dut.yml
+++ b/data/benefits/javascript/region-bretagne-bourse-international-bts-dut.yml
@@ -15,7 +15,7 @@ conditions_generales:
     values:
       - "53"
   - type: quotient_familial
-    cap: 25000
+    floor: 25000
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/region-bretagne-bourse-international-formation-sanitaires-sociales.yml
+++ b/data/benefits/javascript/region-bretagne-bourse-international-formation-sanitaires-sociales.yml
@@ -16,7 +16,7 @@ conditions_generales:
     values:
       - "53"
   - type: quotient_familial
-    cap: 25000
+    floor: 25000
     period: year
   - type: formation_sanitaire_social
 profils:

--- a/data/benefits/javascript/region-bretagne-bourse-international-formation-sanitaires-sociales.yml
+++ b/data/benefits/javascript/region-bretagne-bourse-international-formation-sanitaires-sociales.yml
@@ -16,7 +16,7 @@ conditions_generales:
     values:
       - "53"
   - type: quotient_familial
-    floor: 25000
+    ceiling: 25000
     period: year
   - type: formation_sanitaire_social
 profils:

--- a/data/benefits/javascript/region-bretagne-bourse-international-formation-sanitaires-sociales.yml
+++ b/data/benefits/javascript/region-bretagne-bourse-international-formation-sanitaires-sociales.yml
@@ -16,7 +16,7 @@ conditions_generales:
     values:
       - "53"
   - type: quotient_familial
-    floor: 25000
+    cap: 25000
     period: year
   - type: formation_sanitaire_social
 profils:

--- a/data/benefits/javascript/region-ile-de-france-bourses-mobilite-etudiants-dut-licence-master.yml
+++ b/data/benefits/javascript/region-ile-de-france-bourses-mobilite-etudiants-dut-licence-master.yml
@@ -16,7 +16,7 @@ conditions_generales:
     values:
       - "11"
   - type: quotient_familial
-    floor: 19190
+    cap: 19190
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/region-ile-de-france-bourses-mobilite-etudiants-dut-licence-master.yml
+++ b/data/benefits/javascript/region-ile-de-france-bourses-mobilite-etudiants-dut-licence-master.yml
@@ -16,7 +16,7 @@ conditions_generales:
     values:
       - "11"
   - type: quotient_familial
-    cap: 19190
+    floor: 19190
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/region-ile-de-france-bourses-mobilite-etudiants-dut-licence-master.yml
+++ b/data/benefits/javascript/region-ile-de-france-bourses-mobilite-etudiants-dut-licence-master.yml
@@ -16,7 +16,7 @@ conditions_generales:
     values:
       - "11"
   - type: quotient_familial
-    floor: 19190
+    ceiling: 19190
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/region-la-reunion-etudier-au-quebec.yml
+++ b/data/benefits/javascript/region-la-reunion-etudier-au-quebec.yml
@@ -8,7 +8,7 @@ conditions_generales:
     values:
       - "04"
   - type: quotient_familial
-    floor: 26631
+    ceiling: 26631
     period: year
 profils:
   - type: lyceen

--- a/data/benefits/javascript/region-la-reunion-etudier-au-quebec.yml
+++ b/data/benefits/javascript/region-la-reunion-etudier-au-quebec.yml
@@ -8,7 +8,7 @@ conditions_generales:
     values:
       - "04"
   - type: quotient_familial
-    floor: 26631
+    cap: 26631
     period: year
 profils:
   - type: lyceen

--- a/data/benefits/javascript/region-la-reunion-etudier-au-quebec.yml
+++ b/data/benefits/javascript/region-la-reunion-etudier-au-quebec.yml
@@ -8,7 +8,7 @@ conditions_generales:
     values:
       - "04"
   - type: quotient_familial
-    cap: 26631
+    floor: 26631
     period: year
 profils:
   - type: lyceen

--- a/data/benefits/javascript/region-normandie-pass-monde-etudes-secondaires.yml
+++ b/data/benefits/javascript/region-normandie-pass-monde-etudes-secondaires.yml
@@ -24,7 +24,7 @@ conditions_generales:
     values:
       - "28"
   - type: quotient_familial
-    floor: 30000
+    cap: 30000
     period: year
 profils:
   - type: lyceen

--- a/data/benefits/javascript/region-normandie-pass-monde-etudes-secondaires.yml
+++ b/data/benefits/javascript/region-normandie-pass-monde-etudes-secondaires.yml
@@ -24,7 +24,7 @@ conditions_generales:
     values:
       - "28"
   - type: quotient_familial
-    cap: 30000
+    floor: 30000
     period: year
 profils:
   - type: lyceen

--- a/data/benefits/javascript/region-normandie-pass-monde-etudes-secondaires.yml
+++ b/data/benefits/javascript/region-normandie-pass-monde-etudes-secondaires.yml
@@ -24,7 +24,7 @@ conditions_generales:
     values:
       - "28"
   - type: quotient_familial
-    floor: 30000
+    ceiling: 30000
     period: year
 profils:
   - type: lyceen

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-programme-regional-aide-mobilite-etudiante-prame.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-programme-regional-aide-mobilite-etudiante-prame.yml
@@ -9,7 +9,7 @@ conditions_generales:
       - "93"
   - type: quotient_familial
     period: year
-    cap: 26000
+    floor: 26000
   - type: age
     operator: <=
     value: 30

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-programme-regional-aide-mobilite-etudiante-prame.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-programme-regional-aide-mobilite-etudiante-prame.yml
@@ -9,7 +9,7 @@ conditions_generales:
       - "93"
   - type: quotient_familial
     period: year
-    floor: 26000
+    cap: 26000
   - type: age
     operator: <=
     value: 30

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-programme-regional-aide-mobilite-etudiante-prame.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-programme-regional-aide-mobilite-etudiante-prame.yml
@@ -9,7 +9,7 @@ conditions_generales:
       - "93"
   - type: quotient_familial
     period: year
-    floor: 26000
+    ceiling: 26000
   - type: age
     operator: <=
     value: 30

--- a/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
+++ b/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
@@ -10,7 +10,7 @@ conditions_generales:
     values:
       - "11"
   - type: quotient_familial
-    floor: 10140
+    ceiling: 10140
     period: year
 profils:
   - type: etudiant

--- a/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
+++ b/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
@@ -10,7 +10,7 @@ conditions_generales:
     values:
       - "11"
   - type: quotient_familial
-    floor: 10140
+    cap: 10140
     period: year
 profils:
   - type: etudiant

--- a/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
+++ b/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
@@ -10,7 +10,7 @@ conditions_generales:
     values:
       - "11"
   - type: quotient_familial
-    cap: 10140
+    floor: 10140
     period: year
 profils:
   - type: etudiant

--- a/data/benefits/javascript/region_normandie-pass-monde-etudes-supérieures-1.yml
+++ b/data/benefits/javascript/region_normandie-pass-monde-etudes-supérieures-1.yml
@@ -25,7 +25,7 @@ conditions_generales:
     operator: <=
     value: 30
   - type: quotient_familial
-    cap: 30000
+    floor: 30000
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/region_normandie-pass-monde-etudes-supérieures-1.yml
+++ b/data/benefits/javascript/region_normandie-pass-monde-etudes-supérieures-1.yml
@@ -25,7 +25,7 @@ conditions_generales:
     operator: <=
     value: 30
   - type: quotient_familial
-    floor: 30000
+    cap: 30000
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/region_normandie-pass-monde-etudes-supérieures-1.yml
+++ b/data/benefits/javascript/region_normandie-pass-monde-etudes-supérieures-1.yml
@@ -25,7 +25,7 @@ conditions_generales:
     operator: <=
     value: 30
   - type: quotient_familial
-    floor: 30000
+    ceiling: 30000
     period: year
 profils:
   - type: enseignement_superieur

--- a/data/benefits/javascript/region_normandie-pass-monde-volontariat.yml
+++ b/data/benefits/javascript/region_normandie-pass-monde-volontariat.yml
@@ -27,7 +27,7 @@ conditions_generales:
     values:
       - "28"
   - type: quotient_familial
-    cap: 30000
+    floor: 30000
     period: year
 profils:
   - type: lyceen

--- a/data/benefits/javascript/region_normandie-pass-monde-volontariat.yml
+++ b/data/benefits/javascript/region_normandie-pass-monde-volontariat.yml
@@ -27,7 +27,7 @@ conditions_generales:
     values:
       - "28"
   - type: quotient_familial
-    floor: 30000
+    ceiling: 30000
     period: year
 profils:
   - type: lyceen

--- a/data/benefits/javascript/region_normandie-pass-monde-volontariat.yml
+++ b/data/benefits/javascript/region_normandie-pass-monde-volontariat.yml
@@ -27,7 +27,7 @@ conditions_generales:
     values:
       - "28"
   - type: quotient_familial
-    floor: 30000
+    cap: 30000
     period: year
 profils:
   - type: lyceen

--- a/lib/benefits/compute-javascript.ts
+++ b/lib/benefits/compute-javascript.ts
@@ -213,7 +213,7 @@ export const CONDITION_STRATEGY: ConditionsLayout = {
         openfiscaResponse.foyers_fiscaux._.nbptr[periods.fiscalYear.id] || 1
       const periodDivider = condition.period === "month" ? 12 : 1
       const quotient_familial = rfr / nbptr / periodDivider
-      return quotient_familial <= condition.floor
+      return quotient_familial <= condition.ceiling
     },
     extra: [
       {

--- a/lib/benefits/compute-javascript.ts
+++ b/lib/benefits/compute-javascript.ts
@@ -213,7 +213,7 @@ export const CONDITION_STRATEGY: ConditionsLayout = {
         openfiscaResponse.foyers_fiscaux._.nbptr[periods.fiscalYear.id] || 1
       const periodDivider = condition.period === "month" ? 12 : 1
       const quotient_familial = rfr / nbptr / periodDivider
-      return quotient_familial <= condition.cap
+      return quotient_familial <= condition.floor
     },
     extra: [
       {

--- a/lib/benefits/compute-javascript.ts
+++ b/lib/benefits/compute-javascript.ts
@@ -213,7 +213,7 @@ export const CONDITION_STRATEGY: ConditionsLayout = {
         openfiscaResponse.foyers_fiscaux._.nbptr[periods.fiscalYear.id] || 1
       const periodDivider = condition.period === "month" ? 12 : 1
       const quotient_familial = rfr / nbptr / periodDivider
-      return quotient_familial <= condition.floor
+      return quotient_familial <= condition.cap
     },
     extra: [
       {


### PR DESCRIPTION
Certaines aides javascripts contiennent une condition quotient familial dont l'éligibilité se mesure grâce à un `plafond`.

Ce plafond est aujourd’hui appelé `floor`, qui se traduit par "sol" en français.

Par exemple, pour une aide avec un `floor` de 800, un foyer est éligible si son quotient familiale est inférieur ou egale à 800.

Le terme floor n’est pas du tout parlant, il faut le changer dans le code JS (est donc aussi pour toutes les aides conditionnées par le quotient familial).

Voici une proposition de changement pour le terme `cap` qui me semble être le terme qui traduit le mieux la notion métier de `Plafond`.
