### PR TITLE
Corrige les warnings de la page /loyer

### DIFF
--- a/src/components/base-layout.vue
+++ b/src/components/base-layout.vue
@@ -11,7 +11,7 @@
           <router-link
             class="fr-link"
             :to="{ hash: '#main' }"
-            :aria-current="none"
+            aria-current="none"
             >Contenu</router-link
           >
         </li>
@@ -19,7 +19,7 @@
           <router-link
             class="fr-link"
             :to="{ hash: '#navigation' }"
-            :aria-current="none"
+            aria-current="none"
             >Menu</router-link
           >
         </li>
@@ -27,7 +27,7 @@
           <router-link
             class="fr-link"
             :to="{ hash: '#footer' }"
-            :aria-current="none"
+            aria-current="none"
             >Pied de page</router-link
           >
         </li>

--- a/src/views/simulation/Menage/loyer.vue
+++ b/src/views/simulation/Menage/loyer.vue
@@ -38,7 +38,7 @@
             <InputNumber
               id="charges"
               v-model="chargesQuestion.selectedValue"
-              data-testid="loyer"
+              data-testid="charges"
               :min="0"
             />
           </div>

--- a/src/views/simulation/Menage/loyer.vue
+++ b/src/views/simulation/Menage/loyer.vue
@@ -69,7 +69,11 @@ export default {
     return { store: useStore() }
   },
   data() {
-    return Logement.getLoyerData(this.store.simulation.answers.all)
+    return {
+      ...Logement.getLoyerData(this.store.simulation.answers.all),
+      chargesQuestion: Logement.getLoyerData(this.store.simulation.answers.all)
+        .chargesQuestion,
+    }
   },
   computed: {
     canSubmit() {

--- a/src/views/simulation/Menage/loyer.vue
+++ b/src/views/simulation/Menage/loyer.vue
@@ -38,7 +38,6 @@
             <InputNumber
               id="charges"
               v-model="chargesQuestion.selectedValue"
-              data-testid="charges"
               :min="0"
             />
           </div>
@@ -69,11 +68,7 @@ export default {
     return { store: useStore() }
   },
   data() {
-    return {
-      ...Logement.getLoyerData(this.store.simulation.answers.all),
-      chargesQuestion: Logement.getLoyerData(this.store.simulation.answers.all)
-        .chargesQuestion,
-    }
+    return Logement.getLoyerData(this.store.simulation.answers.all)
   },
   computed: {
     canSubmit() {


### PR DESCRIPTION
[Tâche trello](https://trello.com/c/zjzDemha/1082-corriger-les-warnings-dans-la-page-loyer)

Sur à un fix bug, le warning suivant s’affiche à l’ouverture de la page /loyer durant la simulation :

**Comment reproduire le bug ?**
- lancer une simulation
- à la page du type de logement, choisir “propriétaire”
- continuer jusqu'à la page des mensualités

=> constater les warnings dans la console

**Définition de la tâche terminée :** le warning ne doit plus apparaître + en profiter pour rectifier le test qui ne rentre pas la charge dans le test student (mauvais data-testid)