### PR TITLE
1201 Gestion du Source Map sur Sentry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
     name: Build
     needs: [install, check_data_file_consistency]
     runs-on: ubuntu-20.04
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.18.6",
+        "@sentry/vite-plugin": "^0.4.0",
         "@types/bluebird": "^3.5.36",
         "@types/errorhandler": "^1.5.0",
         "@types/express": "^4.17.14",
@@ -2682,6 +2683,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.44.1.tgz",
+      "integrity": "sha512-oSDyP9hD0Df35U9LPNpXYmaIjRMEVQxNUdco30uwrPsaO5I2thVNURn8H1OokU1M1D5aIeK1SjqSV91U3U1llA==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "7.44.1",
+        "@sentry/types": "7.44.1",
+        "@sentry/utils": "7.44.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/@sentry/core": {
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.44.1.tgz",
+      "integrity": "sha512-MiDQ7cGPrWMvvnU1pszSNak4DuH7RnPS/WLVKPJDBh1paozA9bPaxRRfJu0BGtw0BV1pRoTP2CQyp0AHdNaHow==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "7.44.1",
+        "@sentry/utils": "7.44.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.44.1.tgz",
+      "integrity": "sha512-g0vlu7EdphUv7x0p/r1t7kjh1kNCoSMmK2G6FQCfGH2cr1AMcOAKF5iFxTN2dv0Ap3glLQPgid0bRyqcQAlCBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.44.1.tgz",
+      "integrity": "sha512-KfgfyurxBMFUBBPmYUPH2L46wT1nf5CbBq1wP/7D1p3EKwspb13ubK7VbxC779+JeSHqtGNOeWfY1jl1/8XBYg==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "7.44.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sentry/browser": {
       "version": "6.14.1",
       "license": "BSD-3-Clause",
@@ -2693,6 +2745,120 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-0.4.0.tgz",
+      "integrity": "sha512-Xi+dqaSOoxbdmxegX7f66FVOxm2dVJLmrMXUpoNyuV6ASoccRWzouGaFekP059SUTTD05ytk1mHqwgVuBCA0Dw==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/cli": "^2.10.0",
+        "@sentry/node": "^7.19.0",
+        "@sentry/tracing": "^7.19.0",
+        "magic-string": "0.27.0",
+        "unplugin": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/core": {
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.44.1.tgz",
+      "integrity": "sha512-MiDQ7cGPrWMvvnU1pszSNak4DuH7RnPS/WLVKPJDBh1paozA9bPaxRRfJu0BGtw0BV1pRoTP2CQyp0AHdNaHow==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "7.44.1",
+        "@sentry/utils": "7.44.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/node": {
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.44.1.tgz",
+      "integrity": "sha512-ISmmrN37m7acLWKLDdLynaIvdMI+Mu2KjVmunz68cnYOt/+DlZnElBxBvpAbVauJ4tRqqqlrbCpKCOIWLtJrvQ==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "7.44.1",
+        "@sentry/types": "7.44.1",
+        "@sentry/utils": "7.44.1",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/tracing": {
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.44.1.tgz",
+      "integrity": "sha512-HC39/KTuzw3DQ46J952cYZ+NONaq6ghgGn5IxWHhG/Dv4u9YeFbMxhJYCdtMWOoXsw0fEkAWiGR+u4Ts7T88Tg==",
+      "dev": true,
+      "dependencies": {
+        "@sentry-internal/tracing": "7.44.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/types": {
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.44.1.tgz",
+      "integrity": "sha512-g0vlu7EdphUv7x0p/r1t7kjh1kNCoSMmK2G6FQCfGH2cr1AMcOAKF5iFxTN2dv0Ap3glLQPgid0bRyqcQAlCBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/utils": {
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.44.1.tgz",
+      "integrity": "sha512-KfgfyurxBMFUBBPmYUPH2L46wT1nf5CbBq1wP/7D1p3EKwspb13ubK7VbxC779+JeSHqtGNOeWfY1jl1/8XBYg==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "7.44.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.15.2.tgz",
+      "integrity": "sha512-jt8RvbHX09eLj2GY2ufytU/n1sWbUh7/EzBE4Ut92kPCLyo+D56VwR641HBrthZluWpGO/w2ujFMNpkk99UPfA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@sentry/core": {
@@ -2794,6 +2960,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-0.4.0.tgz",
+      "integrity": "sha512-dBxM00MCLzO/idzAqj33ZfbIBKZxP+FzpxtS2WaV0yzad9yLBAFZ/VGDIGHQJC0Qo3fsFi/CZpmN39wJkJoWFA==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "0.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@sentry/vue": {
@@ -3870,8 +4048,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.5.0",
-      "license": "MIT",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4876,8 +5055,15 @@
       "license": "0BSD"
     },
     "node_modules/chokidar": {
-      "version": "3.5.2",
-      "license": "MIT",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -5721,20 +5907,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/cypress/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/cypress/node_modules/yallist": {
       "version": "4.0.0",
       "dev": true,
@@ -5968,19 +6140,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/default-gateway/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -7115,20 +7274,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/eslint/node_modules/yallist": {
@@ -9164,21 +9309,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-changed-files/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/jest-circus": {
       "version": "27.4.2",
       "dev": true,
@@ -10132,21 +10262,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/jest-serializer": {
@@ -11880,22 +11995,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/node-notifier/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/node-notifier/node_modules/yallist": {
       "version": "4.0.0",
       "dev": true,
@@ -12631,20 +12730,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pretty-quick/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "license": "MIT"
@@ -12684,6 +12769,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -14483,6 +14574,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unplugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+      "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.1",
+        "chokidar": "^3.5.3",
+        "webpack-sources": "^3.2.3",
+        "webpack-virtual-modules": "^0.5.0"
+      }
+    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "dev": true,
@@ -15189,19 +15292,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/webpack-cli/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webpack-dev-middleware": {
       "version": "5.3.0",
       "license": "MIT",
@@ -15404,11 +15494,18 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.2",
-      "license": "MIT",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+      "dev": true
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "3.1.1",
@@ -15466,6 +15563,20 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which-boxed-primitive": {
@@ -17319,6 +17430,47 @@
       "version": "1.0.0-next.21",
       "dev": true
     },
+    "@sentry-internal/tracing": {
+      "version": "7.44.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.44.1.tgz",
+      "integrity": "sha512-oSDyP9hD0Df35U9LPNpXYmaIjRMEVQxNUdco30uwrPsaO5I2thVNURn8H1OokU1M1D5aIeK1SjqSV91U3U1llA==",
+      "dev": true,
+      "requires": {
+        "@sentry/core": "7.44.1",
+        "@sentry/types": "7.44.1",
+        "@sentry/utils": "7.44.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.44.1.tgz",
+          "integrity": "sha512-MiDQ7cGPrWMvvnU1pszSNak4DuH7RnPS/WLVKPJDBh1paozA9bPaxRRfJu0BGtw0BV1pRoTP2CQyp0AHdNaHow==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.44.1",
+            "@sentry/utils": "7.44.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.44.1.tgz",
+          "integrity": "sha512-g0vlu7EdphUv7x0p/r1t7kjh1kNCoSMmK2G6FQCfGH2cr1AMcOAKF5iFxTN2dv0Ap3glLQPgid0bRyqcQAlCBw==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.44.1.tgz",
+          "integrity": "sha512-KfgfyurxBMFUBBPmYUPH2L46wT1nf5CbBq1wP/7D1p3EKwspb13ubK7VbxC779+JeSHqtGNOeWfY1jl1/8XBYg==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.44.1",
+            "tslib": "^1.9.3"
+          }
+        }
+      }
+    },
     "@sentry/browser": {
       "version": "6.14.1",
       "requires": {
@@ -17326,6 +17478,94 @@
         "@sentry/types": "6.14.1",
         "@sentry/utils": "6.14.1",
         "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/bundler-plugin-core": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-0.4.0.tgz",
+      "integrity": "sha512-Xi+dqaSOoxbdmxegX7f66FVOxm2dVJLmrMXUpoNyuV6ASoccRWzouGaFekP059SUTTD05ytk1mHqwgVuBCA0Dw==",
+      "dev": true,
+      "requires": {
+        "@sentry/cli": "^2.10.0",
+        "@sentry/node": "^7.19.0",
+        "@sentry/tracing": "^7.19.0",
+        "magic-string": "0.27.0",
+        "unplugin": "1.0.1"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.44.1.tgz",
+          "integrity": "sha512-MiDQ7cGPrWMvvnU1pszSNak4DuH7RnPS/WLVKPJDBh1paozA9bPaxRRfJu0BGtw0BV1pRoTP2CQyp0AHdNaHow==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.44.1",
+            "@sentry/utils": "7.44.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/node": {
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.44.1.tgz",
+          "integrity": "sha512-ISmmrN37m7acLWKLDdLynaIvdMI+Mu2KjVmunz68cnYOt/+DlZnElBxBvpAbVauJ4tRqqqlrbCpKCOIWLtJrvQ==",
+          "dev": true,
+          "requires": {
+            "@sentry/core": "7.44.1",
+            "@sentry/types": "7.44.1",
+            "@sentry/utils": "7.44.1",
+            "cookie": "^0.4.1",
+            "https-proxy-agent": "^5.0.0",
+            "lru_map": "^0.3.3",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/tracing": {
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.44.1.tgz",
+          "integrity": "sha512-HC39/KTuzw3DQ46J952cYZ+NONaq6ghgGn5IxWHhG/Dv4u9YeFbMxhJYCdtMWOoXsw0fEkAWiGR+u4Ts7T88Tg==",
+          "dev": true,
+          "requires": {
+            "@sentry-internal/tracing": "7.44.1"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.44.1.tgz",
+          "integrity": "sha512-g0vlu7EdphUv7x0p/r1t7kjh1kNCoSMmK2G6FQCfGH2cr1AMcOAKF5iFxTN2dv0Ap3glLQPgid0bRyqcQAlCBw==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "7.44.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.44.1.tgz",
+          "integrity": "sha512-KfgfyurxBMFUBBPmYUPH2L46wT1nf5CbBq1wP/7D1p3EKwspb13ubK7VbxC779+JeSHqtGNOeWfY1jl1/8XBYg==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.44.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "magic-string": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+          "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
+      }
+    },
+    "@sentry/cli": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.15.2.tgz",
+      "integrity": "sha512-jt8RvbHX09eLj2GY2ufytU/n1sWbUh7/EzBE4Ut92kPCLyo+D56VwR641HBrthZluWpGO/w2ujFMNpkk99UPfA==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
       }
     },
     "@sentry/core": {
@@ -17395,6 +17635,15 @@
       "requires": {
         "@sentry/types": "6.14.1",
         "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/vite-plugin": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-0.4.0.tgz",
+      "integrity": "sha512-dBxM00MCLzO/idzAqj33ZfbIBKZxP+FzpxtS2WaV0yzad9yLBAFZ/VGDIGHQJC0Qo3fsFi/CZpmN39wJkJoWFA==",
+      "dev": true,
+      "requires": {
+        "@sentry/bundler-plugin-core": "0.4.0"
       }
     },
     "@sentry/vue": {
@@ -18147,7 +18396,9 @@
       }
     },
     "acorn": {
-      "version": "8.5.0"
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -18765,7 +19016,9 @@
       }
     },
     "chokidar": {
-      "version": "3.5.2",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -19295,13 +19548,6 @@
             "has-flag": "^4.0.0"
           }
         },
-        "which": {
-          "version": "2.0.2",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
         "yallist": {
           "version": "4.0.0",
           "dev": true
@@ -19453,12 +19699,6 @@
         },
         "shebang-regex": {
           "version": "3.0.0"
-        },
-        "which": {
-          "version": "2.0.2",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
         }
       }
     },
@@ -20003,13 +20243,6 @@
         "type-fest": {
           "version": "0.20.2",
           "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
         },
         "yallist": {
           "version": "4.0.0",
@@ -21413,14 +21646,6 @@
           "version": "3.0.0",
           "dev": true,
           "peer": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
         }
       }
     },
