### PR TITLE
new notification email type and begin followup methods

### DIFF
--- a/backend/lib/email.ts
+++ b/backend/lib/email.ts
@@ -62,6 +62,8 @@ function processSend(args) {
         switch (emailType) {
           case EmailType.simulationResults:
             return followup.sendSimulationResultsEmail()
+          case EmailType.pricingNotification:
+            return followup.sendPricingNotificationEmail()
           case EmailType.benefitAction:
             return followup.sendSurvey(
               SurveyType.trackClickOnBenefitActionEmail

--- a/backend/types/email.ts
+++ b/backend/types/email.ts
@@ -2,4 +2,5 @@ export enum EmailType {
   simulationResults = "simulation-results",
   benefitAction = "benefit-action",
   simulationUsefulness = "simulation-usefulness",
+  pricingNotification = "pricing-notification",
 }


### PR DESCRIPTION
# 🎯 Objectif 

Dans le cadre de l'expérimentation de [Tous à bord](https://beta.gouv.fr/startups/tous.a.bord.html) autour de l'administration proactive, ajouter l'envoi automatique d'email après une simulation affichant l'aide liée (pass pass x demandeur·se d'emploi)

# ⚒️ Implémentation

- [X] Add email and email type
- [ ] Modification du modèle followup
- [ ] Délimitation du contenu du mail

