### PR TITLE
ajoute un test contrôlant les extensions yml

### DIFF
--- a/tests/integration/test-filename.spec.js
+++ b/tests/integration/test-filename.spec.js
@@ -48,4 +48,15 @@ describe("Test filenames rules", function () {
       })
     })
   })
+
+  const benefitsFiles = files.filter((file) =>
+    file.absolute.match(/data\/(institutions|benefits\/(javascript|openfisca))/)
+  )
+  benefitsFiles.forEach((file) => {
+    describe(file.absolute, function () {
+      it("institution and benefit files should use yml extension", function () {
+        expect(file.extension === "yml").toBeTruthy()
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Détails

Cette PR ajoute un test permettant de s'assurer que l'extension `.yml` (et non `.yaml) est utilisé pour les fichiers d'aides et d'institutions.

À noter que la norme recommandée par [la documentation](https://yaml.org/faq.html) est `yaml`