### PR TITLE
Corrige l'utilisation des custom Dimensions pour l'A/B testing

### DIFF
--- a/src/plugins/ab-testing-service.js
+++ b/src/plugins/ab-testing-service.js
@@ -35,14 +35,12 @@ function getEnvironment() {
   Object.keys(ABTesting).forEach(function (name) {
     const data = ABTesting[name]
     if (data.deleted) {
-      window._paq.push(["setCustomDimension", data.index, "visit"])
+      window._paq.push(["deleteCustomDimension", data.index])
     } else {
       window._paq.push([
         "setCustomDimension",
         data.index,
-        name,
-        data.value,
-        "visit",
+        `${name}/${data.value}`,
       ])
     }
   })


### PR DESCRIPTION
J'avais mal utilisé `setCustomDimension` et je m'étais trompé dans l'usage de `deleteCustomDimension`.


cf doc https://developer.matomo.org/guides/tracking-javascript-guide#custom-dimensions