### PR TITLE
Corrige la redirection de l'outil accompagnement lors d'une connexion d'un utilisateur non autorisé

### DIFF
--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -37,7 +37,7 @@ const all: ConfigurationLayout = {
       "Allan-CodeWorks",
       "Cugniere",
       "guillett",
-      "shamzic",
+      "Shamzic",
       "yasmine-glitch",
       "Valandr",
     ],

--- a/backend/controllers/github.ts
+++ b/backend/controllers/github.ts
@@ -52,7 +52,6 @@ const access = async (req, res, next) => {
       res.cookie("github_token", github_payload)
     }
   }
-  console.log("github_payload", github_payload)
   if (github_payload) {
     try {
       const result = await validateCookieToken(github_payload)

--- a/backend/controllers/github.ts
+++ b/backend/controllers/github.ts
@@ -42,38 +42,28 @@ function validateCookieToken(github_payload) {
   })
 }
 
-const MAX_ATTEMPTS = 3
-
 const access = async (req, res, next) => {
   let github_payload = req.cookies && req.cookies["github_token"]
-  let attemptCount = parseInt(req.cookies["attemptCount"]) || 0
-
-  if (attemptCount >= MAX_ATTEMPTS) {
-    return res.redirect("/error")
-  }
 
   if (req.query.code) {
     const result = await validateToken(req)
     if (result.status === 200 && result.data.access_token) {
       github_payload = result.data
       res.cookie("github_token", github_payload)
-    } else {
-      attemptCount++
-      res.cookie("attemptCount", attemptCount)
     }
   }
+  console.log("github_payload", github_payload)
   if (github_payload) {
     try {
       const result = await validateCookieToken(github_payload)
       if (config.github.authorized_users.includes(result.data.login)) {
         return next()
       } else {
-        attemptCount++
-        res.cookie("attemptCount", attemptCount)
+        res.clearCookie("github_token")
+        return res.redirect("/accompagnement?authorization=false")
       }
     } catch (e) {
-      attemptCount++
-      res.cookie("attemptCount", attemptCount)
+      console.error("error", e)
     }
   }
   return authenticate(req, res)

--- a/backend/controllers/github.ts
+++ b/backend/controllers/github.ts
@@ -56,6 +56,8 @@ const access = async (req, res, next) => {
       const result = await validateCookieToken(github_payload)
       if (config.github.authorized_users.includes(result.data.login)) {
         return next()
+      } else {
+        return res.redirect("/accompagnement?error=access_denied")
       }
       // If cookie validation fails an error will be triggered
       // eslint-disable-next-line no-empty

--- a/backend/controllers/github.ts
+++ b/backend/controllers/github.ts
@@ -9,15 +9,15 @@ function current_uri(req) {
 }
 
 function authenticate(req, res) {
-  return res.redirect(
-    url.format({
-      pathname: config.github.authorize_url,
-      query: {
-        client_id: config.github.client_id,
-        redirect_uri: current_uri(req),
-      },
-    })
-  )
+  const params = new URLSearchParams({
+    client_id: config.github.client_id,
+    redirect_uri: current_uri(req),
+  })
+
+  const url = new URL(config.github.authorize_url)
+  url.search = params.toString()
+
+  return res.redirect(url.toString())
 }
 
 function validateToken(req) {

--- a/backend/controllers/github.ts
+++ b/backend/controllers/github.ts
@@ -59,7 +59,7 @@ const access = async (req, res, next) => {
         return next()
       } else {
         res.clearCookie("github_token")
-        return res.redirect("/accompagnement?authorization=false")
+        return res.redirect("/accompagnement?unauthorized")
       }
     } catch (e) {
       console.error("error", e)
@@ -70,7 +70,7 @@ const access = async (req, res, next) => {
 
 const postAuthRedirect = (req, res) => {
   if (req.query.redirect) {
-    return res.redirect(req.query.redirect)
+    res.redirect("/accompagnement")
   } else {
     return res.redirect("/")
   }

--- a/backend/controllers/github.ts
+++ b/backend/controllers/github.ts
@@ -1,5 +1,4 @@
 import axios from "axios"
-import url from "url"
 import config from "../config/index.js"
 
 function current_uri(req) {

--- a/src/views/accompagnement/accompagnement.vue
+++ b/src/views/accompagnement/accompagnement.vue
@@ -15,7 +15,7 @@
       >Se connecter</a
     >
 
-    <div v-if="!userAccessAuthorized" class="fr-mt-4w">
+    <div v-if="unauthorizedUserAccess" class="fr-mt-4w">
       <div class="fr-alert fr-alert--warning">
         <h3 class="fr-alert__title"
           >Vous n'êtes pas autorisé à vous connecter.</h3
@@ -187,8 +187,8 @@ export default {
     connect() {
       return `/api/auth/redirect?redirect=${window.location}`
     },
-    userAccessAuthorized() {
-      return this.$route.query.authorization === "true"
+    unauthorizedUserAccess() {
+      return this.$route.query.unauthorized !== undefined
     },
   },
   watch: {

--- a/src/views/accompagnement/accompagnement.vue
+++ b/src/views/accompagnement/accompagnement.vue
@@ -16,7 +16,7 @@
     >
 
     <div
-      v-if="loggedIn && accompagnements && accompagnements.length > 1"
+      v-if="loggedIn && followups && followups.length > 1"
       class="fr-container fr-px-0 fr-mb-0 fr-py-2w"
     >
       <div class="fr-grid-row fr-grid-row--gutters">
@@ -25,7 +25,7 @@
       </div>
     </div>
     <WarningMessage v-if="loggedIn && error">{{ error }}</WarningMessage>
-    <div v-if="loggedIn && accompagnements">
+    <div v-if="loggedIn && followups">
       <div class="fr-text--lead fr-mt-5w fr-mb-1w"
         >Réponses au sondage
         <span v-if="surveyEmail"
@@ -58,38 +58,36 @@
         ></span
         ><span class="fr-ml-1w fr-mr-2w">Déjà perçue</span>
       </div>
-      <div v-for="accompagnement in accompagnements" :key="accompagnement._id">
+      <div v-for="followup in followups" :key="followup._id">
         <div
-          v-if="accompagnement.surveys[0]"
+          v-if="followup.surveys[0]"
           class="fr-p-2w fr-mb-2w"
           style="background: var(--background-alt-grey); border-radius: 0.4rem"
         >
           <div class="aj-flex-row fr-mb-2w">
-            <a :href="`mailto:${accompagnement.email}`">{{
-              accompagnement.email
-            }}</a>
+            <a :href="`mailto:${followup.email}`">{{ followup.email }}</a>
             <span class="fr-tag">
-              Sondage le {{ formatDate(accompagnement.surveys[0].repliedAt) }}
+              Sondage le {{ formatDate(followup.surveys[0].repliedAt) }}
             </span>
             <span class="fr-tag">
-              Simulation le {{ formatDate(accompagnement.createdAt) }}
+              Simulation le {{ formatDate(followup.createdAt) }}
             </span>
-            <router-link :to="`/accompagnement/${accompagnement._id}`"
+            <router-link :to="`/accompagnement/${followup._id}`"
               >Permalink</router-link
             >
             <a
-              :href="`/api/support/simulation/${accompagnement.simulation}`"
+              :href="`/api/support/simulation/${followup.simulation}`"
               target="_blank"
               >Résultats de la simulation</a
             >
             <CopyButton
-              :followupId="accompagnement.simulation"
+              :followupId="followup.simulation"
               :benefitsMap="benefitsMap"
-              :benefitsList="accompagnement.benefits"
+              :benefitsList="followup.benefits"
             />
           </div>
           <ul
-            v-for="answer in accompagnement.benefits"
+            v-for="answer in followup.benefits"
             :key="answer.id"
             class="fr-toggle__list"
           >
@@ -159,7 +157,7 @@ export default {
   data: function () {
     return {
       benefitsMap: getBenefit,
-      accompagnements: undefined,
+      followups: undefined as FollowupLayout[] | undefined,
       loggedIn: undefined,
       error: undefined,
     }
@@ -179,7 +177,7 @@ export default {
     $route: {
       immediate: true,
       async handler() {
-        this.accompagnements = await this.fetchPollResults()
+        this.followups = await this.fetchPollResults()
       },
     },
   },
@@ -224,18 +222,18 @@ export default {
               : "cet identifiant"
           }`
         } else {
-          const accompagnements: FollowupLayout[] = await response.json()
-          this.accompagnements = accompagnements
-            .map((accompagnement) => {
-              accompagnement.surveys = accompagnement.surveys.filter(
+          const followups: FollowupLayout[] = await response.json()
+          this.followups = followups
+            .map((followup) => {
+              followup.surveys = followup.surveys.filter(
                 (survey) =>
                   survey.type === SurveyType.benefitAction &&
                   survey.answers.length
               )
-              return accompagnement
+              return followup
             })
             .filter(({ surveys }) => surveys.length)
-          this.accompagnements.forEach(({ surveys, benefits }) => {
+          this.followups.forEach(({ surveys, benefits }) => {
             const surveyStates = {}
             surveys[0].answers.forEach(({ id, value, comments }) => {
               surveyStates[id] = { status: value, comments }
@@ -249,10 +247,10 @@ export default {
           })
         }
       } catch (status) {
-        this.accompagnements = []
+        this.followups = []
         this.loggedIn = false
       }
-      return this.accompagnements
+      return this.followups
     },
   },
 }

--- a/src/views/accompagnement/accompagnement.vue
+++ b/src/views/accompagnement/accompagnement.vue
@@ -15,7 +15,7 @@
       >Se connecter</a
     >
 
-    <div v-if="$route.query.authorization === 'false'" class="fr-mt-4w">
+    <div v-if="!userAccessAuthorized" class="fr-mt-4w">
       <div class="fr-alert fr-alert--warning">
         <h3 class="fr-alert__title"
           >Vous n'êtes pas autorisé à vous connecter.</h3
@@ -186,6 +186,9 @@ export default {
     },
     connect() {
       return `/api/auth/redirect?redirect=${window.location}`
+    },
+    userAccessAuthorized() {
+      return this.$route.query.authorization === "true"
     },
   },
   watch: {

--- a/src/views/accompagnement/accompagnement.vue
+++ b/src/views/accompagnement/accompagnement.vue
@@ -15,6 +15,21 @@
       >Se connecter</a
     >
 
+    <div v-if="$route.query.authorization === 'false'" class="fr-mt-4w">
+      <div class="fr-alert fr-alert--warning">
+        <h3 class="fr-alert__title"
+          >Vous n'êtes pas autorisé à vous connecter.</h3
+        >
+        <p
+          >Contactez un administrateur pour ajouter votre utilisateur à la liste
+          des utilisateurs autorisés ou essayez de
+          <a href="https://github.com/login" target="_blank">
+            vous connecter avec un autre compte Github</a
+          >.
+        </p>
+      </div>
+    </div>
+
     <div
       v-if="loggedIn && followups && followups.length > 1"
       class="fr-container fr-px-0 fr-mb-0 fr-py-2w"

--- a/src/views/accompagnement/accompagnement.vue
+++ b/src/views/accompagnement/accompagnement.vue
@@ -17,7 +17,7 @@
 
     <div v-if="unauthorizedUserAccess" class="fr-mt-4w">
       <div class="fr-alert fr-alert--warning">
-        <h3 class="fr-alert__title"
+        <h3 class="fr-alert__title fr-mt-0"
           >Vous n'êtes pas autorisé à vous connecter.</h3
         >
         <p


### PR DESCRIPTION
### Description 📖 

Tâche associée : https://trello.com/c/40SMl4zO/1222-supprimer-la-boucle-infinie-lors-dune-tentative-dacc%C3%A8s-%C3%A0-loutil-daccompagnement-pour-un-compte-non-list%C3%A9-dans-notre-application

- [x] Supprime la boucle de redirection infinie de l'outil d'accompagnement (page `/accompagnement`) lorsqu'un utilisateur se connecte et qu'il est pas dans la liste des utilisateurs autorisés par l'app OAuth.
- [x] Refacto le nom d'un pseudo Github (Ia majuscule manquante empêchait l'autorisation à l'app OAuth locale)
- [x] Refacto le fichier accompagnement.vue (accompagnement => followup )
- [x] Refacto la méthode authenticate de github.ts car l'appel à url.format() est déprécié
- [x] Ajoute une div de warning pour alerter l'utilisateur si il n'est pas autorisé à accéder à l'outil d'accompagnement avec un lien vers Github pour pouvoir essayer de se connecter avec un autre compte.

### Comment tester les modifications ❓ 

Voici une petite suggestion du parcours à effectuer si vous souhaitez tester en local :

- Paramétrer une app OAuth sur son compte Github (https://github.com/settings/developers) avec les liens de redirection vers `http://localhost:8080/` (le slash est important à la fin de l'URL)
- Indiquer les variables d'environnement de son app OAuth au run de l'application (ex : `GITHUB_CLIENT_SECRET=xxxxxxxxxxxx GITHUB_CLIENT_ID=xxxxxxxxxxxx npm run serve`
- Se déconnecter de son compte Github
- Accéder à la page `/accompagnement`
- Se connecter avec un compte Github random non autorisé
- La redirection ne doit pas boucler à l'infini et un message d'informations est visible sur la page
- Se connecter avec un compte Github autorisé, la redirection doit fonctionner et l'outil d'accompagnement doit être fonctionnel