### PR TITLE
1191 ajouter des stats sur laffichage du lien pour prendre rdv

### DIFF
--- a/src/views/suivi.vue
+++ b/src/views/suivi.vue
@@ -202,9 +202,6 @@ export default {
       })
   },
   methods: {
-    isBoolean: (val) => typeof val === "boolean",
-    isString: (val) => typeof val === "string",
-    isNumber: (val) => typeof val === "number",
     isNegative,
     prefix: function (droit) {
       if (droit.prefix) {

--- a/src/views/suivi.vue
+++ b/src/views/suivi.vue
@@ -15,7 +15,7 @@
                 <h3 class="last"
                   >Merci d'avoir rempli ce questionnaire&nbsp;!</h3
                 >
-                <div v-if="droits && showAccompanimentBlock === true">
+                <div v-if="showAccompanimentBlock">
                   <p class="fr-text--lg">
                     Vous avez besoin d'aide pour effectuer vos démarches ?
                     Prenez rendez-vous pour être accompagné·e par notre

--- a/src/views/suivi.vue
+++ b/src/views/suivi.vue
@@ -23,11 +23,16 @@
                   >
                   <p>
                     <a
+                      v-analytics="{
+                        name: currentPath,
+                        action: 'click-accompaniment-link',
+                        category: 'Accompaniment',
+                      }"
                       class="fr-btn fr-btn--lg"
                       href="https://www.rdv-aide-numerique.fr/?address=1&departement=AJ"
-                      >Prendre rendez-vous pour être aidé·e dans mes
-                      démarches</a
                     >
+                      Prendre rendez-vous pour être aidé·e dans mes démarches
+                    </a>
                   </p>
 
                   <p class="fr-mt-3w"
@@ -174,6 +179,9 @@ export default {
         ["failed", "nothing"].includes(droit.choiceValue)
       )
     },
+    currentPath: function () {
+      return this.$route.path
+    },
   },
   mounted: async function () {
     const { data: followup } = await axios.get(
@@ -227,6 +235,14 @@ export default {
 
       this.submitted = true
       window.scrollTo(0, 0)
+
+      if (this.showAccompanimentBlock) {
+        this.$matomo?.trackEvent(
+          "Accompaniment",
+          "show-accompaniment-link",
+          this.currentPath
+        )
+      }
     },
   },
 }


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/EEb9VcqO/1191

Note: en amont de l'ajout des deux statistiques `show-accompaniment-link` et `click-accompaniment-link`, cette PR comporte trois commits séparés avec des petites refacto du component `Suivi` 