### PR TITLE
Correction de la modélisation de l'aide guadeloupe-hebergement-cite-internationale-universitaire-de-paris

### DIFF
--- a/data/benefits/javascript/guadeloupe-hebergement-cite-internationale-universitaire-de-paris.yml
+++ b/data/benefits/javascript/guadeloupe-hebergement-cite-internationale-universitaire-de-paris.yml
@@ -16,8 +16,6 @@ profils:
       - type: annee_etude
         values:
           - master_1
-      - type: annee_etude
-        values:
           - master_2
 conditions:
   - Être inscrit·e au sein d’un établissement d’enseignement supérieur privé ou


### PR DESCRIPTION
L'aide `guadeloupe-hebergement-cite-internationale-universitaire-de-paris` était mal modélisée, demandant d'être à la fois en master 1 ET 2 pour bénéficier de l'aide.