### PR TITLE
Refactor la gestion de l'A/B testing

### DIFF
--- a/backend/lib/migrations/index.ts
+++ b/backend/lib/migrations/index.ts
@@ -48,8 +48,8 @@ export function apply(model) {
 
   migrations.forEach(function (migration: any) {
     if (model.version === undefined || model.version < migration.version) {
-      model.version = migration.version
       model = migration.apply(model)
+      model.version = migration.version
     }
   })
   return model

--- a/backend/lib/migrations/simulations/to-v14.ts
+++ b/backend/lib/migrations/simulations/to-v14.ts
@@ -1,0 +1,26 @@
+/*
+ * Migre la gestion de abtesting
+ */
+
+const VERSION = 14
+
+export default {
+  apply(simulation) {
+    const ab = simulation.abtesting
+    if (!ab) {
+      return simulation
+    }
+
+    const keys = Object.keys(ab)
+    simulation.abtesting = keys.reduce((result, key) => {
+      const v = ab[key]
+      if (!v.deleted) {
+        result[key] = v.value
+      }
+      return result
+    }, {})
+    console.log(simulation.abtesting)
+    return simulation
+  },
+  version: VERSION,
+}

--- a/backend/lib/migrations/simulations/to-v14.ts
+++ b/backend/lib/migrations/simulations/to-v14.ts
@@ -19,7 +19,6 @@ export default {
       }
       return result
     }, {})
-    console.log(simulation.abtesting)
     return simulation
   },
   version: VERSION,

--- a/lib/simulation.ts
+++ b/lib/simulation.ts
@@ -1,1 +1,1 @@
-export const version = 13
+export const version = 14

