### PR TITLE
Envoi un message d'alerting sur le channel principal en cas de problème de CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,4 +379,4 @@ jobs:
       - name: Send CI failed message
         shell: bash
         run: |
-          curl -i -X POST -H 'Content-Type: application/json' -d '{"text": ":icon-danger: La CI a rencontré un problème sur la branche master ([lien](https://github.com/betagouv/aides-jeunes/actions/workflows/ci.yml?query=branch%3Amaster+is%3Afailure))"}' ${{ secrets.MATTERMOST_POST_URL }}
+          curl -i -X POST -H 'Content-Type: application/json' -d '{"text": ":icon-danger: [équipe-tech] La CI a rencontré un problème sur la branche master ([lien](https://github.com/betagouv/aides-jeunes/actions/workflows/ci.yml?query=branch%3Amaster+is%3Afailure))"}' ${{ secrets.MATTERMOST_ALERTING_URL }}


### PR DESCRIPTION
## Détails

Cette PR déplace les messages d'alerting en cas d'échec de la CI sur master vers le channel principal.