### PR TITLE
Update aide_formation_gen.yml

### DIFF
--- a/data/benefits/openfisca/aide_formation_gen.yml
+++ b/data/benefits/openfisca/aide_formation_gen.yml
@@ -1,7 +1,7 @@
 label: aide aux apprenants de la Grande École du Numérique
 institution: etat
 description: La Grande École du numérique (GEN) est une labellisation des formations courtes et qualifiantes permettent d’acquérir un socle professionnalisant de compétences numériques. Cette aide délivrée par le CROUS s’adresse à des personnes diplômées en situation de recherche d’emploi ou dépourvues de qualification professionnelle ou de diplôme.
-link: https://www.grandeecolenumerique.fr/espace-apprenants/se-renseigner-sur-les-aides
+link: https://www.grandeecolenumerique.fr/aide-crous-apprenants-gen
 teleservice: https://dse.phm.education.gouv.fr/GEN/
 prefix: l’
 type: float


### PR DESCRIPTION
correction du lien qui mène vers la page d'information officielle
ancien lien : https://www.grandeecolenumerique.fr/espace-apprenants/se-renseigner-sur-les-aides
nouveau lien : https://www.grandeecolenumerique.fr/aide-crous-apprenants-gen