--- a/src/mixins/statistics.js
+++ b/src/mixins/statistics.js
@@ -1,3 +1,5 @@
+import ABTestingService from "@/plugins/ab-testing-service"
+
 const uuid = `uid_${Math.random().toString(12).slice(2)}`
 
 export default {
@@ -14,6 +16,7 @@ export default {
           benefits = [{ id: benefitId }]
         }
         const id = this?.$matomo ? this.$matomo.getVisitorId() : uuid
+        const abtesting = ABTestingService.getValues()
         const benefitsStats = []
         const totalResults = benefits.length
         benefits.forEach(function (benefit, i) {
@@ -21,6 +24,7 @@ export default {
             benefitsStats.push({
               benefit_id: benefit.id,
               hash_id: id,
+              abtesting,
               benefit_index: i + 1,
               page_total: totalResults,
               event_type: event,

--- a/src/plugins/ab-testing-service.js
+++ b/src/plugins/ab-testing-service.js
@@ -58,7 +58,7 @@ const ABTestingService = {
   getValues() {
     return extractValueMap(getEnvironment())
   },
-  setVariante(key, value) {
+  setVariant(key, value) {
     const ABTestingEnvironment = getEnvironment()
     ABTestingEnvironment[key].value = value
     localStorage.setItem("ABTesting", JSON.stringify(ABTestingEnvironment))

--- a/src/plugins/ab-testing-service.js
+++ b/src/plugins/ab-testing-service.js
@@ -1,54 +1,69 @@
-const ABTestingService = {
-  /*
-   * L'AB testing repose sur les custom variables de Matomo
-   * https://matomo.org/docs/custom-variables/
-   *
-   * NB :
-   * *  Les variables d'AB testing sont enregistrées dans le localStorage pour toujours
-   *       -> afficher la même version pour un usager donné
-   * *  L'utilisation des 5 customs variables de Piwik permet de
-   *       -> faire 5 tests différents en même temps
-   * *  La suppression des variables en fin de test permet de
-   *      -> ne pas polluer Matomo d'anciennes périodes de tests
-   */
-  getEnvironment() {
-    if (!window._paq) {
-      return {}
+/*
+ * L'AB testing repose sur les custom variables de Matomo
+ * https://matomo.org/docs/custom-variables/
+ *
+ * NB :
+ * *  Les variables d'AB testing sont enregistrées dans le localStorage pour toujours
+ *       -> afficher la même version pour un usager donné
+ * *  L'utilisation des 5 customs variables de Piwik permet de
+ *       -> faire 5 tests différents en même temps
+ * *  La suppression des variables en fin de test permet de
+ *      -> ne pas polluer Matomo d'anciennes périodes de tests
+ */
+function getEnvironment() {
+  if (!window._paq) {
+    return {}
+  }
+  const ABTesting = JSON.parse(localStorage.getItem("ABTesting") || "{}")
+
+  // // Prépare la variable d'AB testing
+  // ABTesting.link = ABTesting.link || { index: 1 };
+  // // Réparti les visiteurs l'AB testing avec cette variable
+  // ABTesting.link.value = ABTesting.link.value || (Math.random() > 0.5 ? 'A' : 'B');
+  // // Après l'AB testing
+  // // Pour le désactiver
+  // // et libérer une custom variable
+  // // ABTesting.link.deleted = true;
+
+  Object.keys(ABTesting).forEach(function (name) {
+    const data = ABTesting[name]
+    if (data.deleted) {
+      window._paq.push(["deleteCustomVariable", data.index, "visit"])
+    } else {
+      window._paq.push([
+        "setCustomVariable",
+        data.index,
+        name,
+        data.value,
+        "visit",
+      ])
     }
-    const ABTesting = JSON.parse(localStorage.getItem("ABTesting") || "{}")
+  })
+  localStorage.setItem("ABTesting", JSON.stringify(ABTesting))
+  return ABTesting
+}
 
-    // // Prépare la variable d'AB testing
-    // ABTesting.link = ABTesting.link || { index: 1 };
-    // // Réparti les visiteurs l'AB testing avec cette variable
-    // ABTesting.link.value = ABTesting.link.value || (Math.random() > 0.5 ? 'A' : 'B');
-    // // Après l'AB testing
-    // // Pour le désactiver
-    // // et libérer une custom variable
-    // // ABTesting.link.deleted = true;
+function getValues(env) {
+  const experimentKeys = Object.keys(env)
+  return experimentKeys.reduce((result, key) => {
+    const experiment = env[key]
+    if (!experiment.deleted) {
+      result[experiment]
+    }
+    return result
+  }, {})
+}
 
-    Object.keys(ABTesting).forEach(function (name) {
-      const data = ABTesting[name]
-      if (data.deleted) {
-        window._paq.push(["deleteCustomVariable", data.index, "visit"])
-      } else {
-        window._paq.push([
-          "setCustomVariable",
-          data.index,
-          name,
-          data.value,
-          "visit",
-        ])
-      }
-    })
-    localStorage.setItem("ABTesting", JSON.stringify(ABTesting))
-    return ABTesting
+const ABTestingService = {
+  getValues() {
+    return getValues(getEnvironment())
   },
   setVariante(key, value) {
-    const ABTesting = this.getEnvironment()
+    const ABTesting = getEnvironment()
     ABTesting[key].value = value
     localStorage.setItem("ABTesting", JSON.stringify(ABTesting))
 
-    return ABTesting
+    return getValues(ABTesting)
   },
 }
 

--- a/src/plugins/ab-testing-service.js
+++ b/src/plugins/ab-testing-service.js
@@ -43,7 +43,7 @@ function getEnvironment() {
   return ABTesting
 }
 
-function getValues(env) {
+function extractValueMap(env) {
   const experimentKeys = Object.keys(env)
   return experimentKeys.reduce((result, key) => {
     const experiment = env[key]
@@ -56,14 +56,14 @@ function getValues(env) {
 
 const ABTestingService = {
   getValues() {
-    return getValues(getEnvironment())
+    return extractValueMap(getEnvironment())
   },
   setVariante(key, value) {
-    const ABTesting = getEnvironment()
-    ABTesting[key].value = value
-    localStorage.setItem("ABTesting", JSON.stringify(ABTesting))
+    const ABTestingEnvironment = getEnvironment()
+    ABTestingEnvironment[key].value = value
+    localStorage.setItem("ABTesting", JSON.stringify(ABTestingEnvironment))
 
-    return getValues(ABTesting)
+    return extractValueMap(ABTestingEnvironment)
   },
 }
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -417,7 +417,7 @@ export const useStore = defineStore("store", {
         simulation.modifiedFrom = this.situationId
       }
 
-      simulation.abtesting = ABTestingService.getEnvironment()
+      simulation.abtesting = ABTestingService.getValues()
       simulation.finishedAt = new Date()
       return axios
         .post("/api/simulation", simulation)


### PR DESCRIPTION
Je conseille de regarder cette PR avec 
https://github.com/betagouv/aides-jeunes/pull/3418/files?w=1

c'est à dire avec les changements d'indentation non affichés en compte.

L'objectif est de passer à une propriété `abtesting` dans la base de données plus simple.
Aujourd'hui on reproduit ce qui est dans le front (pour Matomo on a besoin de conserver des indices [1, 5]).

```js
{
  super_test: {
    index: 1,
    value: "A"
  }
}
```

Avec cette PR, dans la base de données on ne garde que

```js
{
  super_test: "A"
}
```

Je n'ai pas pu remplacer dans le schéma `Object` en `{type: Map, of: String}` car sinon la migration ne fonctionne pas. Je ferai dans une seconde PR.

https://trello.com/c/DtAlPkhw/1089-refactor-a-b-testing