### PR TITLE
Ajouter l'anonymisation des données FC et API à H+24

### DIFF
--- a/backend/lib/france-connect-service.ts
+++ b/backend/lib/france-connect-service.ts
@@ -3,6 +3,7 @@ import jwt from "jsonwebtoken"
 
 import config from "../config/index.js"
 import { answerLayout } from "../../lib/types/answer.js"
+import { SimulationFranceConnectStatusEnum } from "../../lib/enums/simulation.js"
 
 export const enum CookiesKeys {
   fcState = "fc_state",
@@ -112,6 +113,7 @@ async function createSimulationFromAnswer(answers) {
     `${process.env.MES_AIDES_ROOT_URL}/api/simulation`,
     {
       dateDeValeur: new Date(),
+      franceConnectStatus: SimulationFranceConnectStatusEnum.FETCHED,
       answers: {
         all: answers,
         current: [],

--- a/backend/models/simulation.ts
+++ b/backend/models/simulation.ts
@@ -13,7 +13,10 @@ import {
 
 import { SimulationInterface } from "../../lib/types/simulation.d.js"
 import { SimulationModel } from "../types/models.js"
-import { SimulationStatusEnum } from "../../lib/enums/simulation.js"
+import {
+  SimulationStatusEnum,
+  SimulationFranceConnectStatusEnum,
+} from "../../lib/enums/simulation.js"
 
 const computeBenefits = computeAides.bind(benefits)
 
@@ -66,6 +69,10 @@ const SimulationSchema = new mongoose.Schema<
       type: String,
       default: SimulationStatusEnum.NEW,
       enum: Object.values(SimulationStatusEnum),
+    },
+    franceConnectStatus: {
+      type: String,
+      enum: Object.values(SimulationFranceConnectStatusEnum),
     },
     teleservice: String,
     token: String,

--- a/lib/cleaner-functions.ts
+++ b/lib/cleaner-functions.ts
@@ -94,3 +94,17 @@ export function anonymizeFollowup(followup) {
 
   return followup
 }
+
+export function franceConnectAnonymizeSimulation(simulation) {
+  const answers = simulation.answers.all
+  const answersAnonymized = answers
+    .map((answer) => (answer.entityName === "franceconnect" ? null : answer))
+    .filter((answer) => answer)
+
+  simulation.answers = {
+    all: answersAnonymized,
+    current: [],
+  }
+
+  return simulation
+}

--- a/lib/cleaner-functions.ts
+++ b/lib/cleaner-functions.ts
@@ -1,4 +1,7 @@
-import { SimulationStatusEnum } from "./enums/simulation.js"
+import {
+  SimulationStatusEnum,
+  SimulationFranceConnectStatusEnum,
+} from "./enums/simulation.js"
 
 function getAnonymizedAnswer(answer, simulation) {
   switch (answer.entityName) {
@@ -98,13 +101,22 @@ export function anonymizeFollowup(followup) {
 export function franceConnectAnonymizeSimulation(simulation) {
   const answers = simulation.answers.all
   const answersAnonymized = answers
-    .map((answer) => (answer.entityName === "franceconnect" ? null : answer))
+    .map((answer) => {
+      if (answer.entityName !== "franceconnect") {
+        return answer
+      }
+
+      answer.value = undefined
+      return answer
+    })
     .filter((answer) => answer)
 
   simulation.answers = {
     all: answersAnonymized,
     current: [],
   }
+
+  simulation.franceConnectStatus = SimulationFranceConnectStatusEnum.ANONYMIZED
 
   return simulation
 }

--- a/lib/enums/simulation.ts
+++ b/lib/enums/simulation.ts
@@ -4,3 +4,8 @@ export enum SimulationStatusEnum {
   INVESTIGATION = "investigation",
   ANONYMIZED = "anonymized",
 }
+
+export enum SimulationFranceConnectStatusEnum {
+  FETCHED = "fetched",
+  ANONYMIZED = "anonymized",
+}

--- a/lib/types/simulation.d.ts
+++ b/lib/types/simulation.d.ts
@@ -1,4 +1,7 @@
-import { SimulationStatusEnum } from "../enums/simulation.js"
+import {
+  SimulationStatusEnum,
+  SimulationFranceConnectStatusEnum,
+} from "../enums/simulation.js"
 
 export interface Answer {
   id: string
@@ -25,6 +28,7 @@ export interface SimulationInterface {
   hasFollowup?: boolean
   modifiedFrom?: string
   status: SimulationStatusEnum
+  franceConnectStatus: SimulationFranceConnectStatusEnum
   teleservice?: string
   token: string
 }

--- a/tests/unit/tools/cleaner.spec.ts
+++ b/tests/unit/tools/cleaner.spec.ts
@@ -166,3 +166,33 @@ describe("anonymizeSimulation", () => {
     )
   })
 })
+
+describe("franceConnectAnonymizeSimulation", () => {
+  it("should remove franceconnect answers and return a new simulation object", () => {
+    const initialSimulation = {
+      answers: {
+        all: [
+          { entityName: "franceconnect", value: "someValue" },
+          { entityName: "famille", value: "otherValue" },
+          { entityName: "franceconnect", value: "anotherValue" },
+          { entityName: "individu", value: "thirdValue" },
+        ],
+        current: [],
+      },
+    }
+
+    const expectedSimulation = {
+      answers: {
+        all: [
+          { entityName: "famille", value: "otherValue" },
+          { entityName: "individu", value: "thirdValue" },
+        ],
+        current: [],
+      },
+    }
+
+    const result = franceConnectAnonymizeSimulation(initialSimulation)
+
+    expect(result).toEqual(expectedSimulation)
+  })
+})

--- a/tests/unit/tools/cleaner.spec.ts
+++ b/tests/unit/tools/cleaner.spec.ts
@@ -2,8 +2,12 @@ import { expect } from "@jest/globals"
 import {
   anonymizeSimulation,
   anonymizeFollowup,
+  franceConnectAnonymizeSimulation,
 } from "@root/lib/cleaner-functions.js"
-import { SimulationStatusEnum } from "@root/lib/enums/simulation.js"
+import {
+  SimulationStatusEnum,
+  SimulationFranceConnectStatusEnum,
+} from "@root/lib/enums/simulation.js"
 
 const anId = "123"
 
@@ -179,16 +183,20 @@ describe("franceConnectAnonymizeSimulation", () => {
         ],
         current: [],
       },
+      franceConnectStatus: SimulationFranceConnectStatusEnum.FETCHED,
     }
 
     const expectedSimulation = {
       answers: {
         all: [
+          { entityName: "franceconnect", value: undefined },
           { entityName: "famille", value: "otherValue" },
+          { entityName: "franceconnect", value: undefined },
           { entityName: "individu", value: "thirdValue" },
         ],
         current: [],
       },
+      franceConnectStatus: SimulationFranceConnectStatusEnum.ANONYMIZED,
     }
 
     const result = franceConnectAnonymizeSimulation(initialSimulation)

--- a/tools/cleaner.ts
+++ b/tools/cleaner.ts
@@ -1,4 +1,5 @@
 import mongoose from "mongoose"
+import dayjs from "dayjs"
 
 import config from "../backend/config/index.js"
 import mongooseConfig from "../backend/config/mongoose.js"
@@ -10,9 +11,9 @@ import {
   anonymizeFollowup,
 } from "../lib/cleaner-functions"
 
-async function main() {
-  const aMonthAgo = Date.now() - 31 * 24 * 60 * 60 * 1000
-  const aWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000
+
+async function anonymizeFollowups() {
+  const aMonthAgo = dayjs().subtract(31, "day").valueOf()
 
   let followup_count = 0
   const followupsCursor = await Followup.find({
@@ -35,6 +36,11 @@ async function main() {
   }
 
   console.log(["Terminé", "Followup", followup_count].join(";"))
+}
+
+async function anonymizeSimulations() {
+  const aMonthAgo = dayjs().subtract(31, "day").valueOf()
+  const aWeekAgo = dayjs().subtract(7, "day").valueOf()
 
   let simulation_count = 0
   const simulationsCursor = await Simulation.find({
@@ -66,6 +72,11 @@ async function main() {
   }
 
   console.log(["Terminé", "Simulation", simulation_count].join(";"))
+}
+
+async function main() {
+  await anonymizeFollowups()
+  await anonymizeSimulations()
 }
 
 try {

--- a/tools/cleaner.ts
+++ b/tools/cleaner.ts
@@ -38,7 +38,7 @@ async function anonymizeFollowups() {
     }
   }
 
-  console.log(["Terminé", "Followup", followup_count].join(";"))
+  console.log(`Followup anonymisées ${followup_count}`)
 }
 
 async function defaultAnonymizeSimulations() {
@@ -74,7 +74,7 @@ async function defaultAnonymizeSimulations() {
     }
   }
 
-  console.log(["Terminé", "Simulation", simulation_count].join(";"))
+  console.log(`Simulations anonymisées ${simulation_count}`)
 }
 
 async function franceConnectAnonymizeSimulations() {
@@ -100,9 +100,7 @@ async function franceConnectAnonymizeSimulations() {
     }
   }
 
-  console.log(
-    ["Terminé", "Simulation France Connect", simulation_count].join(";")
-  )
+  console.log(`Simulations FranceConnect anonymisées: ${simulation_count}`)
 }
 
 async function main() {

--- a/tools/cleaner.ts
+++ b/tools/cleaner.ts
@@ -4,14 +4,16 @@ import dayjs from "dayjs"
 import config from "../backend/config/index.js"
 import mongooseConfig from "../backend/config/mongoose.js"
 import Simulation from "../backend/models/simulation.js"
-import { SimulationStatusEnum } from "../lib/enums/simulation.js"
-import Followup from "../backend/models/followup"
+import {
+  SimulationStatusEnum,
+  SimulationFranceConnectStatusEnum,
+} from "../lib/enums/simulation.js"
+import Followup from "../backend/models/followup.js"
 import {
   anonymizeSimulation,
   anonymizeFollowup,
   franceConnectAnonymizeSimulation,
 } from "../lib/cleaner-functions.js"
-
 
 async function anonymizeFollowups() {
   const aMonthAgo = dayjs().subtract(31, "day").valueOf()
@@ -81,7 +83,10 @@ async function franceConnectAnonymizeSimulations() {
   let simulation_count = 0
   const simulationsCursor = await Simulation.find({
     dateDeValeur: { $lt: aDayAgo },
-    "answers.entityName": "franceconnect",
+    "answers.all": {
+      $elemMatch: { value: { $exists: true }, entityName: "franceconnect" },
+    },
+    franceConnectStatus: SimulationFranceConnectStatusEnum.FETCHED,
   })
 
   for await (const simulation of simulationsCursor) {


### PR DESCRIPTION
Trello : https://trello.com/c/YQ2Kr7uu/1255-ajouter-lanonymisation-des-donn%C3%A9es-fc-et-api-%C3%A0-h24

- Split des étapes d'anonymisation en tâche distinctes et nommées
- Ajout d'une étape `franceConnectAnonymizeSimulations`
- Ajout d'un state FranceConnect dans la simulation `franceConnectStatus`

