### PR TITLE
Met à jour webpack pour corriger une faille de sécurité

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "rollup-plugin-visualizer": "^5.8.2",
         "ts-jest": "^27.1.4",
         "typescript": "^4.8.3",
-        "webpack": "^5.64.3",
+        "webpack": "^5.78.0",
         "webpack-bundle-analyzer": "^4.5.0"
       },
       "engines": {
@@ -3162,24 +3162,27 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "7.28.2",
-      "license": "MIT",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
+      "integrity": "sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
       }
     },
     "node_modules/@types/eslint-scope": {
-      "version": "3.7.1",
-      "license": "MIT",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.50",
-      "license": "MIT"
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "node_modules/@types/express": {
       "version": "4.17.14",
@@ -6470,8 +6473,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.8.3",
-      "license": "MIT",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+      "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -8043,7 +8047,8 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/global-dirs": {
       "version": "3.0.0",
@@ -10743,9 +10748,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-parse-better-errors": {
-      "version": "1.0.2",
-      "license": "MIT"
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -13994,7 +14000,8 @@
     },
     "node_modules/tapable": {
       "version": "2.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "engines": {
         "node": ">=6"
       }
@@ -14998,8 +15005,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -15068,33 +15076,34 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.64.3",
-      "license": "MIT",
+      "version": "5.78.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.78.0.tgz",
+      "integrity": "sha512-gT5DP72KInmE/3azEaQrISjTvLYlSM0j1Ezhht/KLVkrqtv10JoP/RXhwmX/frrutOPuSq3o5Vq0ehR/4Vmd1g==",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.0",
-        "@types/estree": "^0.0.50",
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.4.1",
+        "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.8.3",
+        "enhanced-resolve": "^5.10.0",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.4",
-        "json-parse-better-errors": "^1.0.2",
+        "graceful-fs": "^4.2.9",
+        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.2.0",
-        "webpack-sources": "^3.2.2"
+        "watchpack": "^2.4.0",
+        "webpack-sources": "^3.2.3"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -17787,21 +17796,27 @@
       }
     },
     "@types/eslint": {
-      "version": "7.28.2",
+      "version": "8.37.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
+      "integrity": "sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
       }
     },
     "@types/eslint-scope": {
-      "version": "3.7.1",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
       "requires": {
         "@types/eslint": "*",
         "@types/estree": "*"
       }
     },
     "@types/estree": {
-      "version": "0.0.50"
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
     },
     "@types/express": {
       "version": "4.17.14",
@@ -19910,7 +19925,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.8.3",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+      "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -20906,7 +20923,9 @@
       }
     },
     "glob-to-regexp": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "global-dirs": {
       "version": "3.0.0",
@@ -22625,8 +22644,10 @@
       "version": "2.5.2",
       "dev": true
     },
-    "json-parse-better-errors": {
-      "version": "1.0.2"
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-schema": {
       "version": "0.4.0",
@@ -24783,7 +24804,9 @@
       "version": "6.12.4"
     },
     "tapable": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "terminal-link": {
       "version": "2.1.1",
@@ -25360,7 +25383,9 @@
       }
     },
     "watchpack": {
-      "version": "2.2.0",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -25407,32 +25432,34 @@
       "version": "3.0.1"
     },
     "webpack": {
-      "version": "5.64.3",
+      "version": "5.78.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.78.0.tgz",
+      "integrity": "sha512-gT5DP72KInmE/3azEaQrISjTvLYlSM0j1Ezhht/KLVkrqtv10JoP/RXhwmX/frrutOPuSq3o5Vq0ehR/4Vmd1g==",
       "requires": {
-        "@types/eslint-scope": "^3.7.0",
-        "@types/estree": "^0.0.50",
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.4.1",
+        "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.8.3",
+        "enhanced-resolve": "^5.10.0",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.4",
-        "json-parse-better-errors": "^1.0.2",
+        "graceful-fs": "^4.2.9",
+        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.2.0",
-        "webpack-sources": "^3.2.2"
+        "watchpack": "^2.4.0",
+        "webpack-sources": "^3.2.3"
       },
       "dependencies": {
         "schema-utils": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "rollup-plugin-visualizer": "^5.8.2",
     "ts-jest": "^27.1.4",
     "typescript": "^4.8.3",
-    "webpack": "^5.64.3",
+    "webpack": "^5.78.0",
     "webpack-bundle-analyzer": "^4.5.0"
   },
   "prettier": {


### PR DESCRIPTION
## Détails

[CVE-2023-28154](https://nvd.nist.gov/vuln/detail/CVE-2023-28154)

Webpack est utilisé pour le build de l'iframe et pas concerné par cette CVE.