### PR TITLE
Corrige l'affichage de certaines aides

### DIFF
--- a/lib/benefits/details.ts
+++ b/lib/benefits/details.ts
@@ -87,9 +87,11 @@ function formatDroitEstime(droit, parameters) {
         }
         break
       case "séances":
+        delete droitEstime.label
         droitEstime.value = `${droitEstime.value} ${droitEstime.unit}`
         break
       case "%":
+        droitEstime.label = "Valeur estimée"
         droitEstime.value = `${droitEstime.value} ${droitEstime.unit}`
         break
       default:


### PR DESCRIPTION
Capture d'écran du avant (en mode debug) :
![Screenshot 2023-02-01 at 18-16-51 Évaluez vos droits aux aides avec le simulateur de 1jeune1solution](https://user-images.githubusercontent.com/1410356/216114834-dcc062b2-4376-4f80-8ae4-3f14c6b5c43b.png)

CApture du après en mode debug
![Screenshot 2023-02-01 at 18-19-17 Évaluez vos droits aux aides avec le simulateur de 1jeune1solution](https://user-images.githubusercontent.com/1410356/216115994-75fa0e51-d32b-47e2-927b-c1ddb7975854.png)


Les noms de certaines aides sont affichés en double.
Cette PR supprime le texte pour les "séances" et le remplace par "Valeur estimée" pour les "%".