### PR TITLE
Déplace l'A/B testing Matomo des custom Variables vers des custom Dimensions

### DIFF
--- a/src/plugins/ab-testing-service.js
+++ b/src/plugins/ab-testing-service.js
@@ -35,10 +35,10 @@ function getEnvironment() {
   Object.keys(ABTesting).forEach(function (name) {
     const data = ABTesting[name]
     if (data.deleted) {
-      window._paq.push(["deleteCustomVariable", data.index, "visit"])
+      window._paq.push(["setCustomDimension", data.index, "visit"])
     } else {
       window._paq.push([
-        "setCustomVariable",
+        "setCustomDimension",
         data.index,
         name,
         data.value,


### PR DESCRIPTION
On a peut-être perdu nos AB test historiques :scream: 

https://mattermost.incubateur.net/betagouv/pl/oamgi7cfi78cddschg8ha8yqse

> notable : désactivation et désinstallation du plugin CustomVariables qui pète Matomo en 4.13.2 (déprécié)

https://developer.matomo.org/guides/tracking-javascript-guide#custom-dimensions