### PR TITLE
Corrige la variable baseURL utilisée dans les templates mjml

### DIFF
--- a/backend/lib/mes-aides/emails/benefit-action.ts
+++ b/backend/lib/mes-aides/emails/benefit-action.ts
@@ -18,7 +18,7 @@ const mjmlTemplate = fs.readFileSync(
 
 const dataTemplate = (followup) => {
   return {
-    baseUrl: config.baseURL,
+    baseURL: config.baseURL,
     ctaLink: `${config.baseURL}${followup.surveyPathTracker}`,
     returnURL: `${config.baseURL}${followup.returnPath}`,
   }

--- a/backend/lib/mes-aides/emails/simulation-usefulness.ts
+++ b/backend/lib/mes-aides/emails/simulation-usefulness.ts
@@ -18,7 +18,7 @@ const mjmlTemplate = fs.readFileSync(
 
 const dataTemplate = (followup) => {
   return {
-    baseUrl: config.baseURL,
+    baseURL: config.baseURL,
     ctaLink: `${config.baseURL}${followup.surveyPath}`,
     returnURL: `${config.baseURL}${followup.returnPath}`,
     wasUsefulLinkYes: `${config.baseURL}${followup.wasUsefulPath}`,


### PR DESCRIPTION
Quick fix sur la variable baseUrl qui s'écrit baseURL dans les templates d'email et posait problème sur l'affichage des images