### PR TITLE
Améliore la réutilisabilité de l'ajout de logique aux aides

### DIFF
--- a/data/index.ts
+++ b/data/index.ts
@@ -86,15 +86,13 @@ export function generate(
     ...aidesVeloBenefits.filter((b) => b.institution),
     ...apaBenefits,
     ...fslBenefits,
-  ].map((benefit) => {
-    return Object.assign({}, benefit, additionalBenefitAttributes[benefit.slug])
-  })
-
+  ]
   const benefitsMap = {}
 
   benefits = benefits.map((benefit) => {
     const institution = institutions[benefit.institution]
     benefit = setDefaults(benefit, institution)
+    Object.assign(benefit, additionalBenefitAttributes[benefit.id])
     institution.benefitsIds.push(benefit.id)
     benefit.institution = institution
     benefitsMap[benefit.id] = benefit


### PR DESCRIPTION
Aujourd'hui, certaines informations associées à des aides ne peuvent pas simplement être ajoutées aux fichiers YAML dans /data/.
Il s'agit de fonctions ou de contenu très spécifique.

Les aides ajoutées depuis aidesvelo ne pouvaient pas bénéficier de cette fonctionnalité d'enrichissement.
Cette PR déplace (et peut-être simplifie) la logique d'enrichissement pour être utilisable pour les aides vélo.

En l'occurrence, cette PR est un travail préparatoire à la PR sur le préremplissage #3495.