@@ -22078,14 +22303,6 @@
           "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "isexe": "^2.0.0"
           }
         }
       }
@@ -23300,15 +23517,6 @@
           "optional": true,
           "peer": true
         },
-        "which": {
-          "version": "2.0.2",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
         "yallist": {
           "version": "4.0.0",
           "dev": true,
@@ -23743,13 +23951,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "which": {
-          "version": "2.0.2",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
         }
       }
     },
@@ -23778,6 +23979,12 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2"
@@ -24914,6 +25121,18 @@
     "unpipe": {
       "version": "1.0.0"
     },
+    "unplugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+      "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.8.1",
+        "chokidar": "^3.5.3",
+        "webpack-sources": "^3.2.3",
+        "webpack-virtual-modules": "^0.5.0"
+      }
+    },
     "untildify": {
       "version": "4.0.0",
       "dev": true
@@ -25314,12 +25533,6 @@
         },
         "shebang-regex": {
           "version": "3.0.0"
-        },
-        "which": {
-          "version": "2.0.2",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
         }
       }
     },
@@ -25445,7 +25658,15 @@
       }
     },
     "webpack-sources": {
-      "version": "3.2.2"
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
+    },
+    "webpack-virtual-modules": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+      "dev": true
     },
     "websocket-driver": {
       "version": "0.7.4",
@@ -25476,6 +25697,14 @@
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
       }
     },
     "which-boxed-primitive": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.18.6",
