### PR TITLE
Fix: modifie la commande de serve pour supporter les checks d'erreur

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simulateur de prestations sociales pour les jeunes",
   "type": "module",
   "scripts": {
-    "serve": "nodemon --exec 'ts-node --transpiler ts-node/transpilers/swc backend/dev'",
+    "serve": "nodemon --exec 'ts-node --swc backend/dev'",
     "build": "concurrently 'npm run build:server' && concurrently 'npm run build:iframes' 'npm run build:front' && npm run copy:templates",
     "clean:dist-server": "rm -fR dist-server",
     "copy:templates": "mkdir -p dist-server/backend/lib/mes-aides/emails/templates && cp backend/lib/mes-aides/emails/templates/* dist-server/backend/lib/mes-aides/emails/templates",


### PR DESCRIPTION
## Détails

La présence d'erreur de syntaxe dans les dossiers `backend` et `lib` n'entrainait pas toujours d'erreur lorsque le serveur était lancé en mode `serve`.