### PR TITLE
fix: corrige un problème de build lié à l'outil de check de liens

### DIFF
--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -172,7 +172,7 @@ function buildGitHubIssueCommentText(benefitWithErrors) {
     .join("<br />")}`
 
   fs.appendFileSync(
-    process.env.GITHUB_OUTPUT,
+    `${process.env.GITHUB_OUTPUT}`,
     `comment=${issueContent}${os.EOL}`,
     {
       encoding: "utf8",


### PR DESCRIPTION
## Détails

La commande `npm run build:server` retourne l'erreur suivante : 
```
tools/check-links-validity.ts:175:5 - error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'PathOrFileDescriptor'.
  Type 'undefined' is not assignable to type 'PathOrFileDescriptor'.

175     process.env.GITHUB_OUTPUT,
        ~~~~~~~~~~~~~~~~~~~~~~~~~
```