### PR TITLE
Permet l'envoi de requêtes locales vers le stat-recorder en mode dev

### DIFF
--- a/backend/config/development.ts
+++ b/backend/config/development.ts
@@ -15,5 +15,8 @@ export default {
   matomo: {
     id: 170,
   },
-  statistics: {},
+  statistics: {
+    url: "http://localhost:4000/benefits",
+    version: 2,
+  },
 }

--- a/src/lib/statistics-service/recorder.ts
+++ b/src/lib/statistics-service/recorder.ts
@@ -84,6 +84,10 @@ export async function sendEventToRecorder(
       body,
     })
   } catch (e) {
-    console.error(e)
+    if (e instanceof TypeError && e.message === "Failed to fetch") {
+      console.debug("Event to recorder", event)
+    } else {
+      console.error(e)
+    }
   }
 }


### PR DESCRIPTION
Toutes les infos sur la tâche ici : https://trello.com/c/WGLDerU3/1202-permettre-de-tester-lenvoi-d%C3%A9v%C3%A9nements-aux-outils-de-statistiques-en-dev-local

~~C'est en draft car j'explore encore la possibilité d'ajouter des tests Cypress~~ => impossible à réaliser sur la CI