### PR TITLE
Ajout msa locale

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -190,6 +190,8 @@ fields:
       value: departement
     - label: CAF locale
       value: caf
+    - label: MSA locale
+      value: msa
     - label: EPCI (Métropole, inter-communauté, etc.)
       value: epci
     - label: Commune

--- a/data/institutions/msa_armorique.yml
+++ b/data/institutions/msa_armorique.yml
@@ -1,5 +1,5 @@
 name: Mutualité Sociale Agricole Armorique
 imgSrc: img/institutions/logo_mutualite_sociale_agricole.png
-type: national
+type: msa
 top: 10
 code_siren: "521431866"

--- a/data/institutions/msa_haute_normandie.yml
+++ b/data/institutions/msa_haute_normandie.yml
@@ -1,5 +1,5 @@
 name: Mutualité Sociale Agricole Haute Normandie
 imgSrc: img/institutions/logo_mutualite_sociale_agricole.png
-type: national
+type: msa
 top: 10
 code_siren: "521191148"

--- a/data/institutions/msa_midi_pyrenees_sud.yml
+++ b/data/institutions/msa_midi_pyrenees_sud.yml
@@ -1,5 +1,5 @@
 name: Mutualité Sociale Agricole Midi Pyrénées Sud
 imgSrc: img/institutions/logo_mutualite_sociale_agricole.png
-type: national
+type: msa
 top: 10
 code_siren: "509744876"

--- a/data/institutions/msa_nord_pas_de_calais.yml
+++ b/data/institutions/msa_nord_pas_de_calais.yml
@@ -1,5 +1,5 @@
 name: Mutualité Sociale Agricole Pas de Calais
 imgSrc: img/institutions/logo_mutualite_sociale_agricole.png
-type: national
+type: msa
 top: 10
 code_siren: "519482152"

--- a/data/institutions/msa_portes_de_bretagne.yml
+++ b/data/institutions/msa_portes_de_bretagne.yml
@@ -1,5 +1,5 @@
 name: Mutualité Sociale Agricole Portes de Bretagne
 imgSrc: img/institutions/logo_mutualite_sociale_agricole.png
-type: national
+type: msa
 top: 10
 code_siren: "521826107"

--- a/rollup/institutions.ts
+++ b/rollup/institutions.ts
@@ -55,7 +55,8 @@ for (const id in generator.institutionsMap) {
     institutionObject.location = institution.code_insee
   }
   if (!institutions[institution.type]) {
-    const msg = `The new institution type '${institution.type}' is required in rollup/institutions.ts`
+    console.log(institution)
+    const msg = `The new institution type '${institution.type}' of '${institution.slug}' needs to be added in rollup/institutions.ts`
     console.error(msg)
     throw new Error(msg)
   }

--- a/rollup/institutions.ts
+++ b/rollup/institutions.ts
@@ -54,6 +54,11 @@ for (const id in generator.institutionsMap) {
   } else if (["region", "departement", "commune"].includes(institution.type)) {
     institutionObject.location = institution.code_insee
   }
+  if (!institutions[institution.type]) {
+    const msg = `The new institution type '${institution.type}' is required in rollup/institutions.ts`
+    console.error(msg)
+    throw new Error(msg)
+  }
   institutions[institution.type].push(institutionObject)
 }
 

--- a/rollup/institutions.ts
+++ b/rollup/institutions.ts
@@ -26,6 +26,7 @@ const institutions = {
   departement: [],
   epci: [],
   caf: [],
+  msa: [],
   commune: [],
   autre: [],
 }

--- a/rollup/institutions.ts
+++ b/rollup/institutions.ts
@@ -48,7 +48,7 @@ for (const id in generator.institutionsMap) {
     institutionObject.location =
       epcis
         .find((element) => element.code === institution.code_siren)
-        ?.membres.map((commune) => commune.code) || []
+        .membres.map((commune) => commune.code) || []
   } else if (institution.type === "caf") {
     institutionObject.location = institution.department
   } else if (["region", "departement", "commune"].includes(institution.type)) {

--- a/rollup/institutions.ts
+++ b/rollup/institutions.ts
@@ -48,7 +48,7 @@ for (const id in generator.institutionsMap) {
     institutionObject.location =
       epcis
         .find((element) => element.code === institution.code_siren)
-        .membres.map((commune) => commune.code) || []
+        ?.membres.map((commune) => commune.code) || []
   } else if (institution.type === "caf") {
     institutionObject.location = institution.department
   } else if (["region", "departement", "commune"].includes(institution.type)) {

--- a/src/views/liste-aides.vue
+++ b/src/views/liste-aides.vue
@@ -87,6 +87,7 @@ const TYPES = {
   departement: "Aides départementales",
   epci: "EPCI (Métropole, inter-communauté, etc.)",
   caf: "CAF Locales",
+  msa: "MSA Locales",
   commune: "Aides communales",
   autre: "Autres aides",
 }
@@ -124,6 +125,9 @@ export default {
           ),
           caf: institutionsBenefits["caf"].filter(
             (caf) => caf.location == this.selectedCommune?.departement
+          ),
+          msa: institutionsBenefits["msa"].filter(
+            (msa) => msa.location == this.selectedCommune?.code
           ),
         }
       }


### PR DESCRIPTION
Il s'agit d'une 2ème itération sur le [ticket Trello suivant](https://trello.com/c/IgW1Zmjz/1132-bug-sur-la-page-toutes-les-aides-le-filtre-par-code-postal-ne-fonctionne-pas-pour-les-aides-msa) : 

- création d'une MSA locale