### PR TITLE
Mise à jour CI - FIX `deprecated warnings`

### DIFF
--- a/.github/actions/reopen-issue-with-comment/main.js
+++ b/.github/actions/reopen-issue-with-comment/main.js
@@ -1,5 +1,5 @@
-const core = require("@actions/core")
-const github = require("@actions/github")
+import core from "@actions/core"
+import github from "@actions/github"
 
 async function run() {
   try {

--- a/.github/workflows/check-links-validity.yaml
+++ b/.github/workflows/check-links-validity.yaml
@@ -8,7 +8,7 @@ jobs:
   run:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: npm ci
       - id: invalid_links
         run: npm run tools:check-links-validity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,14 +256,14 @@ jobs:
           cp dist-server/backend/config/continuous-integration.js dist-server/backend/config/production.js
           nohup Xvfb :99 &
       - name: Cypress install
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@v4
         if: steps.restore-cypress.outputs.cache-hit != 'true'
         with:
           browser: chrome
           config-file: cypress.config.ts
           runTests: false
       - name: Cypress run
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@v4
         with:
           browser: chrome
           config-file: cypress.config.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Cache NPM install files
@@ -53,7 +53,7 @@ jobs:
         with:
           path: .venv
           key: ${{ runner.os }}-cache-python-dependencies-${{ hashFiles('**/openfisca/requirements.txt') }}
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Setup VirtualEnv
@@ -175,7 +175,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Restore node modules
@@ -211,7 +211,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Restore node modules
@@ -306,7 +306,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Restore node modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: stop-early
-        run: if "${GITHUB_WORKSPACE}/.github/has-openfisca-requirement-changes.sh" ; then echo "::set-output name=status::success" ; fi
+        run: if "${GITHUB_WORKSPACE}/.github/has-openfisca-requirement-changes.sh" ; then echo "{status}={success}" >> $GITHUB_OUTPUT ; fi
   test_definition_periods:
     name: Openfisca definition periods tests
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Cache NPM install files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-npm-install-packages
         with:
           path: ~/.npm
           key: ${{ runner.os }}-cache-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-dependencies
         with:
           path: node_modules
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Cache Virtual Environment
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: python-dependencies
         with:
           path: .venv
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Restore node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-dependencies
         with:
           path: node_modules
@@ -92,7 +92,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Restore node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-dependencies
         with:
           path: node_modules
@@ -107,7 +107,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Restore node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-dependencies
         with:
           path: node_modules
@@ -122,19 +122,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Restore node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-dependencies
         with:
           path: node_modules
           key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Cache build output
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-build
         with:
           path: dist
           key: ${{ runner.os }}-cache-build-${{ github.sha }}
       - name: Cache server build output
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-server-build
         with:
           path: dist-server
@@ -149,7 +149,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Restore contribuer/node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-contribuer-dependencies
         with:
           path: contribuer/node_modules
@@ -158,7 +158,7 @@ jobs:
         if: steps.restore-contribuer-dependencies.outputs.cache-hit != 'true'
         run: cd contribuer && npm ci --prefer-offline --no-audit
       - name: Restore contribuer/.next/cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.npm
@@ -179,13 +179,13 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Restore node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-dependencies
         with:
           path: node_modules
           key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Cache Virtual Environment
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: python-dependencies
         with:
           path: .venv
@@ -215,31 +215,31 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Restore node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-dependencies
         with:
           path: node_modules
           key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Cache Cypress installation
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-cypress
         with:
           path: ~/.cache/Cypress
           key: ${{ runner.os }}-cache-cypress-${{ hashFiles('**/package-lock.json') }}
       - name: Cache Virtual Environment
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: python-dependencies
         with:
           path: .venv
           key: ${{ runner.os }}-cache-python-dependencies-${{ hashFiles('**/openfisca/requirements.txt') }}
       - name: Cache build output
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-build
         with:
           path: dist
           key: ${{ runner.os }}-cache-build-${{ github.sha }}
       - name: Cache server build output
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-server-build
         with:
           path: dist-server
@@ -310,19 +310,19 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Restore node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-dependencies
         with:
           path: node_modules
           key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Cache Virtual Environment
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: python-dependencies
         with:
           path: .venv
           key: ${{ runner.os }}-cache-python-dependencies-${{ hashFiles('**/openfisca/requirements.txt') }}
       - name: Cache server build output
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-server-build
         with:
           path: dist-server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache Virtual Environment
         uses: actions/cache@v2
         id: python-dependencies
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Restore node modules
         uses: actions/cache@v2
         id: restore-dependencies
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Restore node modules
         uses: actions/cache@v2
         id: restore-dependencies
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Restore node modules
         uses: actions/cache@v2
         id: restore-dependencies
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Restore node modules
         uses: actions/cache@v2
         id: restore-dependencies
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Restore contribuer/node_modules
         uses: actions/cache@v2
         id: restore-contribuer-dependencies
@@ -174,7 +174,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -210,7 +210,7 @@ jobs:
         test: [base, family, handicap, patrimoine, student]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -286,7 +286,7 @@ jobs:
       status: ${{ steps.stop-early.outputs.status }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: stop-early
@@ -305,7 +305,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Cache NPM install files
@@ -53,7 +53,7 @@ jobs:
         with:
           path: .venv
           key: ${{ runner.os }}-cache-python-dependencies-${{ hashFiles('**/openfisca/requirements.txt') }}
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Setup VirtualEnv
@@ -175,7 +175,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Restore node modules
@@ -211,7 +211,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Restore node modules
@@ -306,7 +306,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Restore node modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,14 +256,14 @@ jobs:
           cp dist-server/backend/config/continuous-integration.js dist-server/backend/config/production.js
           nohup Xvfb :99 &
       - name: Cypress install
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v3
         if: steps.restore-cypress.outputs.cache-hit != 'true'
         with:
           browser: chrome
           config-file: cypress.config.ts
           runTests: false
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v3
         with:
           browser: chrome
           config-file: cypress.config.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           install: false
           spec: cypress/e2e/${{matrix.test}}.cy.js
       - name: Upload cypress videos
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-${{matrix.test}}

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -157,18 +157,17 @@ function basicFormat(data) {
 }
 
 function buildMessage(benefitWithErrors, rowFormat) {
-  return `Certaines aides référencées (${
-    benefitWithErrors.length
-  }) ont des liens dysfonctionnels :
+  return `Certaines aides référencées (${benefitWithErrors.length
+    }) ont des liens dysfonctionnels :
 
 ${benefitWithErrors.map(rowFormat).join("\n")}`
 }
 
 function buildGitHubIssueCommentText(benefitWithErrors) {
-  return `::set-output name=comment::${buildMessage(
+  return `'{comment}={${buildMessage(
     benefitWithErrors,
     githubRowFormat
-  )}`
+  )}}' >> $GITHUB_OUTPUT`
     .split("\n")
     .join("<br />")
 }

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -157,17 +157,18 @@ function basicFormat(data) {
 }
 
 function buildMessage(benefitWithErrors, rowFormat) {
-  return `Certaines aides référencées (${benefitWithErrors.length
+  return `Certaines aides référencées (${
+    benefitWithErrors.length
     }) ont des liens dysfonctionnels :
 
 ${benefitWithErrors.map(rowFormat).join("\n")}`
 }
 
 function buildGitHubIssueCommentText(benefitWithErrors) {
-  return `'{comment}={${buildMessage(
+  return `{comment}={${buildMessage(
     benefitWithErrors,
     githubRowFormat
-  )}}' >> $GITHUB_OUTPUT`
+  )}} >> $GITHUB_OUTPUT`
     .split("\n")
     .join("<br />")
 }

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -165,10 +165,10 @@ ${benefitWithErrors.map(rowFormat).join("\n")}`
 }
 
 function buildGitHubIssueCommentText(benefitWithErrors) {
-  return `{comment}={${buildMessage(
+  return `"{comment}={${buildMessage(
     benefitWithErrors,
     githubRowFormat
-  )}} >> $GITHUB_OUTPUT`
+  )}}" >> $GITHUB_OUTPUT`
     .split("\n")
     .join("<br />")
 }

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -159,15 +159,14 @@ function basicFormat(data) {
 }
 
 function buildMessage(benefitWithErrors, rowFormat) {
-  return `Certaines aides référencées (${
-    benefitWithErrors.length
-  }) ont des liens dysfonctionnels :
+  return `Certaines aides référencées (${benefitWithErrors.length
+    }) ont des liens dysfonctionnels :
 
 ${benefitWithErrors.map(rowFormat).join("\n")}`
 }
 
 function buildGitHubIssueCommentText(benefitWithErrors) {
-  const issueContent = `comment=${buildMessage(
+  const issueContent = `${buildMessage(
     benefitWithErrors,
     githubRowFormat
   )

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -173,6 +173,9 @@ function buildGitHubIssueCommentText(benefitWithErrors) {
     }} >> $GITHUB_OUTPUT`
 }
 
+import * as fs from 'fs'
+import * as os from 'os'
+
 async function main() {
   // const benefitData = await getBenefitData()
   // const results = await Bluebird.map(benefitData, checkURL, { concurrency: 3 })
@@ -187,6 +190,10 @@ async function main() {
   //   }
   // }
   // console.log("Terminé")
+
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `comment=value${os.EOL}`, {
+    encoding: 'utf8'
+  })
   console.log(`"{name}={value}" >> $GITHUB_OUTPUT`)
 }
 

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -159,17 +159,15 @@ function basicFormat(data) {
 }
 
 function buildMessage(benefitWithErrors, rowFormat) {
-  return `Certaines aides référencées (${benefitWithErrors.length
-    }) ont des liens dysfonctionnels :
+  return `Certaines aides référencées (${
+    benefitWithErrors.length
+  }) ont des liens dysfonctionnels :
 
 ${benefitWithErrors.map(rowFormat).join("\n")}`
 }
 
 function buildGitHubIssueCommentText(benefitWithErrors) {
-  const issueContent = `${buildMessage(
-    benefitWithErrors,
-    githubRowFormat
-  )
+  const issueContent = `${buildMessage(benefitWithErrors, githubRowFormat)
     .split("\n")
     .join("<br />")}`
 

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -157,36 +157,37 @@ function basicFormat(data) {
 }
 
 function buildMessage(benefitWithErrors, rowFormat) {
-  return `Certaines aides référencées (${
-    benefitWithErrors.length
+  return `Certaines aides référencées (${benefitWithErrors.length
     }) ont des liens dysfonctionnels :
 
 ${benefitWithErrors.map(rowFormat).join("\n")}`
 }
 
 function buildGitHubIssueCommentText(benefitWithErrors) {
-  return `"{comment}={${buildMessage(
+  return `{comment}={${buildMessage(
     benefitWithErrors,
     githubRowFormat
-  )}}" >> $GITHUB_OUTPUT`
+  )
     .split("\n")
     .join("<br />")
+    }} >> $GITHUB_OUTPUT`
 }
 
 async function main() {
-  const benefitData = await getBenefitData()
-  const results = await Bluebird.map(benefitData, checkURL, { concurrency: 3 })
-  const detectedErrors = results
-    .filter((i) => i.errors.length)
-    .sort((a, b) => -(a.priority - b.priority))
-  if (detectedErrors.length > 0) {
-    if (process.argv.slice(2).includes("--ci")) {
-      console.log(buildGitHubIssueCommentText(detectedErrors))
-    } else if (detectedErrors) {
-      console.log(buildMessage(detectedErrors, basicFormat))
-    }
-  }
-  console.log("Terminé")
+  // const benefitData = await getBenefitData()
+  // const results = await Bluebird.map(benefitData, checkURL, { concurrency: 3 })
+  // const detectedErrors = results
+  //   .filter((i) => i.errors.length)
+  //   .sort((a, b) => -(a.priority - b.priority))
+  // if (detectedErrors.length > 0) {
+  //   if (process.argv.slice(2).includes("--ci")) {
+  //     console.log(buildGitHubIssueCommentText(detectedErrors))
+  //   } else if (detectedErrors) {
+  //     console.log(buildMessage(detectedErrors, basicFormat))
+  //   }
+  // }
+  // console.log("Terminé")
+  console.log(`"{name}={value}" >> $GITHUB_OUTPUT`)
 }
 
 main()


### PR DESCRIPTION
# Description :
Notre CI emet des warnings car nous utilisons différents outils dépréciées: 
- la commande `set-output` qui a changé de syntaxe (cf [Communication Github](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))
- les actions `chekout@v2` , `cache@v2`, `setup-python@v2` et `upload-artifact@v2` qui utilsent soit l'ancienne syntaxe de `set-output` également, ou bien `Node.js 12` qui est maintenant déprécié

# Actions :
- Utiliser la nouvelle syntaxe de `set-output`
- Mettre à jour les actions qui utilisent l'ancienne syntaxe de `set-output` ou `Node.js 12`