### PR TITLE
FIX : corrige un problème de CI lié au test d'iframe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
           npm run test tests/unit/openfisca/test.spec.js
   iframe_build_control:
     name: Iframe build control
+    needs: [install]
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout


### PR DESCRIPTION
## Détails

Le test de build de l'iframe sur la CI échouait lorsque le fichier `package-lock.json` était modifié.

## Notes

Le problème venait du fait que la tâche de test de l'iframe était lancé immédiatement avec la CI sans attendre la tâche d'installation (et sa mise en cache). La tâche échouait lorsque la CI était exécutée une première fois, mais passait lors du second run.