### PR TITLE
Ajoute au modèle simulation un attribut pour indiquer qu'un followup lié existe

### DIFF
--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -53,7 +53,10 @@ export function persist(req: ajRequest, res: Response) {
     surveyOptin: req.body.surveyOptin,
   })
     .then((followup) => {
-      return followup.sendSimulationResultsEmail()
+      req.simulation.hasFollowup = true
+      return req.simulation
+        .save()
+        .then(() => followup.sendSimulationResultsEmail())
     })
     .then(() => {
       return res.send({ result: "OK" })

--- a/backend/models/simulation.ts
+++ b/backend/models/simulation.ts
@@ -55,6 +55,7 @@ const SimulationSchema = new mongoose.Schema<MongooseLayout, SimulationModel>(
     abtesting: { type: Map, of: String },
     finishedAt: Date,
     createdAt: { type: Date, default: Date.now },
+    hasFollowup: Boolean,
     modifiedFrom: String,
     status: {
       type: String,


### PR DESCRIPTION
L'objectif de cette PR est de plus facilement identifier les simulations sans followup pour les anonymiser plus rapidement.
J'ai préféré ne pas mettre l'identifiant du followup pour éviter de trop lier les deux modèles et surtout pour éviter qu'une association entre une simulation donnée et une adresse email soit trop facile.