### PR TITLE
Ajoute un timestamp côté client pour avoir des estimations plus propres de durée de simulation

### DIFF
--- a/backend/models/simulation.ts
+++ b/backend/models/simulation.ts
@@ -53,6 +53,7 @@ const SimulationSchema = new mongoose.Schema<MongooseLayout, SimulationModel>(
     },
     version: { type: Number, default: version },
     abtesting: Object,
+    finishedAt: Date,
     createdAt: { type: Date, default: Date.now },
     modifiedFrom: String,
     status: {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -418,6 +418,7 @@ export const useStore = defineStore("store", {
       }
 
       simulation.abtesting = ABTestingService.getEnvironment()
+      simulation.finishedAt = new Date()
       return axios
         .post("/api/simulation", simulation)
         .then((result) => result.data)


### PR DESCRIPTION
Avec `dateDeValeur` et `finishedAt`.

https://trello.com/c/9Me3Y0xM/1092-ajout-dun-attribut-pour-%C3%A9valuer-la-dur%C3%A9e-du-parcous