### PR TITLE
Autorise l'entrée vide pour un input number sans message d'erreur

### DIFF
--- a/src/components/input-number.vue
+++ b/src/components/input-number.vue
@@ -50,7 +50,7 @@ export default {
         return this.value || this.modelValue
       },
       set(value) {
-        if (value || value === 0) {
+        if (value || value === (0 || "")) {
           this.error = false
           this.$emit("update:modelValue", value)
         } else {


### PR DESCRIPTION
[Tâche Trello](https://trello.com/c/CxkQhyzX/1046-sur-la-page-de-revenus-ex-revenusactivite-entr%C3%A9e-une-valeur-valide-dans-un-champ-puis-la-supprimer-fait-apparaitre-un-message-de)