### PR TITLE
fix: n'affiche pas les aides n'existant plus dans le sondage

### DIFF
--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import Followup from "../models/followup.js"
-
+import Benefits from "../../data/all.js"
 import pollResult from "../lib/mattermost-bot/poll-result.js"
 import simulationController from "./simulation.js"
 import { Response, NextFunction } from "express"
@@ -68,7 +68,12 @@ export function persist(req: ajRequest, res: Response) {
 }
 
 export function getFollowup(req: ajRequest, res: Response) {
-  res.send(req.followup)
+  res.send({
+    createdAt: req.followup.createdAt,
+    benefits: req.followup.benefits.filter(
+      (benefit) => benefit.id in Benefits.benefitsMap
+    ),
+  })
 }
 
 export function showSurveyResult(req: ajRequest, res: Response) {


### PR DESCRIPTION
## Détails

[Tâche Trello](https://trello.com/c/3oVZIfK5/1194-bug-la-page-sondage-retourne-une-erreur-lorsquun-droit-nexiste-plus)

## Reproduction du bug

Pour reproduire le bug en local, il est possible d'ajouter le document suivant dans la collection mongo `followups` : 
```json
{
  "simulation": {
    "$oid": "69ba392a8279be3722e6ab4f"
  },
  "email": "someimaginaryemail@mail.com",
  "surveyOptin": true,
  "createdAt": {
    "$date": {
      "$numberLong": "1675171688368"
    }
  },
  "surveys": [],
  "version": 3,
  "accessToken": "pr-3571-test-token",
  "__v": 5,
  "benefits": [
    {
      "id": "aide_logement",
      "amount": 320,
      "unit": "€"
    },
    {
      "id": "nom_aide_fictive",
      "amount": true
    }
  ],
  "messageId": "<202301311328.98327488560@smtp-relay.mailin.fr>",
  "sentAt": {
    "$date": {
      "$numberLong": "1675171690611"
    }
  }
}
```
En lançant le serveur en mode serve et en allant sur la page `http://localhost:8080/suivi?token=pr-3571-test-token`, une erreur doit apparaitre dans la console sur la branche `master` mais pas sur la branche `fix/suivi-benefit`

## Correctif

La solution ici est de filtrer les aides qui n'existent plus lors d'une requête vers l'API `/api/followups/surveys/:token`

## Notes

L'aide n'existant plus appelée dans le sondage est `etat-aide-nationale-exceptionnelle-au-brevet-daptitude-aux-fonctions-danimateur-bafa` ; modifiée dans #3570 