### PR TITLE
Cypress: améliore l'attente des résultats en fin de simulation pour éviter les instabilités sur la CI

### DIFF
--- a/cypress/e2e/base.cy.js
+++ b/cypress/e2e/base.cy.js
@@ -22,7 +22,6 @@ context("Full simulation", () => {
       cy.checkA11y()
     })
 
-    results.setupInterceptors()
     profil.defaultIndivu()
     foyer.children(0)
     foyer.fill_en_couple(false)

--- a/cypress/e2e/base.cy.js
+++ b/cypress/e2e/base.cy.js
@@ -22,6 +22,7 @@ context("Full simulation", () => {
       cy.checkA11y()
     })
 
+    results.setupInterceptors()
     profil.defaultIndivu()
     foyer.children(0)
     foyer.fill_en_couple(false)
@@ -66,6 +67,7 @@ context("Full simulation", () => {
     results.wait()
     results.hasPrimeActivite()
     results.captureFiscalResources()
+    results.checkResultsRequests()
     results.receiveResultsEmail()
   })
 })

--- a/cypress/utils/navigate.js
+++ b/cypress/utils/navigate.js
@@ -1,6 +1,7 @@
 const init = () => {
   cy.intercept("GET", "/api/simulation/*/results").as("results")
   cy.intercept("GET", "/api/outils/communes/*").as("communes")
+  cy.intercept("POST", "/api/simulation").as("post-simulation")
   cy.visit("http://localhost:8080/init-ci")
 }
 

--- a/cypress/utils/results.js
+++ b/cypress/utils/results.js
@@ -169,7 +169,7 @@ const receiveResultsEmail = () => {
   })
     .should("be.visible")
     .click()
-  cy.get("input#email").should("be.visible").type("simon.hamery@beta.gouv.fr")
+  cy.get("input#email").should("be.visible").type("prenom.nom@beta.gouv.fr")
   cy.get(".fr-btn:contains(J'accepte d'être recontacté·e par email)")
     .should("be.visible")
     .click()

--- a/cypress/utils/results.js
+++ b/cypress/utils/results.js
@@ -164,7 +164,7 @@ const receiveResultsEmail = () => {
     url: "/api/simulation/*/followup",
   }).as("post-receive-results-email")
 
-  cy.get(".fr-btn:contains('Recevoir les résultats par email')", {
+  cy.get("[data-testid='send-email-button']", {
     timeout: 20000,
   })
     .should("be.visible")

--- a/cypress/utils/results.js
+++ b/cypress/utils/results.js
@@ -180,24 +180,12 @@ const receiveResultsEmail = () => {
   })
 }
 
-const setupInterceptors = () => {
-  cy.intercept({
-    method: "GET",
-    url: "/api/simulation/*/results",
-  }).as("get-results")
-
-  cy.intercept({
-    method: "POST",
-    url: "/api/simulation",
-  }).as("post-simulation")
-}
-
 const checkResultsRequests = () => {
   cy.wait("@post-simulation").should(({ request, response }) => {
     expect(request.method).to.equal("POST")
     expect(response.statusCode).to.equal(200)
   })
-  cy.wait("@get-results").should(({ request, response }) => {
+  cy.wait("@results").should(({ request, response }) => {
     expect(request.method).to.equal("GET")
     expect(response.statusCode).to.equal(200)
   })
@@ -215,6 +203,5 @@ export default {
   hasIleDeFranceAideAuMerite,
   hasAideVeloNationale,
   receiveResultsEmail,
-  setupInterceptors,
   checkResultsRequests,
 }

--- a/cypress/utils/results.js
+++ b/cypress/utils/results.js
@@ -178,6 +178,29 @@ const receiveResultsEmail = () => {
   })
 }
 
+const setupInterceptors = () => {
+  cy.intercept({
+    method: "GET",
+    url: "/api/simulation/*/results",
+  }).as("get-results")
+
+  cy.intercept({
+    method: "POST",
+    url: "/api/simulation",
+  }).as("post-simulation")
+}
+
+const checkResultsRequests = () => {
+  cy.wait("@post-simulation").should(({ request, response }) => {
+    expect(request.method).to.equal("POST")
+    expect(response.statusCode).to.equal(200)
+  })
+  cy.wait("@get-results").should(({ request, response }) => {
+    expect(request.method).to.equal("GET")
+    expect(response.statusCode).to.equal(200)
+  })
+}
+
 export default {
   wait,
   back,
@@ -190,4 +213,6 @@ export default {
   hasIleDeFranceAideAuMerite,
   hasAideVeloNationale,
   receiveResultsEmail,
+  setupInterceptors,
+  checkResultsRequests,
 }

--- a/cypress/utils/results.js
+++ b/cypress/utils/results.js
@@ -164,7 +164,9 @@ const receiveResultsEmail = () => {
     url: "/api/simulation/*/followup",
   }).as("post-receive-results-email")
 
-  cy.get(".fr-btn:contains('Recevoir les résultats par email')")
+  cy.get(".fr-btn:contains('Recevoir les résultats par email')", {
+    timeout: 20000,
+  })
     .should("be.visible")
     .click()
   cy.get("input#email").should("be.visible").type("simon.hamery@beta.gouv.fr")

--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -13,6 +13,7 @@
         >
           <li>
             <SendRecapEmailButton
+              data-testid="send-email-button"
               text="Recevoir les résultats par email"
             ></SendRecapEmailButton>
           </li>


### PR DESCRIPTION
https://trello.com/c/EAOdLIUz/1088-corriger-le-test-cypress-instable