### PR TITLE
fix: le bouton permettant de fermer menu et popup n'était plus visible

### DIFF
--- a/src/styles/aides-jeunes.css
+++ b/src/styles/aides-jeunes.css
@@ -137,6 +137,9 @@ textarea {
   color: var(--main-btn-text-color);
 }
 
+.fr-btn--close {
+  color: var(--main-color);
+}
 .fr-btn--icon-center {
   justify-content: center;
 }


### PR DESCRIPTION
## Détails

La PR gérant les couleurs par thème affiche en blanc sur blanc les boutons "fermer" (présent sur le menu "je suis employeur" et sur les popups).

Avant : 
<img width="631" alt="image" src="https://user-images.githubusercontent.com/16650011/234570585-994b3099-857b-4d37-963d-ea6faf75ea85.png">

Après : 
<img width="629" alt="image" src="https://user-images.githubusercontent.com/16650011/234570653-7758a203-3c63-4e81-bd6b-94e9d0adb5cf.png">
