### PR TITLE
Répare le script de stats à partir des sondages dans Mongo

### DIFF
--- a/backend/lib/stats/mongodb.ts
+++ b/backend/lib/stats/mongodb.ts
@@ -77,7 +77,7 @@ function extractSurveySummary(db) {
           already: 4,
         }
         const benefitActionSurvey = this.surveys.find(
-          (s) => s.type === "benefit-action"
+          (s) => s.type === SurveyType.benefitAction
         )
         if (benefitActionSurvey.answers.length) {
           benefitActionSurvey.answers.sort(function (a, b) {
@@ -95,6 +95,9 @@ function extractSurveySummary(db) {
           "surveys.repliedAt": { $exists: true },
         },
         out: { inline: 1 },
+        scope: {
+          SurveyType,
+        },
       }
     )
     .then((r) => r.results || r)
@@ -121,7 +124,7 @@ function extractSurveyDetails(db) {
           obj[b.id] = b.amount
         })
         const benefitActionSurvey = this.surveys.find(
-          (s) => s.type === "benefit-action"
+          (s) => s.type === SurveyType.benefitAction
         )
         benefitActionSurvey.answers.forEach(function (a) {
           emit(`${a.id};${a.value}`, 1)
@@ -136,6 +139,9 @@ function extractSurveyDetails(db) {
           "surveys.repliedAt": { $exists: true },
         },
         out: { inline: 1 },
+        scope: {
+          SurveyType,
+        },
       }
     )
     .then((r) => r.results || r)

--- a/backend/lib/stats/mongodb.ts
+++ b/backend/lib/stats/mongodb.ts
@@ -76,11 +76,14 @@ function extractSurveySummary(db) {
           nothing: 3,
           already: 4,
         }
-        if (this.surveys[0].answers.length) {
-          this.surveys[0].answers.sort(function (a, b) {
+        const benefitActionSurvey = this.surveys.find(
+          (s) => s.type === "benefit-action"
+        )
+        if (benefitActionSurvey.answers.length) {
+          benefitActionSurvey.answers.sort(function (a, b) {
             return m[a.value] > m[b.value]
           })
-          emit(this.surveys[0].answers[0].value, 1)
+          emit(benefitActionSurvey.answers[0].value, 1)
         }
       },
       function (k, values) {
@@ -117,7 +120,10 @@ function extractSurveyDetails(db) {
         this.benefits.forEach(function (b) {
           obj[b.id] = b.amount
         })
-        this.surveys[0].answers.forEach(function (a) {
+        const benefitActionSurvey = this.surveys.find(
+          (s) => s.type === "benefit-action"
+        )
+        benefitActionSurvey.answers.forEach(function (a) {
           emit(`${a.id};${a.value}`, 1)
         })
       },


### PR DESCRIPTION
Le déploiement continu est cassé, enfin ça part en prod mais on a une erreur car le script de génération de stats échoue.

C'est suite aux travaux sur les sondages. Les scripts n'avaient pas été complètement mis à jour et ça cassait.

Testé en local avec un tunnel SSH vers la prod.