### PR TITLE
1278 par defaut la variable mongodburl devrait etre undefined

### DIFF
--- a/backend/config/development.ts
+++ b/backend/config/development.ts
@@ -19,4 +19,12 @@ export default {
     url: "http://localhost:4000/benefits",
     version: 2,
   },
+  mongo: {
+    uri:
+      process.env.MONGODB_URL || "mongodb://localhost:27017/dev-aides-jeunes",
+    options: {
+      useUnifiedTopology: true,
+      useNewUrlParser: true,
+    },
+  },
 }

--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -52,7 +52,7 @@ const all: ConfigurationLayout = {
     version: Number(process.env.VITE_STATS_VERSION) || 2,
   },
   mongo: {
-    uri: process.env.MONGODB_URL || "mongodb://127.0.0.1/db_aides_jeunes",
+    uri: process.env.MONGODB_URL,
     options: {
       useUnifiedTopology: true,
       useNewUrlParser: true,

--- a/backend/config/mongoose.ts
+++ b/backend/config/mongoose.ts
@@ -6,6 +6,10 @@ import { ConfigurationLayout } from "../types/config.js"
 export default function (mongoose: any, config: ConfigurationLayout) {
   mongoose.Promise = bluebird
 
+  if (!config.mongo.uri) {
+    throw new Error("Please provide a `MONGODB_URL` environment variable")
+  }
+
   mongoose
     .connect(config.mongo.uri, config.mongo.options)
     .then(() => console.info("DB connected"))

--- a/backend/lib/stats/mongodb.ts
+++ b/backend/lib/stats/mongodb.ts
@@ -188,7 +188,7 @@ function manageMissingDBOrCollection(error) {
 }
 
 async function connect() {
-  return await MongoClient.connect(config.mongo.uri)
+  return await MongoClient.connect(config.mongo.uri as string)
     .then(saveClient)
     .then((client) => client.db())
 }

--- a/backend/types/config.d.ts
+++ b/backend/types/config.d.ts
@@ -29,7 +29,7 @@ export interface ConfigurationLayout {
     version: number
   }
   mongo: {
-    uri: string
+    uri?: string
     options: {
       useUnifiedTopology: boolean
       useNewUrlParser: boolean


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/vzdTB1f3/1278-par-d%C3%A9faut-la-variable-mongodburl-devrait-%C3%AAtre-undefined

J'ai mis une valeur par default pour `MONGODB_URL` en development
Afin d'éviter qu'on pointe la prod en oubliant de set le `NODE_ENV`, j'ai choisi de mettre un nom de base de données différent où `dev` apparait explicitement dans cette valeur. 
Si on part sur ça on aura tous à faire une modification du nom de notre base locale. 

Dispo pour en discuter.