### PR TITLE
Ajout de l'option `--max-warning 0` à l'étape de lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:front": "vite build",
     "build:server": "tsc -p tsconfig.server.json",
     "preview": "vite preview",
-    "lint": "eslint backend data iframes lib src --ext ts,js,vue",
+    "lint": "eslint backend data iframes lib src --ext ts,js,vue --max-warnings 0",
     "ci": "npm run stats && cd dist-server && NODE_ENV=production node ./backend/server.js",
     "cypress": "cypress run",
     "cypress:open": "cypress open",

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -20,7 +20,7 @@
     </div>
   </WarningMessage>
 
-  <div class="fr-alert fr-alert--info fr-my-1w" v-if="simulationAnonymized()">
+  <div v-if="simulationAnonymized()" class="fr-alert fr-alert--info fr-my-1w">
     <div>
       <h2 class="fr-text--lead">
         Vos résultats de simulation ne sont plus disponibles


### PR DESCRIPTION
trello: https://trello.com/c/Ykq7hvZW/1284-eslint-nous-donne-des-warning-que-lon-g%C3%A8re-pas

Le soucis c'est que d'une part on ignore les warning dans eslint, donc certains vont sur la default branch, cependant ces warning sont parfois réparable par l'option `--fix`. Ce qui fait qu'on doit vérifier les fix si on ne veut pas intégré des partie qui n'ont rien à voir avec la PR en cours. 

ℹ️ ça nous avait déjà fait perdre du temps y'a moins de deux semaines : https://github.com/betagouv/aides-jeunes/pull/3659

Cette PR propose de traiter les warning comme des erreurs afin que le problème soit pris en amont : 
<img width="713" alt="image" src="https://user-images.githubusercontent.com/4059803/235700570-38dfdaaf-755d-437f-aeb8-b71674b122ed.png">

Cela corrige aussi le warning en cours sur master.
