### PR TITLE
Change le wording de la question sur le taux d'incapacité

### DIFF
--- a/lib/properties/individu-properties.ts
+++ b/lib/properties/individu-properties.ts
@@ -572,11 +572,11 @@ export default {
         },
         {
           value: (0.5 + tauxMax) / 2,
-          label: `Entre 50% et ${tauxMax * 100}%`,
+          label: `De 50% à ${(tauxMax - 0.01) * 100}%`,
         },
         {
           value: (tauxMax + 1) / 2,
-          label: `Plus de ${tauxMax * 100}%`,
+          label: `${tauxMax * 100}% et plus`,
         },
       ]
     },


### PR DESCRIPTION
## Détails

Reformulation des réponses à la question sur le taux d'incapacité : 

Avant la PR 
<img width="556" alt="image" src="https://user-images.githubusercontent.com/16650011/218769399-a73e317e-d1b4-4316-b514-08839e4ddeac.png">

Après la PR
<img width="543" alt="image" src="https://user-images.githubusercontent.com/16650011/218769467-b35fb55b-9fd8-445b-a0fb-239568b97bb9.png">

## Notes

Le taux d'incapacité fonctionne par seuil ; plus de détail [sur legifrance](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027037614/)