### PR TITLE
[FIX] Corrige un bug empêchant un retour arrière

### DIFF
--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -344,6 +344,7 @@ export const useStore = defineStore("store", {
         value: `votre ${enfants.length}${
           enfants.length === 1 ? "ᵉʳ" : "ᵉ"
         } enfant`,
+        path: `/simulation/individu/enfant_${enfantId}/_firstName`,
       }
 
       // When you add a children you need to remove all current answer after the child validation


### PR DESCRIPTION
## Détails

[Tâche Trello](https://trello.com/c/qURiy0DZ/1130-bug-erreur-sentry-cannot-read-properties-of-undefined-reading-indexof)

De nombreuses erreurs sont retournées à Sentry pour la partie front du simulateur. Le problème se produit en ajoutant un enfant sur une simulation, en remplissant les différentes étapes le concernant, puis en cliquant sur le bouton "Précédent" jusqu'à revenir à la page "date de naissance de l'enfant". Sur cette page si l'on clique sur le bouton "Précédent" rien ne se passe et une erreur apparait dans la console.

Ce comportement est dû au fait que l'étape "prénom de l'enfant" est généré de manière différentes des autres questions du simulateur et ne dispose pas de la propriété `path` sur laquelle la logique de retour arrière est basée.

## Erreurs Sentry liées

- https://sentry.incubateur.net/organizations/betagouv/issues/19601/?project=18&query=is%3Aunresolved
- https://sentry.incubateur.net/organizations/betagouv/issues/19597/?project=18&query=is%3Aunresolved
- https://sentry.incubateur.net/organizations/betagouv/issues/15366/?project=18&query=is%3Aunresolved
- https://sentry.incubateur.net/organizations/betagouv/issues/15357/?project=18&query=is%3Aunresolved
- https://sentry.incubateur.net/organizations/betagouv/issues/19554/?project=18&query=is%3Aunresolved