### PR TITLE
Allongement barre séparation menu latéral

### DIFF
--- a/src/components/base-layout.vue
+++ b/src/components/base-layout.vue
@@ -44,7 +44,7 @@
       id="main"
       ref="main"
       role="main"
-      class="fr-container fr-container--fluid"
+      class="fr-container fr-container--fluid aj-main-container"
       tabindex="-1"
     >
       <slot />

--- a/src/components/summary.vue
+++ b/src/components/summary.vue
@@ -1,6 +1,6 @@
 <template>
   <nav class="fr-sidemenu fr-col-lg-12" aria-label="Sommaire" role="navigation">
-    <div class="fr-sidemenu__inner">
+    <div class="fr-sidemenu__inner aj-fr-sidemenu__inner">
       <button
         ref="sideMenuButton"
         class="fr-sidemenu__btn fr-px-2w"

--- a/src/styles/aides-jeunes.css
+++ b/src/styles/aides-jeunes.css
@@ -184,8 +184,19 @@
   min-width: 70px;
 }
 
-.fr-sidemenu__inner {
-  min-height: 100vh;
+.aj-main-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+.aj-fr-col-12 {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.aj-fr-sidemenu__inner {
+  height: 100%;
 }
 
 @media (max-width: 576px) {

--- a/src/styles/aides-jeunes.css
+++ b/src/styles/aides-jeunes.css
@@ -112,7 +112,6 @@
 }
 
 .aj-page--full-height {
-  min-height: 100vh;
   display: flex;
   flex-direction: column;
 }
@@ -183,6 +182,10 @@
 .aj-institution-icon {
   width: 70px;
   min-width: 70px;
+}
+
+.fr-sidemenu__inner {
+  min-height: 100vh;
 }
 
 @media (max-width: 576px) {

--- a/src/styles/aides-jeunes.css
+++ b/src/styles/aides-jeunes.css
@@ -206,6 +206,10 @@
   .aj-action-buttons .fr-btns-group {
     justify-content: space-between !important;
   }
+
+  .fr-sidemenu__inner {
+    min-height: 0;
+  }
 }
 
 .aj-iframe-footer {
@@ -232,6 +236,15 @@
 
   [data-text]:after {
     display: none !important;
+  }
+
+  .fr-sidemenu__inner {
+    min-height: 0;
+  }
+}
+@media (max-width: 1024px) {
+  .fr-sidemenu__inner {
+    min-height: 0;
   }
 }
 

--- a/src/views/simulation.vue
+++ b/src/views/simulation.vue
@@ -1,7 +1,7 @@
 <template>
   <ProgressBar></ProgressBar>
   <div class="fr-grid-row">
-    <div class="fr-col-12 fr-col-md-3">
+    <div class="fr-col-12 fr-col-md-3 aj-fr-col-12">
       <Progress v-if="debug" />
       <Summary v-else />
     </div>


### PR DESCRIPTION
[Tâche Trello](https://trello.com/c/znN5vmSr/1099-ui-allonger-la-barre-de-s%C3%A9paration-entre-le-r%C3%A9sum%C3%A9-%C3%A0-gauche-et-la-question) : 

- Ancien aperçu : cf capture tâche trello

- Nouvel aperçu : 

<img width="1440" alt="Capture d’écran 2023-01-05 à 12 40 53" src="https://user-images.githubusercontent.com/52297439/210772191-3b0c7882-f905-4674-873e-06801c79b3e7.png">

- 2ème itération affichage desktop : 

<img width="1430" alt="Capture d’écran 2023-01-11 à 14 34 31" src="https://user-images.githubusercontent.com/52297439/211819635-3cd3fec7-672c-415e-83c1-0b3a1e29315b.png">

<img width="1439" alt="Capture d’écran 2023-01-11 à 14 35 51" src="https://user-images.githubusercontent.com/52297439/211819893-2d1ae746-93c2-431a-93a1-e0c11795cfba.png">
