### PR TITLE
config: désactive le formatting du dossier contribuer/out

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ dist-server
 .next
 public
 .venv*
+contribuer/out


### PR DESCRIPTION
## Détails

La commande `npm run prettier:fix` formatte le code généré par un build de l'outil de contribution