### PR TITLE
1134-fix-email-recap-entree

### DIFF
--- a/src/components/modals/recap-email-modal.vue
+++ b/src/components/modals/recap-email-modal.vue
@@ -48,6 +48,7 @@
                 v-if="recapEmailState === 'show'"
                 ref="form"
                 class="fr-form"
+                @submit.prevent="getRecap(true)"
               >
                 <div class="fr-form-group">
                   <label class="fr-label" for="email"


### PR DESCRIPTION
https://trello.com/c/tHHlm2Hc/1134-lemail-de-recap-nest-pas-envoy%C3%A9-quand-on-valide-le-formulaire-avec-entr%C3%A9e