### PR TITLE
fix simulation locataire to propietaire

### DIFF
--- a/lib/logement.ts
+++ b/lib/logement.ts
@@ -41,9 +41,12 @@ function isOwner(_logementType) {
   return _logementType === LogementType.proprietaire
 }
 
-function captureCharges(_locationType) {
+function captureCharges(_logementType, _locationType) {
   return (
-    _locationType === LocationType.vide || _locationType === LocationType.foyer
+    _logementType !== LogementType.proprietaire && (
+      _locationType === LocationType.vide ||
+      _locationType === LocationType.foyer
+    )
   )
 }
 
@@ -53,7 +56,7 @@ export function getLoyerData(answers) {
   const coloc = getAnswer(answers, "menage", "coloc")
   const loyer = getAnswer(answers, "menage", "loyer") || {}
   const isOwner = Logement.isOwner(_logementType)
-  const captureCharges = Logement.captureCharges(_locationType)
+  const captureCharges = Logement.captureCharges(_logementType, _locationType)
 
   if (!isOwner) {
     const loyerLabel = `Quel est le montant de votre ${

--- a/lib/logement.ts
+++ b/lib/logement.ts
@@ -85,6 +85,7 @@ export function getLoyerData(answers) {
         hint: "Laissez ce champ à 0 € si vous ne remboursez pas actuellement de crédit pour votre logement.",
         selectedValue: loyer.loyer,
       },
+      chargesQuestion: null
     }
   }
 }

--- a/src/views/simulation/Menage/loyer.vue
+++ b/src/views/simulation/Menage/loyer.vue
@@ -34,7 +34,7 @@
 
       <div class="fr-container fr-px-0">
         <div class="fr-grid-row">
-          <div class="fr-col-12 fr-col-sm-5 fr-col-md-5 fr-col-lg-5">
+          <div class="fr-col-12 fr-col-md-6 fr-col-md-5 fr-col-lg-5">
             <InputNumber
               id="charges"
               v-model="chargesQuestion.selectedValue"


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/00GVHSBZ/1192-bug-une-simulation-en-tant-que-locataire-modif%C3%A9e-en-propri%C3%A9taire-se-bloque-apr%C3%A8s-l%C3%A9tape-primo-acc%C3%A9dant

# Resumé des recherches : 
- On affiche la step de loyer qu’on soit proprio ou locataire ([ici](https://github.com/betagouv/aides-jeunes/blob/f9797e74938000c3c9272d9e0568345580614f39/lib/state/blocks.ts#L335-L341))
- Dans le cas où on est propriétaire on demande quand même les charge si le `_locationType` est `"vide"` ou `"foyer"` : ([ici](https://github.com/betagouv/aides-jeunes/blob/6eb141967aa271d7f4e72bacc54ef12d5833cca3/lib/logement.ts#L46)) 
- Cependant, comme on n'est pas owner ([ici](https://github.com/betagouv/aides-jeunes/blob/6eb141967aa271d7f4e72bacc54ef12d5833cca3/lib/logement.ts#L62)) => on a pas de `chargesQuestion` alors que `captureCharges` est quand même à true => BUG

# Proposition de solution : 
- Soit on split la page loyer en deux afin d’avoir loyer et mensualité, ça évite de mélanger une logique locataire et propriétaire. 
- Soit on force le fait de remettre `_locationType` à `null` si on passe propriétaire, (💡cependant je ne sais pas si on veut quand même garder cette info au cas où il y a rechargement dans le formulaire)
- On peut plus simplement modifier `captureCharges()` ([ici](https://github.com/betagouv/aides-jeunes/blob/6eb141967aa271d7f4e72bacc54ef12d5833cca3/lib/logement.ts#L44-L48)) afin de renvoyer `false` on est dans un cas propriétaire. 

Pour le moment cette PR implémente le dernier point.
