### PR TITLE
[FIX] Corrige un bug dû à l'absence de polyfill pour replaceAll sur certains navigateurs

### DIFF
--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,5 +1,5 @@
 export function stringIsValidNumber(value, min = null, max = null) {
-  value = value.replaceAll(/\s/g, "").replaceAll(/,/g, ".")
+  value = (value || "").replace(/\s/g, "").replace(/,/g, ".")
   // regex:
   // ^(-)?              may start with a minus sign
   // (\d)+              as at least one digit
@@ -12,7 +12,7 @@ export function stringIsValidNumber(value, min = null, max = null) {
 }
 
 export function stringToNumber(value) {
-  value = value.replaceAll(/\s/g, "").replaceAll(/,/g, ".")
+  value = (value || "").replace(/\s/g, "").replace(/,/g, ".")
   value = value === "" ? "0" : value
   const trailingZeros = value.match(/(\.)0+$/)
   if (trailingZeros) {


### PR DESCRIPTION
## Détails

[Erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/16340/?project=18&query=is%3Aunresolved)

Une erreur sentry est retournée par certains utilisateurs dont le navigateur ne supporte pas la méthode `String.replaceAll()`. Sachant que l'on utilise une regex avec le paramètre `/g`, utiliser `replace` ou `replaceAll` a le même effet.

La méthode `replaceAll` aurait cependant dû être remplacée par un polyfill lors du build par Vite. Le problème semble venir du fait que le plugin Vite "Vite plugin legacy" utilise une version de `core-js` inférieure à celle supportant `replaceAll`. Plus d'informations : https://github.com/babel/babel/issues/13701