### PR TITLE
Ajout condition éligibilité territoire EPCI

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -117,15 +117,6 @@ fields:
         name: values
         widget: list
         hint: Pour saisir plusieurs département, séparez les codes des départements par une virgule.
-  field_communes: &field_communes
-    label: Condition géographique communale
-    name: communes
-    widget: object
-    fields:
-      - label: Code INSEE des communes
-        name: values
-        widget: list
-        hint: Pour saisir plusieurs communes, séparez les codes INSEE des communes par une virgule.
   field_epcis: &field_epcis
     label: Condition géographique d'EPCI
     name: epcis
@@ -135,6 +126,15 @@ fields:
         name: values
         widget: list
         hint: Pour saisir plusieurs EPCI, séparez les codes SIREN par une virgule.
+  field_communes: &field_communes
+    label: Condition géographique communale
+    name: communes
+    widget: object
+    fields:
+      - label: Code INSEE des communes
+        name: values
+        widget: list
+        hint: Pour saisir plusieurs communes, séparez les codes INSEE des communes par une virgule.
   field_boursier: &field_boursier
     <<: *field_empty
     label: Boursier
@@ -731,8 +731,8 @@ fields:
       - *field_age
       - *field_regions
       - *field_departements
-      - *field_communes
       - *field_epcis
+      - *field_communes
       - *field_regime_securite_sociale
       - *field_quotient_familial
       - *field_formation_sanitaire_social

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -126,6 +126,15 @@ fields:
         name: values
         widget: list
         hint: Pour saisir plusieurs communes, séparez les codes INSEE des communes par une virgule.
+  field_epcis: &field_epcis
+    label: Condition géographique d'EPCI
+    name: epcis
+    widget: object
+    fields:
+      - label: Code SIREN des EPCI
+        name: values
+        widget: list
+        hint: Pour saisir plusieurs EPCI, séparez les codes SIREN par une virgule.
   field_boursier: &field_boursier
     <<: *field_empty
     label: Boursier
@@ -723,6 +732,7 @@ fields:
       - *field_regions
       - *field_departements
       - *field_communes
+      - *field_epcis
       - *field_regime_securite_sociale
       - *field_quotient_familial
       - *field_formation_sanitaire_social


### PR DESCRIPTION
[Tâche trello](https://trello.com/c/pWAB2c5T/1093-ajouter-la-possibilit%C3%A9-de-d%C3%A9crire-une-condition-d%C3%A9ligibilit%C3%A9-par-rapport-%C3%A0-la-r%C3%A9sidence-sur-le-territoire-dun-epci)

Dans le fichier config.yml : 
- [x]  Création nouveau field pour les epcis sur le modèle des communes/départements/régions
- [x]  Ajout du champ ```field_epcis``` dans la liste des conditions générales

![Capture d’écran 2022-12-28 à 11 31 34](https://user-images.githubusercontent.com/52297439/209798546-19ceb2e0-a5fb-4d72-b35b-d16ca0130f62.png)

![Capture d’écran 2022-12-28 à 11 31 16](https://user-images.githubusercontent.com/52297439/209798500-f834444e-90b4-4395-8942-06880ad800fc.png) 

Test : 
- [x] Vérifier que le champ apparait bien lorsque l'outil de config est lancé localement
- [x] Création d'une aide de test localement et y ajouter la contrainte d'EPCI

Défintion of done :  
- [x] L'aide doit bien s'afficher quand on est sur le territoire et ne pas s'afficher quand on est en dehors

![Capture d’écran 2022-12-28 à 12 06 55](https://user-images.githubusercontent.com/52297439/209802772-fb8705c8-0cdb-4711-b073-a3b202ed3826.png)
