### PR TITLE
Met à jour le menu du header pour correspondre à celui du site 1jeune1solution

### DIFF
--- a/src/components/navigation.vue
+++ b/src/components/navigation.vue
@@ -127,37 +127,60 @@ const navigation = [
       { label: "Stages", link: "/stages" },
       { label: "Contrats d’alternance", link: "/apprentissage" },
       { label: "Jobs étudiants", link: "/jobs-etudiants" },
-      { label: "Emplois en Europe", link: "/europe" },
+      { label: "Expérience en Europe", link: "/europe" },
     ],
   },
   {
     label: "Formations et orientation",
     children: [
       { label: "Formations", link: "/formations" },
+      {
+        label: "Formations en apprentissage",
+        link: "/formations/apprentissage",
+      },
       { label: "Découvrir les métiers", link: "/decouvrir-les-metiers" },
-      { label: "Participer à un évènement", link: "/evenements" },
+      { label: "Participer à des évènements", link: "/evenements" },
     ],
   },
-  {
-    label: "Aides et accompagnement",
-    active: true,
-    children: [
-      { label: "Contrat Engagement Jeune", link: "/contrat-engagement-jeune" },
-      { label: "Mes aides financières", link: "/mes-aides", active: true },
-      { label: "Mes aides au logement", link: "/logements/aides-logement" },
-      { label: "Le mentorat", link: "/mentorat" },
-      { label: "Je crée mon CV personnalisé", link: "/creer-mon-cv" },
-      { label: "Entreprendre", link: "/entreprendre" },
-      { label: "Accompagnement", link: "/accompagnement" },
-      { label: "Les mesures jeunes", link: "/espace-jeune" },
-    ],
-  },
-
   {
     label: "Engagement",
     children: [
-      { label: "Le service civique", link: "/service-civique" },
-      { label: "Le bénévolat", link: "/benevolat" },
+      { label: "Bénévolat", link: "/benevolat" },
+      { label: "Service civique", link: "/service-civique" },
+    ],
+  },
+  {
+    label: "Logement",
+    children: [
+      { label: "Annonces", link: "/logement/annonces" },
+      {
+        label: "Aides financières au logement",
+        link: "/logements/aides-logement",
+      },
+      { label: "Découvrir tous nos conseils", link: "/logements/conseils" },
+    ],
+  },
+  {
+    label: "Accompagnement",
+    children: [
+      { label: "Contrat Engagement Jeune", link: "/contrat-engagement-jeune" },
+      { label: "Échanger avec un mentor", link: "/mentorat" },
+      {
+        label: "Trouver une structure d'accompagnement",
+        link: "/accompagnement",
+      },
+      {
+        label: "Entreprendre : financements, aides et accompagnements",
+        link: "/entreprendre",
+      },
+    ],
+  },
+  {
+    label: "Aides et outils",
+    active: true,
+    children: [
+      { label: "Mes aides financières", link: "/mes-aides", active: true },
+      { label: "Je crée son CV personnalisé", link: "/creer-mon-cv" },
     ],
   },
   {


### PR DESCRIPTION
## Détails

[Tâche Trello](https://trello.com/c/kyp0XiOO/1240-mettre-%C3%A0-jour-le-header-pour-respecter-les-menus-et-leur-ordre)

## Contexte

Le but de cette tâche est de s'assurer que le menu de navigation principal du simulateur comprend les mêmes entrées que celui présent sur [1jeune1solution](https://www.1jeune1solution.gouv.fr/).

Le code utilisé par 1jeune1solution pour générer les entrées de ce menu est [trouvable ici](https://github.com/DNUM-SocialGouv/1j1s-front/blob/main/src/client/components/layouts/Header/NavigationStructure.ts).

Plusieurs choses sont à noter : 
- les différences de style ne sont pas à prendre en compte sur cette PR :  le simulateur utilise le DSFR pour afficher le menu là où le site 1jeune1solution utilise un thème custom s'en rapprochant
- le sous-menu "je suis employeur" présent sur le site 1jeune1solution une colonne avec le texte "Je suis employeur Découvrez des services faits pour vous !". Cette colonne n'est pas présente sur le simulateur pour des questions d'accessibilités