### PR TITLE
Met à jour la version de Python en 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   OPENFISCA_BIND_HOST: 127.0.0.1:2000
   LC_ALL: C.UTF-8
   LANG: C.UTF-8
-  PYTHON_VERSION: 3.7.12
+  PYTHON_VERSION: 3.8
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -52,7 +52,7 @@ jobs:
         id: python-dependencies
         with:
           path: .venv
-          key: ${{ runner.os }}-cache-python-dependencies-${{ hashFiles('**/openfisca/requirements.txt') }}
+          key: ${{ runner.os }}-cache-python-dependencies-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/openfisca/requirements.txt') }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -189,7 +189,7 @@ jobs:
         id: python-dependencies
         with:
           path: .venv
-          key: ${{ runner.os }}-cache-python-dependencies-${{ hashFiles('**/openfisca/requirements.txt') }}
+          key: ${{ runner.os }}-cache-python-dependencies-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/openfisca/requirements.txt') }}
       - name: Validate OpenFisca test generation
         shell: bash
         run: |
@@ -249,7 +249,7 @@ jobs:
         id: python-dependencies
         with:
           path: .venv
-          key: ${{ runner.os }}-cache-python-dependencies-${{ hashFiles('**/openfisca/requirements.txt') }}
+          key: ${{ runner.os }}-cache-python-dependencies-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/openfisca/requirements.txt') }}
       - name: Cache build output
         uses: actions/cache@v3
         id: restore-build
@@ -338,7 +338,7 @@ jobs:
         id: python-dependencies
         with:
           path: .venv
-          key: ${{ runner.os }}-cache-python-dependencies-${{ hashFiles('**/openfisca/requirements.txt') }}
+          key: ${{ runner.os }}-cache-python-dependencies-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/openfisca/requirements.txt') }}
       - name: Cache server build output
         uses: actions/cache@v3
         id: restore-server-build

--- a/openfisca/Dockerfile
+++ b/openfisca/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 
 RUN mkdir /usr/src/openfisca
 WORKDIR /usr/src/openfisca


### PR DESCRIPTION
## Détails

[Tâche Trello](https://trello.com/c/I7P1BYDh/582-passer-la-production-de-python-en-38-pour-openfisca)

## Notes

Cette PR nécessite idéalement le passage en amont de : 
- https://github.com/openfisca/openfisca-core/pull/1168
- la PR correspondante sur le repo Ops

~~Cette PR n'a pas d'impact sur la production mais rend la CI non iso-fonctionnelle.~~

**À date du 16 juin l'Ops tourne déjà sur Python 3.8**