### PR TITLE
Question nombre de mois d'entrée logement

### DIFF
--- a/cypress/e2e/student.cy.js
+++ b/cypress/e2e/student.cy.js
@@ -40,7 +40,7 @@ context("Full simulation", () => {
       "75001",
       "_bourseCriteresSociauxCommuneDomicileFamilial"
     )
-    logement.fill__nombreMoisEntreeLogement(12)
+    logement.fill__nombreMoisEntreeLogement(-2)
 
     revenu.fill_ressources_types(["salaire_net"])
     revenu.fillConstantRevenu(1101.42)

--- a/lib/properties/menage-properties.ts
+++ b/lib/properties/menage-properties.ts
@@ -39,7 +39,7 @@ export default {
       { value: 12, label: "Oui" },
       {
         value: -2,
-        label: "Non, j'ai emmenagé il y a moins de 3 mois",
+        label: "Non, j'ai emménagé il y a moins de 3 mois",
         isRelevant: ({ simulation }) => {
           const value = getAnswer(
             simulation.answers.current,

--- a/lib/properties/menage-properties.ts
+++ b/lib/properties/menage-properties.ts
@@ -46,7 +46,7 @@ export default {
             "menage",
             "_logementType"
           )
-          return _logementType ==="locataire"
+          return value === "locataire"
         },
       },
       { value: -12, label: "Non" },

--- a/lib/properties/menage-properties.ts
+++ b/lib/properties/menage-properties.ts
@@ -44,7 +44,7 @@ export default {
           const value = getAnswer(
             simulation.answers.current,
             "menage",
-            "statut_occupation_logement"
+            "_logementType"
           )
           return value?.startsWith("locataire")
         },

--- a/lib/properties/menage-properties.ts
+++ b/lib/properties/menage-properties.ts
@@ -46,7 +46,7 @@ export default {
             "menage",
             "_logementType"
           )
-          return value?.startsWith("locataire")
+          return _logementType ==="locataire"
         },
       },
       { value: -12, label: "Non" },

--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -396,7 +396,7 @@ function housingBlock() {
         ],
       },
       {
-        isActive: (subject) => subject._logementType === "locataire",
+        isActive: (subject) => subject._logementType !== "sansDomicle",
         steps: [
           new Step({
             entity: "menage",

--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -396,7 +396,10 @@ function housingBlock() {
         ],
       },
       {
-        isActive: (subject) => subject._logementType !== "sansDomicle",
+        isActive: (subject) =>
+          ["locataire", "sansDomicile", "heberge"].includes(
+            subject._logementType
+          ),
         steps: [
           new Step({
             entity: "menage",

--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -396,7 +396,7 @@ function housingBlock() {
         ],
       },
       {
-        isActive: (subject) => subject._logementType !== "proprietaire",
+        isActive: (subject) => subject._logementType === "locataire",
         steps: [
           new Step({
             entity: "menage",


### PR DESCRIPTION
[Tâche trello](https://trello.com/c/dsYQs9Ra/1033-refactor-lib-state-blocksnombremoisentreelogement)

Affiche la question du nombre de mois d'entrée dans le logement uniquement aux locataires

Fix : la réponse "Non, j'ai emménagé il y a moins de 3 mois" n'était plus affichée car le label a été refacto précédement et n'était plus fetch

Le nom de la page / question ne me paraît pas cohérent et pourrait être refacto : pourquoi "_nombreMoisEntreeLogement" avec la question "Prévoyez-vous de déménager prochainement ?" ?