### PR TITLE
Met à jour les liens d'édition des aides

### DIFF
--- a/src/components/droits-contributions.vue
+++ b/src/components/droits-contributions.vue
@@ -8,19 +8,35 @@
         title="Code source de l'aide - Nouvelle fenêtre"
         >Code source de l'aide</a
       >
-      -
-      <a
-        :href="netlifyContributionUrl()"
-        target="_blank"
-        rel="noreferrer"
-        title="Proposer une modification : outil de contribution - Nouvelle fenêtre"
-        >Proposer une modification</a
-      ></span
-    >
+      <span v-if="netlifyContributionUrl()">
+        -
+        <a
+          :href="netlifyContributionUrl()"
+          target="_blank"
+          rel="noreferrer"
+          title="Proposer une modification : outil de contribution - Nouvelle fenêtre"
+          >Proposer une modification</a
+        >
+      </span>
+    </span>
   </p>
 </template>
 
 <script>
+const benefitsUrlPatterns = [
+  {
+    pattern: /-fsl-eligibilite$/,
+    file: `${process.env.VITE_REPOSITORY_URL}/blob/master/data/benefits/dynamic/fsl.ts`,
+  },
+  {
+    pattern: /-apa-eligibilite$/,
+    file: `${process.env.VITE_REPOSITORY_URLl}/blob/master/data/benefits/dynamic/apa.ts`,
+  },
+  {
+    pattern: /^aidesvelo_/,
+    file: `https://github.com/mquandalle/mesaidesvelo/blob/master/src/aides.yaml`,
+  },
+]
 export default {
   name: "DroitsContributions",
   props: {
@@ -30,19 +46,24 @@ export default {
       default: false,
     },
   },
-  data() {
-    return {
-      brokenLinkButtonState: "show",
-    }
-  },
   methods: {
     isEditableBenefit() {
       return ["javascript", "openfisca"].includes(this.droit.source)
     },
     repositoryBenefitUrl() {
+      for (let category of benefitsUrlPatterns) {
+        if (this.droit.id.match(category.pattern)) {
+          return category.file
+        }
+      }
       return `${process.env.VITE_BENEFIT_URL}/${this.droit.source}/${this.droit.id}.yml`
     },
     netlifyContributionUrl() {
+      for (let category of benefitsUrlPatterns) {
+        if (this.droit.id.match(category.pattern)) {
+          return
+        }
+      }
       return `${process.env.VITE_NETLIFY_CONTRIBUTION_URL}/admin/#/collections/benefits_${this.droit.source}/entries/${this.droit.id}`
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig(async ({ mode }) => {
     VITE_BASE_URL: baseURL,
     VITE_CONTEXT: process.env.NODE_ENV,
     VITE_PR_URL: `${process.env.REPOSITORY_URL}/pull/${process.env.REVIEW_ID}`,
+    VITE_REPOSITORY_URL: github.repository_url,
     VITE_BENEFIT_URL: `${github.repository_url}/blob/master/data/benefits`,
     VITE_NETLIFY_CONTRIBUTION_URL: netlifyContributionURL,
     VITE_STATS_URL: statistics?.url ? statistics.url : "",


### PR DESCRIPTION
## Détails

Sur certaines pages d'aides les liens "Code source de l'aide" et "Proposer une modification" ne fonctionnait pas (ex : https://mes-aides.1jeune1solution.beta.gouv.fr/aides/departement-essonne-fsl-eligibilite)

Cette PR modifie le lien "Code source de l'aide" pour l'adapter pour certaines aides et supprime le "Proposer une modification" lorsque le l'aide ne peut pas être modifiée via l'outil de contribution.