### PR TITLE
Ajout d'une valeur min et max pour nbptr

### DIFF
--- a/lib/properties/parents-properties.ts
+++ b/lib/properties/parents-properties.ts
@@ -41,6 +41,8 @@ export default {
     questionType: "number",
     optional: true,
     type: "count",
+    min: 0,
+    max: 30,
     moreInfo:
       "Une part fiscale est une unité représentative des personnes composant le foyer fiscal, servant au calcul de l’impôt sur le revenu.",
   }),

--- a/lib/properties/property.ts
+++ b/lib/properties/property.ts
@@ -202,6 +202,7 @@ export class NumberProperty extends Property {
   type: string
   unit?: string
   min?: number
+  max?: number
 
   constructor({
     type = "amount",
@@ -214,6 +215,7 @@ export class NumberProperty extends Property {
     this.type = type
     this.unit = numberPropertyConstruct.unit
     this.min = numberPropertyConstruct.min
+    this.max = numberPropertyConstruct.max
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -221,6 +223,7 @@ export class NumberProperty extends Property {
     return {
       type: "number",
       min: this.min,
+      max: this.max,
     }
   }
 

--- a/lib/types/property.d.ts
+++ b/lib/types/property.d.ts
@@ -43,6 +43,7 @@ export interface NumberPropertyConstruct extends PropertyConstruct {
   type?: string
   unit?: string
   min?: number
+  max?: number
 }
 
 export interface RecapPropertyLine {

--- a/src/views/simulation/mutualized-step.vue
+++ b/src/views/simulation/mutualized-step.vue
@@ -43,6 +43,7 @@
                     :id="fieldName"
                     v-model="value"
                     :min="step.min"
+                    :max="step.max"
                     :data-type="step.type"
                     ariaLabelledBy="step-question"
                   />


### PR DESCRIPTION
## Détails

Le champ "nombre de part sur l'avis d'imposition des parents" est souvent mal rempli. Pour faciliter l'entrée de donnée correcte, le champ a pour valeur minimum `0` et valeur maximum `30`.

Le plafond du champ est arbitrairement fixé à `30` alors qu'il n'y a pas de valeur maximum théorique. Cependant en prenant en compte les critères de [service-public.fr](https://www.service-public.fr/particuliers/vosdroits/F2705), il faudrait une famille de plus de 25 enfants.

Au-delà de l'aspect technique de cette PR, la pertinence des valeurs minimum et maximum est à débattre en review.