### PR TITLE
Mutualise le setup store Pinia

### DIFF
--- a/src/components/buttons/send-recap-email-button.vue
+++ b/src/components/buttons/send-recap-email-button.vue
@@ -11,6 +11,7 @@
 
 <script>
 import { useStore } from "@/stores"
+import { mapStores } from "pinia"
 
 export default {
   name: "SendRecapEmailButton",
@@ -20,14 +21,12 @@ export default {
       default: "Recevoir par email",
     },
   },
-  setup() {
-    return {
-      store: useStore(),
-    }
+  computed: {
+    ...mapStores(useStore),
   },
   methods: {
     showModal() {
-      this.store.setRecapEmailState("show")
+      this.storeStore.setRecapEmailState("show")
     },
   },
 }

--- a/src/components/buttons/send-recap-email-button.vue
+++ b/src/components/buttons/send-recap-email-button.vue
@@ -1,3 +1,21 @@
+<script setup>
+import { defineProps } from "vue"
+import { useStore } from "@/stores"
+
+defineProps({
+  text: {
+    type: String,
+    default: "Recevoir par email",
+  },
+})
+
+const store = useStore()
+
+const showModal = () => {
+  store.setRecapEmailState("show")
+}
+</script>
+
 <template>
   <button
     class="fr-btn fr-btn--icon-center fr-icon-mail-line fr-px-3v"
@@ -8,26 +26,3 @@
     {{ text }}
   </button>
 </template>
-
-<script>
-import { useStore } from "@/stores"
-import { mapStores } from "pinia"
-
-export default {
-  name: "SendRecapEmailButton",
-  props: {
-    text: {
-      type: String,
-      default: "Recevoir par email",
-    },
-  },
-  computed: {
-    ...mapStores(useStore),
-  },
-  methods: {
-    showModal() {
-      this.storeStore.setRecapEmailState("show")
-    },
-  },
-}
-</script>


### PR DESCRIPTION
## Refactoring du store Pinia

Le [premier commit](https://github.com/betagouv/aides-jeunes/pull/3435/commits/dca31fb29aa23eecd418d6330c5ff86046e168e5) est un exemple de ce que j'ai compris par rapport à la formulation de la [tâche Trello associée](https://trello.com/c/zNfiCb96/883-mutualiser-le-setup-du-store-pinia) en option API (mutualiser avec mapStores ?).

Le [second commit](https://github.com/betagouv/aides-jeunes/pull/3435/commits/b9af83d58ba89f6ce5ab64024953dc9540f58d65) est le même refacto migré sur la composition API, mais dans ce cas là, plus besoin de `mapStores`.

Ceci n'étant pas une instanciation du store mais bien une référence : 
```js
const store = useStore()
```