### PR TITLE
Évite l'affichage de la tarification solidaire de Bordeaux

### DIFF
--- a/data/benefits/openfisca/bordeaux_metropole_aide_tarification_solidaire_transport.yml
+++ b/data/benefits/openfisca/bordeaux_metropole_aide_tarification_solidaire_transport.yml
@@ -12,3 +12,4 @@ instructions: https://tarificationsolidaire.bordeaux-metropole.fr/infosCreationC
 floorAt: 0.01
 entity: individus
 openfiscaPeriod: thisMonth
+private: true


### PR DESCRIPTION
L'aide n'est pas conditionnée géographiquement.