### PR TITLE
Recueillir les statistiques d’affichage du lien “Montant Inattendu” dans la page résultat

### DIFF
--- a/src/mixins/resultats.js
+++ b/src/mixins/resultats.js
@@ -35,6 +35,9 @@ export default {
         this.droits
       )
     },
+    ressourcesYearMinusTwoCaptured() {
+      return this.store.ressourcesYearMinusTwoCaptured
+    },
   },
   methods: {
     eligibleBenefits() {

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -113,10 +113,10 @@ export default {
       after(() => {
         switch (name) {
           case "setResults": {
-            store.calculs.resultats.droitsEligibles.forEach(function (d) {
-              vm.$matomo?.trackEvent("General", "show", d.id)
+            this.sendShowStatistics({
+              droitsEligibles: store.calculs.resultats.droitsEligibles,
+              droits: this.droits,
             })
-            this.sendStatistics(this.droits, "show")
             break
           }
           case "saveComputationFailure": {
@@ -178,6 +178,12 @@ export default {
   methods: {
     isEmpty(array) {
       return !array || array.length === 0
+    },
+    sendShowStatistics({ droitsEligibles, droits }) {
+      droitsEligibles.forEach((droit) => {
+        this.$matomo?.trackEvent("General", "show", droit.id)
+      })
+      this.sendStatistics(droits, "show")
     },
   },
 }

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -113,14 +113,8 @@ export default {
       after(() => {
         switch (name) {
           case "setResults": {
-            this.sendShowStatistics({
-              droits: this.droits,
-            })
-            this.sendDisplayUnexpectedAmountLinkStatistics({
-              droits: this.droits,
-              ressourcesYearMinusTwoCaptured:
-                this.store.ressourcesYearMinusTwoCaptured,
-            })
+            this.sendShowStatistics()
+            this.sendDisplayUnexpectedAmountLinkStatistics()
             break
           }
           case "saveComputationFailure": {
@@ -183,22 +177,19 @@ export default {
     isEmpty(array) {
       return !array || array.length === 0
     },
-    sendShowStatistics({ droits }) {
-      droits.forEach((droit) => {
+    sendShowStatistics() {
+      this.droits.forEach((droit) => {
         this.$matomo?.trackEvent("General", "show", droit.id)
       })
-      this.sendStatistics(droits, "show")
+      this.sendStatistics(this.droits, "show")
     },
-    sendDisplayUnexpectedAmountLinkStatistics({
-      droits,
-      ressourcesYearMinusTwoCaptured,
-    }) {
+    sendDisplayUnexpectedAmountLinkStatistics() {
       const droitsWithUnexpectedAmount = []
 
-      droits.forEach((droit) => {
+      this.droits.forEach((droit) => {
         const unexpectedAmountLinkDisplayed =
           (droit.isBaseRessourcesYearMinusTwo &&
-            !ressourcesYearMinusTwoCaptured) ||
+            !this.ressourcesYearMinusTwoCaptured) ||
           droit.showUnexpectedAmount
 
         if (!unexpectedAmountLinkDisplayed) {

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -109,12 +109,11 @@ export default {
     this.store.updateCurrentAnswers(this.$route.path)
 
     let vm = this
-    this.stopSubscription = this.store.$onAction(({ after, store, name }) => {
+    this.stopSubscription = this.store.$onAction(({ after, name }) => {
       after(() => {
         switch (name) {
           case "setResults": {
             this.sendShowStatistics({
-              droitsEligibles: store.calculs.resultats.droitsEligibles,
               droits: this.droits,
             })
             this.sendDisplayUnexpectedAmountLinkStatistics({
@@ -184,8 +183,8 @@ export default {
     isEmpty(array) {
       return !array || array.length === 0
     },
-    sendShowStatistics({ droitsEligibles, droits }) {
-      droitsEligibles.forEach((droit) => {
+    sendShowStatistics({ droits }) {
+      droits.forEach((droit) => {
         this.$matomo?.trackEvent("General", "show", droit.id)
       })
       this.sendStatistics(droits, "show")

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -117,6 +117,11 @@ export default {
               droitsEligibles: store.calculs.resultats.droitsEligibles,
               droits: this.droits,
             })
+            this.sendDisplayUnexpectedAmountLinkStatistics({
+              droits: this.droits,
+              ressourcesYearMinusTwoCaptured:
+                this.store.ressourcesYearMinusTwoCaptured,
+            })
             break
           }
           case "saveComputationFailure": {
@@ -184,6 +189,35 @@ export default {
         this.$matomo?.trackEvent("General", "show", droit.id)
       })
       this.sendStatistics(droits, "show")
+    },
+    sendDisplayUnexpectedAmountLinkStatistics({
+      droits,
+      ressourcesYearMinusTwoCaptured,
+    }) {
+      const droitsWithUnexpectedAmount = []
+
+      droits.forEach((droit) => {
+        const unexpectedAmountLinkDisplayed =
+          (droit.isBaseRessourcesYearMinusTwo &&
+            !ressourcesYearMinusTwoCaptured) ||
+          droit.showUnexpectedAmount
+
+        if (!unexpectedAmountLinkDisplayed) {
+          return
+        }
+
+        this.$matomo?.trackEvent(
+          "General",
+          "show-unexpected-amount-link",
+          droit.id
+        )
+        droitsWithUnexpectedAmount.push(droit)
+      })
+
+      this.sendStatistics(
+        droitsWithUnexpectedAmount,
+        "show-unexpected-amount-link"
+      )
     },
   },
 }


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/3sC6kwfw/1181-ajouter-une-stats-sur-la-page-de-r%C3%A9sultats-sur-le-nombre-daffichage-du-message-montant-inattendu-sur-les-aides

ℹ️ Cette PR permet d'envoyer des statistiques `show-unexpected-amount-link` à chaque fois que le lien "Montant Inattendu" est montré. 
⚠️ Cette Pr refactor un petit peu la method `mounted` du composant `resultats.vue` en bougeant l'envoi de statistiques dans des méthodes qui n'ont que cette responsabilité