+    "@sentry/vite-plugin": "^0.4.0",
     "@types/bluebird": "^3.5.36",
     "@types/errorhandler": "^1.5.0",
     "@types/express": "^4.17.14",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import vue from "@vitejs/plugin-vue"
 import legacy from "@vitejs/plugin-legacy"
 import { createHtmlPlugin } from "vite-plugin-html"
+import { sentryVitePlugin } from "@sentry/vite-plugin"
 
 import path from "path"
 import { defineConfig, loadEnv } from "vite"
@@ -14,6 +15,20 @@ import { visualizer } from "rollup-plugin-visualizer"
 import generator from "./rollup/generator.rollup"
 
 const { baseURL, github, matomo, netlifyContributionURL, statistics } = config
+
+function createSentryPlugin() {
+  if (!process.env.SENTRY_AUTH_TOKEN) {
+    return null
+  }
+
+  return sentryVitePlugin({
+    org: "betagouv",
+    project: "aides-jeunes-front",
+    include: "./dist",
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    url: "https://sentry.incubateur.net/",
+  })
+}
 
 export default defineConfig(async ({ mode }) => {
   process.env = Object.assign(process.env, loadEnv(mode, process.cwd(), ""))
@@ -49,6 +64,7 @@ export default defineConfig(async ({ mode }) => {
         exclude: ["lib"],
       },
       emptyOutDir: false,
+      sourcemap: true,
     },
     plugins: [
       generator,
@@ -68,6 +84,7 @@ export default defineConfig(async ({ mode }) => {
         targets: ["defaults"],
       }),
       visualizer(),
+      createSentryPlugin(),
     ],
     resolve: {
       preferBuiltins: false,


### PR DESCRIPTION
Trello : https://trello.com/c/135QJRWs/1201-gestion-du-source-map-sur-sentry

Avancement : 
- Création d'un token sur sentry pour pouvoir push le source-map : ⚠️ c'est un token sur un utilisateur (le mien) : faudrait en discuter
- Config pour pouvoir push au build : ça marche
- Le token sentry a été mis dans les secrets sur Github
- Si le Token sentry n'est pas dispo, le Source Map n'est pas push, mais ça ne pose pas de soucis

Pour voir l'upload des Source Map sur Sentry : https://sentry.incubateur.net/settings/betagouv/projects/aides-jeunes-front/source-maps/ (avant il n'y avait pas d'artifacts) : 

<img width="963" alt="image" src="https://user-images.githubusercontent.com/4059803/230091276-2364441f-e291-4749-872d-c11320475f90.png">

> Note : Une hypothèse de travail c'est que les hash des fichiers build sont les même au moment du build dans la CI que lors de la mise en prod : les sources maps uploader en CI serviront pour la prod. Si cette hypothèse n'est finalement pas vérifié nous allons devoir trouver un autre moyen
