### PR TITLE
Migre les variables situationId vers simulationId

### DIFF
--- a/backend/controllers/simulation.ts
+++ b/backend/controllers/simulation.ts
@@ -98,11 +98,11 @@ function openfiscaResponse(req, res, next) {
     if (err)
       return next(
         Object.assign(err.response?.data || err, {
-          _id: req.situationId,
+          _id: req.simulationId,
         })
       )
 
-    res.send(Object.assign(result, { _id: req.situationId }))
+    res.send(Object.assign(result, { _id: req.simulationId }))
   })
 }
 
@@ -124,9 +124,9 @@ function results(req, res, next) {
 function openfiscaTrace(req, res, next) {
   return openfisca.trace(req.situation, function (err, result) {
     if (err)
-      return next(Object.assign(err.response.data, { _id: req.situationId }))
+      return next(Object.assign(err.response.data, { _id: req.simulationId }))
 
-    res.send(Object.assign(result, { _id: req.situationId }))
+    res.send(Object.assign(result, { _id: req.simulationId }))
   })
 }
 

--- a/backend/lib/teleservices/openfisca-response.ts
+++ b/backend/lib/teleservices/openfisca-response.ts
@@ -18,7 +18,7 @@ OpenFiscaResponse.prototype.toExternal = function () {
   const p = new Promise((resolve, reject) => {
     openfisca.calculate(this.situation, (err, result) => {
       const additions = {
-        _id: this.situationId,
+        _id: this.simulationId,
         external_id: this.situation.external_id,
       }
       if (err) {

--- a/backend/models/simulation.ts
+++ b/backend/models/simulation.ts
@@ -75,7 +75,7 @@ SimulationSchema.virtual("cookieName").get(function () {
   return `simulation_${this._id}`
 })
 SimulationSchema.virtual("returnPath").get(function () {
-  return `/simulation/resultats?situationId=${this._id}`
+  return `/simulation/resultats?simulationId=${this._id}`
 })
 
 SimulationSchema.method("isAccessible", function (keychain) {

--- a/lib/types/store.d.ts
+++ b/lib/types/store.d.ts
@@ -53,6 +53,7 @@ export interface Situation {
 
 export interface PersistedStore {
   simulationId: string | null
+  situationId: string | null
   simulation: Simulation
   calculs: Calculs
   ameliNoticationDone: boolean

--- a/lib/types/store.d.ts
+++ b/lib/types/store.d.ts
@@ -62,6 +62,7 @@ export interface PersistedStore {
 
 export interface Store {
   simulationId: string | null
+  situationId: string | null
   simulation: Simulation
   message: {
     text: string | null

--- a/lib/types/store.d.ts
+++ b/lib/types/store.d.ts
@@ -53,7 +53,6 @@ export interface Situation {
 
 export interface PersistedStore {
   simulationId: string | null
-  situationId: string | null
   simulation: Simulation
   calculs: Calculs
   ameliNoticationDone: boolean

--- a/lib/types/store.d.ts
+++ b/lib/types/store.d.ts
@@ -52,7 +52,7 @@ export interface Situation {
 }
 
 export interface PersistedStore {
-  situationId: string | null
+  simulationId: string | null
   simulation: Simulation
   calculs: Calculs
   ameliNoticationDone: boolean
@@ -61,7 +61,7 @@ export interface PersistedStore {
 }
 
 export interface Store {
-  situationId: string | null
+  simulationId: string | null
   simulation: Simulation
   message: {
     text: string | null

--- a/lib/types/store.d.ts
+++ b/lib/types/store.d.ts
@@ -62,7 +62,6 @@ export interface PersistedStore {
 
 export interface Store {
   simulationId: string | null
-  situationId: string | null
   simulation: Simulation
   message: {
     text: string | null

--- a/src/app.vue
+++ b/src/app.vue
@@ -35,11 +35,7 @@ export default {
     },
   },
   mounted() {
-    // migrate old situationId to simulationId
-    if (this.store.situationId) {
-      this.store.setSimulationId(this.store.situationId)
-      delete this.store.situationId
-    }
+    this.store.migrateSituationIdToSimulationId()
   },
 }
 </script>

--- a/src/app.vue
+++ b/src/app.vue
@@ -34,5 +34,12 @@ export default {
       return this.store.inIframe ? "iFrameLayout" : "BaseLayout"
     },
   },
+  mounted() {
+    // migrate old situationId to simulationId
+    if (this.store.situationId) {
+      this.store.setSimulationId(this.store.situationId)
+      delete this.store.situationId
+    }
+  },
 }
 </script>

--- a/src/app.vue
+++ b/src/app.vue
@@ -34,8 +34,5 @@ export default {
       return this.store.inIframe ? "iFrameLayout" : "BaseLayout"
     },
   },
-  mounted() {
-    this.store.migrateSituationIdToSimulationId()
-  },
 }
 </script>

--- a/src/components/benefit-cta-link.vue
+++ b/src/components/benefit-cta-link.vue
@@ -75,7 +75,7 @@ export default {
         window.localStorage.setItem(
           "trampoline",
           JSON.stringify({
-            situationId: this.store.calculs.resultats._id,
+            simulationId: this.store.calculs.resultats._id,
           })
         )
       }

--- a/src/components/error-block.vue
+++ b/src/components/error-block.vue
@@ -81,7 +81,7 @@ export default {
   },
   methods: {
     sendErrorMail() {
-      return sendError(this.store.situationId, this.errorText)
+      return sendError(this.store.simulationId, this.errorText)
     },
   },
 }

--- a/src/components/feedback.vue
+++ b/src/components/feedback.vue
@@ -6,7 +6,7 @@
     La plupart des résultats que nous vous proposons sont automatiquement
     arrondis à une dizaine d'euros près.
   </p>
-  <ul :key="`${situationId}-${droits?.length}`">
+  <ul :key="`${simulationId}-${droits?.length}`">
     <li>
       <a
         v-analytics="{
@@ -43,9 +43,9 @@
     </li>
   </ul>
   <p
-    ><small v-if="situationId"
+    ><small v-if="simulationId"
       >Cette simulation a pour identifiant
-      <span class="preformatted">{{ situationId }}</span> (en savoir plus sur
+      <span class="preformatted">{{ simulationId }}</span> (en savoir plus sur
       <router-link to="/confidentialite"
         >le traitement de vos données personnelles
       </router-link>
@@ -53,7 +53,7 @@
     </small></p
   >
   <p
-    ><small v-if="situationId">
+    ><small v-if="simulationId">
       <button
         v-if="!showExpertLinks"
         class="fr-btn fr-btn--sm"
@@ -151,17 +151,17 @@ export default {
 
       return droits?.map((droit) => this.formatDroit(droit))
     },
-    situationId() {
-      return this.store.situationId
+    simulationId() {
+      return this.store.simulationId
     },
     sendMailEcartSimulation() {
-      return sendEcartSimulation(this.situationId, this.droits)
+      return sendEcartSimulation(this.simulationId, this.droits)
     },
     sendMailEcartInstruction() {
-      return sendEcartInstructions(this.situationId, this.droits)
+      return sendEcartInstructions(this.simulationId, this.droits)
     },
     sendMailSuggestion() {
-      return sendSuggestion(this.situationId)
+      return sendSuggestion(this.simulationId)
     },
   },
   methods: {

--- a/src/components/support/copy-button.vue
+++ b/src/components/support/copy-button.vue
@@ -15,7 +15,7 @@ export default {
   },
   data() {
     return {
-      situationId: "",
+      simulationId: "",
     }
   },
   methods: {

--- a/src/components/support/simulation-search.vue
+++ b/src/components/support/simulation-search.vue
@@ -6,7 +6,7 @@
     <div class="aj-flex-row">
       <input
         id="simulationId"
-        v-model="situationId"
+        v-model="simulationId"
         class="fr-input"
         type="text"
         placeholder="ID de la simulation"
@@ -22,13 +22,13 @@ export default {
   name: "SimulationSearch",
   data() {
     return {
-      situationId: "",
+      simulationId: "",
     }
   },
   methods: {
     onSubmit() {
-      const situationId = /([a-z0-9]{24})/.exec(this.situationId)[0]
-      window?.open(`/api/support/simulation/${situationId}`, "_blank").focus()
+      const simulationId = /([a-z0-9]{24})/.exec(this.simulationId)[0]
+      window?.open(`/api/support/simulation/${simulationId}`, "_blank").focus()
     },
   },
 }

--- a/src/plugins/mails.js
+++ b/src/plugins/mails.js
@@ -6,12 +6,12 @@ const generateResultLines = (droits, customAmount) => {
     .join("\n")
 }
 
-export const sendEcartInstructions = (situationId, droitsEligibles) => {
-  if (!situationId) situationId = "??"
+export const sendEcartInstructions = (simulationId, droitsEligibles) => {
+  if (!simulationId) simulationId = "??"
   if (!droitsEligibles) droitsEligibles = []
 
   return {
-    subject: `Montants inattendus [${situationId}]`,
+    subject: `Montants inattendus [${simulationId}]`,
     body: `Bonjour,
 
     En effectuant une simulation sur votre simulateur, j'ai obtenu le résultat suivant :
@@ -25,16 +25,16 @@ export const sendEcartInstructions = (situationId, droitsEligibles) => {
     Bonne journée,
 
     ————
-    ID : ${situationId} (à conserver impérativement pour traitement de votre demande)
+    ID : ${simulationId} (à conserver impérativement pour traitement de votre demande)
             ————`,
   }
 }
-export const sendEcartSimulation = (situationId, droitsEligibles) => {
-  if (!situationId) situationId = "??"
+export const sendEcartSimulation = (simulationId, droitsEligibles) => {
+  if (!simulationId) simulationId = "??"
   if (!droitsEligibles) droitsEligibles = []
 
   return {
-    subject: `Montants inattendus [${situationId}]`,
+    subject: `Montants inattendus [${simulationId}]`,
     body: `Bonjour,
 
     En effectuant une simulation sur votre simulateur, j'ai obtenu le résultat suivant :
@@ -47,23 +47,23 @@ export const sendEcartSimulation = (situationId, droitsEligibles) => {
     Bonne journée,
 
     ————
-    ID : ${situationId} (à conserver impérativement pour traitement de votre demande)
+    ID : ${simulationId} (à conserver impérativement pour traitement de votre demande)
             ————`,
   }
 }
 
-export const sendSuggestion = (situationId) => {
-  if (!situationId) situationId = "??"
+export const sendSuggestion = (simulationId) => {
+  if (!simulationId) simulationId = "??"
   return {
-    subject: `[${situationId}] Suggestion`,
+    subject: `[${simulationId}] Suggestion`,
   }
 }
 
-export const sendError = (situationId, error) => {
-  if (!situationId) situationId = "??"
+export const sendError = (simulationId, error) => {
+  if (!simulationId) simulationId = "??"
   if (!error) error = "Impossible de récupérer l'erreur."
   return {
-    subject: `Problème technique [${situationId}]`,
+    subject: `Problème technique [${simulationId}]`,
     body: `Bonjour,
 
   J'ai tenté de XXX,
@@ -73,16 +73,16 @@ export const sendError = (situationId, error) => {
   Je vous joins également une capture d'écran pour faciliter la compréhension du problème.
 
   ————
-  ID : ${situationId}
+  ID : ${simulationId}
   Erreur : ${error}
   ————`,
   }
 }
 
-export const sendMontantsAttendus = (situationId) => {
-  if (!situationId) situationId = "??"
+export const sendMontantsAttendus = (simulationId) => {
+  if (!simulationId) simulationId = "??"
   return {
-    subject: `Montant attendus [${situationId}]`,
+    subject: `Montant attendus [${simulationId}]`,
     body: `Bonjour,
 
     En effectuant une simulation sur votre simulateur, j'ai obtenu le résultat suivant :
@@ -93,7 +93,7 @@ export const sendMontantsAttendus = (situationId) => {
     Je vous joins le fichier de résultats pour faciliter la compréhension du problème.
 
   ————
-  ID : ${situationId}
+  ID : ${simulationId}
   ————`,
   }
 }

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -38,6 +38,7 @@ function defaultStore(): Store {
 
   return {
     simulationId: null,
+    situationId: null,
     simulation: {
       answers: {
         all: [],

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -38,7 +38,6 @@ function defaultStore(): Store {
 
   return {
     simulationId: null,
-    situationId: null,
     simulation: {
       answers: {
         all: [],
@@ -306,15 +305,6 @@ export const useStore = defineStore("store", {
     setPatrimoine(patrimoine: any) {
       this.simulation.patrimoine = patrimoine
       this.setDirty()
-    },
-    deleteSituationId() {
-      delete this.situationId
-    },
-    async migrateSituationIdToSimulationId() {
-      if (this.situationId) {
-        await this.setSimulationId(this.situationId)
-        this.deleteSituationId()
-      }
     },
     initialize() {
       Object.assign(this, restoreLocal(), { saveSituationError: null })

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -312,7 +312,9 @@ export const useStore = defineStore("store", {
     async migrateSituationIdToSimulationId() {
       if (this.situationId) {
         await this.setSimulationId(this.situationId)
-        this.deleteSituationId()
+        if (this.simulationId) {
+          this.deleteSituationId()
+        }
       }
     },
     initialize() {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -306,15 +306,15 @@ export const useStore = defineStore("store", {
       this.simulation.patrimoine = patrimoine
       this.setDirty()
     },
-    deleteSituationId() {
-      delete this.situationId
-    },
+    // deleteSituationId() {
+    //   delete this.situationId
+    // },
     async migrateSituationIdToSimulationId() {
       if (this.situationId) {
         await this.setSimulationId(this.situationId)
-        if (this.simulationId) {
-          this.deleteSituationId()
-        }
+        // if (this.simulationId) {
+        //   this.deleteSituationId()
+        // }
       }
     },
     initialize() {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -78,6 +78,7 @@ function getPersitedStateProperties(
 ): PersistedStore {
   const persistedStoreData: PersistedStore = {
     simulationId: state.simulationId || state.simulationId,
+    situationId: state.simulationId,
     simulation: state.simulation,
     calculs: state.calculs || defaultCalculs(),
     ameliNoticationDone: state.ameliNoticationDone,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -309,9 +309,9 @@ export const useStore = defineStore("store", {
     deleteSituationId() {
       delete this.situationId
     },
-    migrateSituationIdToSimulationId() {
+    async migrateSituationIdToSimulationId() {
       if (this.situationId) {
-        this.setSimulationId(this.situationId)
+        await this.setSimulationId(this.situationId)
         this.deleteSituationId()
       }
     },

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -306,6 +306,15 @@ export const useStore = defineStore("store", {
       this.simulation.patrimoine = patrimoine
       this.setDirty()
     },
+    deleteSituationId() {
+      delete this.situationId
+    },
+    migrateSituationIdToSimulationId() {
+      if (this.situationId) {
+        this.setSimulationId(this.situationId)
+        this.deleteSituationId()
+      }
+    },
     initialize() {
       Object.assign(this, restoreLocal(), { saveSituationError: null })
     },

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -307,15 +307,13 @@ export const useStore = defineStore("store", {
       this.simulation.patrimoine = patrimoine
       this.setDirty()
     },
-    // deleteSituationId() {
-    //   delete this.situationId
-    // },
+    deleteSituationId() {
+      delete this.situationId
+    },
     async migrateSituationIdToSimulationId() {
       if (this.situationId) {
         await this.setSimulationId(this.situationId)
-        // if (this.simulationId) {
-        //   this.deleteSituationId()
-        // }
+        this.deleteSituationId()
       }
     },
     initialize() {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -77,8 +77,8 @@ function getPersitedStateProperties(
   save = false
 ): PersistedStore {
   const persistedStoreData: PersistedStore = {
-    simulationId: state.simulationId || state.simulationId,
-    situationId: state.simulationId,
+    simulationId: state.simulationId || state.situationId,
+    situationId: state.situationId,
     simulation: state.simulation,
     calculs: state.calculs || defaultCalculs(),
     ameliNoticationDone: state.ameliNoticationDone,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -76,7 +76,7 @@ function getPersitedStateProperties(
   save = false
 ): PersistedStore {
   const persistedStoreData: PersistedStore = {
-    simulationId: state.simulationId,
+    simulationId: state.simulationId || state.simulationId,
     simulation: state.simulation,
     calculs: state.calculs || defaultCalculs(),
     ameliNoticationDone: state.ameliNoticationDone,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -78,7 +78,6 @@ function getPersitedStateProperties(
 ): PersistedStore {
   const persistedStoreData: PersistedStore = {
     simulationId: state.simulationId || state.situationId,
-    situationId: state.situationId,
     simulation: state.simulation,
     calculs: state.calculs || defaultCalculs(),
     ameliNoticationDone: state.ameliNoticationDone,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -37,7 +37,7 @@ function defaultStore(): Store {
   const now = dayjs().format()
 
   return {
-    situationId: null,
+    simulationId: null,
     simulation: {
       answers: {
         all: [],
@@ -76,7 +76,7 @@ function getPersitedStateProperties(
   save = false
 ): PersistedStore {
   const persistedStoreData: PersistedStore = {
-    situationId: state.situationId,
+    simulationId: state.simulationId,
     simulation: state.simulation,
     calculs: state.calculs || defaultCalculs(),
     ameliNoticationDone: state.ameliNoticationDone,
@@ -222,11 +222,11 @@ export const useStore = defineStore("store", {
       }, undefined)
     },
     fetchRepresentation() {
-      return (representation: string, situationId: string) => {
+      return (representation: string, simulationId: string) => {
         return axios
           .get(
             `/api/simulation/${
-              situationId || this.situationId
+              simulationId || this.simulationId
             }/${representation}`
           )
           .then((response) => response.data)
@@ -234,9 +234,9 @@ export const useStore = defineStore("store", {
     },
     hasResults(): boolean {
       return Boolean(
-        this.situationId &&
+        this.simulationId &&
           this.calculs.resultats._id &&
-          this.calculs.resultats._id === this.situationId
+          this.calculs.resultats._id === this.simulationId
       )
     },
     situation(): Situation {
@@ -406,16 +406,16 @@ export const useStore = defineStore("store", {
     setRecapEmailState(newState: string | undefined) {
       this.recapEmailState = newState
     },
-    setId(id: string) {
-      this.situationId = id
+    setSimulationId(id: string) {
+      this.simulationId = id
       this.calculs.dirty = false
     },
     save() {
       this.setRecapEmailState(undefined)
 
       const simulation = { ...this.simulation, _id: undefined }
-      if (this.situationId) {
-        simulation.modifiedFrom = this.situationId
+      if (this.simulationId) {
+        simulation.modifiedFrom = this.simulationId
       }
 
       simulation.abtesting = ABTestingService.getValues()
@@ -424,7 +424,7 @@ export const useStore = defineStore("store", {
         .post("/api/simulation", simulation)
         .then((result) => result.data)
         .then((payload) => payload._id)
-        .then((id) => this.setId(id))
+        .then((id) => this.setSimulationId(id))
     },
     reset(simulation: Simulation) {
       this.access.fetching = false
@@ -446,7 +446,7 @@ export const useStore = defineStore("store", {
         .get(`/api/simulation/${id}`)
         .then((result) => result.data)
         .then((payload) => this.reset(payload))
-        .then(() => this.setId(id))
+        .then(() => this.setSimulationId(id))
         .catch((e) => {
           console.log(e)
           this.saveAccessFailure()
@@ -476,7 +476,7 @@ export const useStore = defineStore("store", {
 
       return axios
         .get(
-          `/api/simulation/${this.situationId}/results${
+          `/api/simulation/${this.simulationId}/results${
             showPrivate ? "&showPrivate" : ""
           }`
         )

--- a/src/views/confidentialite.vue
+++ b/src/views/confidentialite.vue
@@ -237,8 +237,8 @@ export default {
 J'ai effectué une simulation sur Mes Aides le **JJ/MM/AAAA à HH:MM:SS**.
 
 ${
-  this.situation && this.situationId
-    ? `La dernière simulation que j'ai effectuée porte l'identifiant **${this.situationId}**.`
+  this.situation && this.simulationId
+    ? `La dernière simulation que j'ai effectuée porte l'identifiant **${this.simulationId}**.`
     : ""
 }
 Voici quelques éléments que j'ai renseigné sur celle-ci pour vous aider à l'identifier.

--- a/src/views/redirection.vue
+++ b/src/views/redirection.vue
@@ -14,11 +14,11 @@
           <a
             v-analytics="{ action: 'Support', category: 'Redirection' }"
             v-mail="{
-              subject: `[${situationId}] Problème redirection`,
+              subject: `[${simulationId}] Problème redirection`,
               body: `Bonjour,
 
         ————
-        ID : ${situationId}
+        ID : ${simulationId}
         Erreur : ${error}
         ————`,
             }"
@@ -75,29 +75,29 @@ export default {
   },
   data() {
     return {
-      situationId: null,
+      simulationId: null,
       error: null,
       teleservice: null,
       updating: true,
     }
   },
   mounted() {
-    this.situationId = window.sessionStorage.getItem("situationId")
-    if (!this.situationId) {
-      this.situationId = JSON.parse(
+    this.simulationId = window.sessionStorage.getItem("simulationId")
+    if (!this.simulationId) {
+      this.simulationId = JSON.parse(
         window.localStorage.getItem("trampoline")
-      ).situationId
+      ).simulationId
       window.localStorage.removeItem("trampoline")
-      window.sessionStorage.setItem("situationId", this.situationId)
+      window.sessionStorage.setItem("simulationId", this.simulationId)
     }
-    if (!this.situationId) {
+    if (!this.simulationId) {
       this.error = "Identifiant de simulation absent… Arrêt."
       this.updating = false
       return
     }
 
     this.store
-      .fetchRepresentation(this.$route.query.vers, this.situationId)
+      .fetchRepresentation(this.$route.query.vers, this.simulationId)
       .then((data) => {
         this.teleservice = data
       })

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -127,13 +127,18 @@ export default {
       })
     })
 
+    // Used for old links containing situationId instead of simulationId
+    if (this.$route.query?.situationId) {
+      this.$route.query.simulationId = this.$route.query.situationId
+    }
+
     if (this.mock(this.$route.params.droitId)) {
       return
-    } else if (this.$route.query?.situationId) {
-      if (this.store.situationId !== this.$route.query.situationId) {
-        this.store.fetch(this.$route.query.situationId).then(() => {
+    } else if (this.$route.query?.simulationId) {
+      if (this.store.simulationId !== this.$route.query.simulationId) {
+        this.store.fetch(this.$route.query.simulationId).then(() => {
           this.store.compute()
-          this.$router.replace({ situationId: null })
+          this.$router.replace({ simulationId: null })
         })
       } // Else nothing to do
     } else if (!this.store.passSanityCheck) {

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -106,6 +106,7 @@ export default {
     }
   },
   mounted() {
+    this.store.migrateSituationIdToSimulationId()
     this.store.updateCurrentAnswers(this.$route.path)
 
     let vm = this

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -106,7 +106,6 @@ export default {
     }
   },
   mounted() {
-    this.store.migrateSituationIdToSimulationId()
     this.store.updateCurrentAnswers(this.$route.path)
 
     let vm = this

--- a/src/views/simulation/resultats/attendu.vue
+++ b/src/views/simulation/resultats/attendu.vue
@@ -139,7 +139,7 @@
         <ul>
           <li>
             le contenu du formulaire et en indiquant l'identifiant suivant :
-            <span class="bold">{{ store.situationId }} .</span>
+            <span class="bold">{{ store.simulationId }} .</span>
           </li>
           <li>en téléchargeant le fichier avec le bouton ci-dessous.</li>
         </ul>
@@ -264,7 +264,7 @@ export default {
       }
     },
     testGenerationEndpoint() {
-      return `/api/simulation/${this.store.situationId}/openfisca-test`
+      return `/api/simulation/${this.store.simulationId}/openfisca-test`
     },
     resultToBase64() {
       return `data:text/octet-stream;charset=utf-8;base64,${window.btoa(
@@ -272,10 +272,10 @@ export default {
       )}`
     },
     filename() {
-      return `mes-aides-${this.store.situationId}.yml`
+      return `mes-aides-${this.store.simulationId}.yml`
     },
     sendMail() {
-      return sendMontantsAttendus(this.store.situationId)
+      return sendMontantsAttendus(this.store.simulationId)
     },
   },
   mounted() {


### PR DESCRIPTION
https://trello.com/c/QH1THy5e/1112-changer-situationid-en-simulationid-notamment-le-query-param-de-la-page-de-r%C3%A9sultats

La migration de `situationId`  vers `simulationId` engendre des adaptations à réaliser dans le store et dans la gestion des routes car le store contenait une variable `situationId` et il existait auparavant des routes dont le chemin contenait `situationId`.

J'ai arbitrairement placé la migration du store à l'étape `mounted` du fichier `App.vue` car il s'agit du fichier racine pour établir le rendu d'une application Vue.js. Tous les utilisateurs ayant une ancienne variable `situationId` dans leur store local auront la valeur de leur variable migrée dans `simulationId` et la variable `situationId` sera ensuite supprimée dès la première étape de rendu de l'application.

Après une review de Thomas, cette migration a été placée dans une méthode du store.