### PR TITLE
fix: permet l'envoi de l'id de simulation dans les emails de demande de suppression de donnée

### DIFF
--- a/src/views/confidentialite.vue
+++ b/src/views/confidentialite.vue
@@ -320,9 +320,6 @@ export default {
     }
   },
   computed: {
-    situation() {
-      return this.store.situation
-    },
     emailBody() {
       return `Bonjour,
 


### PR DESCRIPTION
## Détails

Aujourd'hui l'utilisateur ne peut jamais envoyer un email de demande de suppression des données le concernant avec l'id de sa simulation indiqué.

Il y a pas mal de cas où ça a compliqué l'exercice des droits des utilisateurs