### PR TITLE
Intégrer dans les emails envoyés un lien vers une version de l'email accessible en ligne (et sécurisé)

### DIFF
--- a/backend/controllers/emails.ts
+++ b/backend/controllers/emails.ts
@@ -1,0 +1,50 @@
+import Followup from "../../backend/models/followup.js"
+import jwt from "jsonwebtoken"
+import config from "../config/index.js"
+import { EmailType } from "../../backend/enums/email.js"
+import emailRender from "../../backend/lib/mes-aides/emails/email-render.js"
+import { SurveyType } from "../../lib/enums/survey.js"
+
+const renderFollowupEmail = async (followup, emailType) => {
+  let surveyType: SurveyType | undefined
+
+  switch (emailType) {
+    case EmailType.simulationResults:
+      return emailRender(EmailType.simulationResults, followup)
+    case EmailType.simulationUsefulness:
+      surveyType = SurveyType.trackClickOnSimulationUsefulnessEmail
+      break
+    case EmailType.benefitAction:
+      surveyType = SurveyType.trackClickOnBenefitActionEmail
+      break
+    default:
+      return
+  }
+
+  if (!surveyType) {
+    throw new Error(`Unknown email type: ${emailType}`)
+  }
+
+  return followup.renderSurveyEmail(surveyType)
+}
+
+const getEtmail = async (req, res, next) => {
+  try {
+    const { followupId, emailType } = jwt.verify(
+      req.params.token,
+      config.sessionSecret
+    )
+    const followup = await Followup.findById(followupId).populate("simulation")
+    if (!followup) {
+      return res.sendStatus(404)
+    }
+    const result = await renderFollowupEmail(followup, emailType)
+    res.send(result["html"])
+  } catch (err) {
+    next(err)
+  }
+}
+
+export default {
+  getEtmail,
+}

--- a/backend/controllers/emails.ts
+++ b/backend/controllers/emails.ts
@@ -4,7 +4,7 @@ import { EmailType } from "../../backend/enums/email.js"
 import emailRender from "../../backend/lib/mes-aides/emails/email-render.js"
 import { SurveyType } from "../../lib/enums/survey.js"
 
-const renderFollowupEmail = async (followup, emailType) => {
+const renderFollowupEmailByType = async (followup, emailType) => {
   let surveyType: SurveyType | undefined
 
   switch (emailType) {
@@ -27,7 +27,7 @@ const renderFollowupEmail = async (followup, emailType) => {
   return followup.renderSurveyEmail(surveyType)
 }
 
-const getEtmail = async (req, res, next) => {
+const getFollowupEmail = async (req, res, next) => {
   try {
     const followup = await Followup.findById(req.params.followupId).populate(
       "simulation"
@@ -36,7 +36,7 @@ const getEtmail = async (req, res, next) => {
     if (!followup) {
       return res.sendStatus(404)
     }
-    const result = await renderFollowupEmail(followup, emailType)
+    const result = await renderFollowupEmailByType(followup, emailType)
     res.send(result["html"])
   } catch (err) {
     next(err)
@@ -44,5 +44,5 @@ const getEtmail = async (req, res, next) => {
 }
 
 export default {
-  getEtmail,
+  getFollowupEmail,
 }

--- a/backend/controllers/emails.ts
+++ b/backend/controllers/emails.ts
@@ -29,9 +29,6 @@ const getFollowupEmail = async (req, res, next) => {
       "simulation"
     )
     const { emailType } = req.query
-    if (!followup) {
-      return res.sendStatus(404)
-    }
     const result = await renderFollowupEmailByType(followup, emailType)
     res.send(result["html"])
   } catch (err) {

--- a/backend/controllers/emails.ts
+++ b/backend/controllers/emails.ts
@@ -17,11 +17,7 @@ const renderFollowupEmailByType = async (followup, emailType) => {
       surveyType = SurveyType.trackClickOnBenefitActionEmail
       break
     default:
-      return
-  }
-
-  if (!surveyType) {
-    throw new Error(`Unknown email type: ${emailType}`)
+      throw new Error(`Unknown email type: ${emailType}`)
   }
 
   return followup.renderSurveyEmail(surveyType)

--- a/backend/controllers/emails.ts
+++ b/backend/controllers/emails.ts
@@ -1,5 +1,3 @@
-// import { followupByAccessToken } from "../../backend/controllers/followups.js"
-import Followup from "../../backend/models/followup.js"
 import { EmailType } from "../../backend/enums/email.js"
 import emailRender from "../../backend/lib/mes-aides/emails/email-render.js"
 import { SurveyType } from "../../lib/enums/survey.js"
@@ -25,8 +23,8 @@ const renderFollowupEmailByType = async (followup, emailType) => {
 
 const getFollowupEmail = async (req, res, next) => {
   try {
-    const followup = await Followup.findById(req.params.followupId)
     const { emailType } = req.query
+    const followup = req.followup
     const result = await renderFollowupEmailByType(followup, emailType)
     res.send(result["html"])
   } catch (err) {

--- a/backend/controllers/emails.ts
+++ b/backend/controllers/emails.ts
@@ -25,9 +25,7 @@ const renderFollowupEmailByType = async (followup, emailType) => {
 
 const getFollowupEmail = async (req, res, next) => {
   try {
-    const followup = await Followup.findById(req.params.followupId).populate(
-      "simulation"
-    )
+    const followup = await Followup.findById(req.params.followupId)
     const { emailType } = req.query
     const result = await renderFollowupEmailByType(followup, emailType)
     res.send(result["html"])

--- a/backend/controllers/emails.ts
+++ b/backend/controllers/emails.ts
@@ -1,6 +1,5 @@
+// import { followupByAccessToken } from "../../backend/controllers/followups.js"
 import Followup from "../../backend/models/followup.js"
-import jwt from "jsonwebtoken"
-import config from "../config/index.js"
 import { EmailType } from "../../backend/enums/email.js"
 import emailRender from "../../backend/lib/mes-aides/emails/email-render.js"
 import { SurveyType } from "../../lib/enums/survey.js"
@@ -30,11 +29,10 @@ const renderFollowupEmail = async (followup, emailType) => {
 
 const getEtmail = async (req, res, next) => {
   try {
-    const { followupId, emailType } = jwt.verify(
-      req.params.token,
-      config.sessionSecret
+    const followup = await Followup.findById(req.params.followupId).populate(
+      "simulation"
     )
-    const followup = await Followup.findById(followupId).populate("simulation")
+    const { emailType } = req.query
     if (!followup) {
       return res.sendStatus(404)
     }

--- a/backend/lib/mes-aides/emails/email-render.ts
+++ b/backend/lib/mes-aides/emails/email-render.ts
@@ -1,7 +1,6 @@
 import fs from "fs"
 import path from "path"
 import consolidate from "consolidate"
-import jwt from "jsonwebtoken"
 
 const mustache = consolidate.mustache
 import config from "../../../config/index.js"
@@ -49,28 +48,19 @@ const textTemplates = {
   [EmailType.tousABordNotification]: tousABordNotificationTextTemplate,
 }
 
-const buildAPIEmailRenderPath = (followupId, emailType) => {
-  const payload = {
-    followupId,
-    emailType,
-  }
-  return `/api/email/${jwt.sign(payload, config.sessionSecret)}`
-}
-
 const dataTemplateBuilder = (
   emailType,
   followup,
   formatedBenefits,
   benefitTexts
 ) => {
-  const emailRenderPath = buildAPIEmailRenderPath(followup._id, emailType)
   return {
     benefitTexts,
     baseURL: config.baseURL,
     ctaLink: `${config.baseURL}${followup.surveyPathTracker}`,
     tousABordNotificationCta: `${config.baseURL}${followup.tousABordNotificationCta}`,
     droits: formatedBenefits,
-    emailRenderURL: `${config.baseURL}${emailRenderPath}`,
+    emailRenderURL: `${config.baseURL}${followup.emailRenderPath}${emailType}`,
     returnURL: `${config.baseURL}${followup.returnPath}`,
     wasUsefulLinkYes: `${config.baseURL}${followup.wasUsefulPath}`,
     wasUsefulLinkNo: `${config.baseURL}${followup.wasNotUsefulPath}`,

--- a/backend/lib/mes-aides/emails/email-render.ts
+++ b/backend/lib/mes-aides/emails/email-render.ts
@@ -1,6 +1,7 @@
 import fs from "fs"
 import path from "path"
 import consolidate from "consolidate"
+import jwt from "jsonwebtoken"
 
 const mustache = consolidate.mustache
 import config from "../../../config/index.js"
@@ -48,7 +49,13 @@ const textTemplates = {
   [EmailType.tousABordNotification]: tousABordNotificationTextTemplate,
 }
 
-const APIEmailRenderURL = "/api/email/"
+const buildAPIEmailRenderURLToken = (followupId, emailType) => {
+  const payload = {
+    followupId,
+    emailType,
+  }
+  return jwt.sign(payload, config.sessionSecret)
+}
 
 const dataTemplateBuilder = (
   emailType,
@@ -56,13 +63,15 @@ const dataTemplateBuilder = (
   formatedBenefits,
   benefitTexts
 ) => {
+  const emailRenderToken = buildAPIEmailRenderURLToken(followup._id, emailType)
+  const APIEmailRenderURL = "/api/email/"
   return {
     benefitTexts,
     baseURL: config.baseURL,
     ctaLink: `${config.baseURL}${followup.surveyPathTracker}`,
     tousABordNotificationCta: `${config.baseURL}${followup.tousABordNotificationCta}`,
     droits: formatedBenefits,
-    emailRenderURL: `${config.baseURL}${APIEmailRenderURL}${followup._id}/${emailType}`,
+    emailRenderURL: `${config.baseURL}${APIEmailRenderURL}${emailRenderToken}`,
     returnURL: `${config.baseURL}${followup.returnPath}`,
     wasUsefulLinkYes: `${config.baseURL}${followup.wasUsefulPath}`,
     wasUsefulLinkNo: `${config.baseURL}${followup.wasNotUsefulPath}`,

--- a/backend/lib/mes-aides/emails/email-render.ts
+++ b/backend/lib/mes-aides/emails/email-render.ts
@@ -48,6 +48,8 @@ const textTemplates = {
   [EmailType.tousABordNotification]: tousABordNotificationTextTemplate,
 }
 
+const APIEmailRenderURL = "/api/email/"
+
 const dataTemplateBuilder = (
   emailType,
   followup,
@@ -60,6 +62,7 @@ const dataTemplateBuilder = (
     ctaLink: `${config.baseURL}${followup.surveyPathTracker}`,
     tousABordNotificationCta: `${config.baseURL}${followup.tousABordNotificationCta}`,
     droits: formatedBenefits,
+    emailRenderURL: `${config.baseURL}${APIEmailRenderURL}${followup._id}/${emailType}`,
     returnURL: `${config.baseURL}${followup.returnPath}`,
     wasUsefulLinkYes: `${config.baseURL}${followup.wasUsefulPath}`,
     wasUsefulLinkNo: `${config.baseURL}${followup.wasNotUsefulPath}`,

--- a/backend/lib/mes-aides/emails/email-render.ts
+++ b/backend/lib/mes-aides/emails/email-render.ts
@@ -49,12 +49,12 @@ const textTemplates = {
   [EmailType.tousABordNotification]: tousABordNotificationTextTemplate,
 }
 
-const buildAPIEmailRenderURLToken = (followupId, emailType) => {
+const buildAPIEmailRenderPath = (followupId, emailType) => {
   const payload = {
     followupId,
     emailType,
   }
-  return jwt.sign(payload, config.sessionSecret)
+  return `/api/email/${jwt.sign(payload, config.sessionSecret)}`
 }
 
 const dataTemplateBuilder = (
@@ -63,15 +63,14 @@ const dataTemplateBuilder = (
   formatedBenefits,
   benefitTexts
 ) => {
-  const emailRenderToken = buildAPIEmailRenderURLToken(followup._id, emailType)
-  const APIEmailRenderURL = "/api/email/"
+  const emailRenderPath = buildAPIEmailRenderPath(followup._id, emailType)
   return {
     benefitTexts,
     baseURL: config.baseURL,
     ctaLink: `${config.baseURL}${followup.surveyPathTracker}`,
     tousABordNotificationCta: `${config.baseURL}${followup.tousABordNotificationCta}`,
     droits: formatedBenefits,
-    emailRenderURL: `${config.baseURL}${APIEmailRenderURL}${emailRenderToken}`,
+    emailRenderURL: `${config.baseURL}${emailRenderPath}`,
     returnURL: `${config.baseURL}${followup.returnPath}`,
     wasUsefulLinkYes: `${config.baseURL}${followup.wasUsefulPath}`,
     wasUsefulLinkNo: `${config.baseURL}${followup.wasNotUsefulPath}`,

--- a/backend/lib/mes-aides/emails/templates/footer.mjml
+++ b/backend/lib/mes-aides/emails/templates/footer.mjml
@@ -28,5 +28,11 @@
         ></span
       >
     </mj-text>
+    <mj-text>
+      <span
+        >Accédez à une version en ligne de cet email en cliquant
+        <a href="{{&emailRenderURL}}" target="_blank">ici</a>.</span
+      >
+    </mj-text>
   </mj-column>
 </mj-section>

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -173,6 +173,10 @@ FollowupSchema.method("updateSurvey", function (type, answers) {
   return this.save()
 })
 
+FollowupSchema.virtual("emailRenderPath").get(function (this) {
+  return `/api/email/followups/${this._id}?accessToken=${this.accessToken}&emailType=`
+})
+
 FollowupSchema.virtual("returnPath").get(function (this) {
   return `/followups/${this._id}?token=${this.accessToken}`
 })

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -174,7 +174,7 @@ FollowupSchema.method("updateSurvey", function (type, answers) {
 })
 
 FollowupSchema.virtual("emailRenderPath").get(function (this) {
-  return `/api/email/followups/${this._id}?accessToken=${this.accessToken}&emailType=`
+  return `/api/email/followups/${this._id}?token=${this.accessToken}&emailType=`
 })
 
 FollowupSchema.virtual("returnPath").get(function (this) {

--- a/backend/routes/emails.ts
+++ b/backend/routes/emails.ts
@@ -1,52 +1,6 @@
-import Followup from "../../backend/models/followup.js"
-import { ajRequest } from "../../backend/types/express.d.js"
-import { EmailType } from "../../backend/enums/email.js"
-import emailRender from "../../backend/lib/mes-aides/emails/email-render.js"
-import { SurveyType } from "../../lib/enums/survey.js"
-import jwt from "jsonwebtoken"
-import config from "../config/index.js"
+import emailController from "../controllers/emails.js"
 
 const emailRoutes = function (api) {
-  const renderFollowupEmail = async (followup, emailType) => {
-    let surveyType: SurveyType | undefined
-
-    switch (emailType) {
-      case EmailType.simulationResults:
-        return emailRender(EmailType.simulationResults, followup)
-      case EmailType.simulationUsefulness:
-        surveyType = SurveyType.trackClickOnSimulationUsefulnessEmail
-        break
-      case EmailType.benefitAction:
-        surveyType = SurveyType.trackClickOnBenefitActionEmail
-        break
-      default:
-        return
-    }
-
-    if (!surveyType) {
-      throw new Error(`Unknown email type: ${emailType}`)
-    }
-
-    return followup.renderSurveyEmail(surveyType)
-  }
-
-  api.route("/email/:token").get(async (req: ajRequest, res, next) => {
-    try {
-      const { followupId, emailType } = jwt.verify(
-        req.params.token,
-        config.sessionSecret
-      )
-      const followup = await Followup.findById(followupId).populate(
-        "simulation"
-      )
-      if (!followup) {
-        return res.sendStatus(404)
-      }
-      const result = await renderFollowupEmail(followup, emailType)
-      res.send(result["html"])
-    } catch (err) {
-      next(err)
-    }
-  })
+  api.get("/email/:token", emailController.getEtmail)
 }
 export default emailRoutes

--- a/backend/routes/emails.ts
+++ b/backend/routes/emails.ts
@@ -1,0 +1,51 @@
+import Followup from "../../backend/models/followup.js"
+import { ajRequest } from "../../backend/types/express.d.js"
+import { EmailType } from "../../backend/enums/email.js"
+import emailRender from "../../backend/lib/mes-aides/emails/email-render.js"
+import { SurveyType } from "../../lib/enums/survey.js"
+
+const emailRoutes = function (api) {
+  const renderFollowupEmail = async (req: ajRequest) => {
+    const { followup } = req
+    const { type: emailType } = req.params
+    let surveyType: SurveyType | undefined
+
+    switch (emailType) {
+      case EmailType.simulationResults:
+        return emailRender(EmailType.simulationResults, followup)
+      case EmailType.simulationUsefulness:
+        surveyType = SurveyType.trackClickOnSimulationUsefulnessEmail
+        break
+      case EmailType.benefitAction:
+        surveyType = SurveyType.trackClickOnBenefitActionEmail
+        break
+      default:
+        return
+    }
+
+    if (!surveyType) {
+      return
+    }
+
+    return followup.renderSurveyEmail(surveyType)
+  }
+
+  api
+    .route("/email/:followupId/:type")
+    .get(async (req: ajRequest, res, next) => {
+      try {
+        const followup = await Followup.findById(
+          req.params.followupId
+        ).populate("simulation")
+        if (!followup) {
+          return res.sendStatus(404)
+        }
+        req.followup = followup
+        const result = await renderFollowupEmail(req)
+        res.send(result["html"])
+      } catch (err) {
+        next(err)
+      }
+    })
+}
+export default emailRoutes

--- a/backend/routes/emails.ts
+++ b/backend/routes/emails.ts
@@ -1,6 +1,6 @@
 import emailController from "../controllers/emails.js"
 
 const emailRoutes = function (api) {
-  api.get("/email/followups/:followupId", emailController.getEtmail)
+  api.get("/email/followups/:followupId", emailController.getFollowupEmail)
 }
 export default emailRoutes

--- a/backend/routes/emails.ts
+++ b/backend/routes/emails.ts
@@ -24,7 +24,7 @@ const emailRoutes = function (api) {
     }
 
     if (!surveyType) {
-      return
+      throw new Error(`Unknown email type: ${emailType}`)
     }
 
     return followup.renderSurveyEmail(surveyType)

--- a/backend/routes/emails.ts
+++ b/backend/routes/emails.ts
@@ -1,6 +1,8 @@
 import emailController from "../controllers/emails.js"
+import { followup } from "../controllers/followups.js"
 
 const emailRoutes = function (api) {
+  api.param("followupId", followup)
   api.get("/email/followups/:followupId", emailController.getFollowupEmail)
 }
 export default emailRoutes

--- a/backend/routes/emails.ts
+++ b/backend/routes/emails.ts
@@ -1,6 +1,6 @@
 import emailController from "../controllers/emails.js"
 
 const emailRoutes = function (api) {
-  api.get("/email/:token", emailController.getEtmail)
+  api.get("/email/followups/:followupId", emailController.getEtmail)
 }
 export default emailRoutes


### PR DESCRIPTION
## Description
[Tâche Trello](https://trello.com/c/3JTAA7V2/1258-int%C3%A9grer-dans-les-emails-envoy%C3%A9s-un-lien-vers-une-version-de-lemail-accessible-en-ligne-et-s%C3%A9curis%C3%A9)

~~Solution proposée~~ => Annulée

~~J'ai ajouté un lien dans le template du footer (commun à tous les email) qui redirige vers une nouvelle route de l'API et qui rend le contenu des emails en HTML.~~

~~Un JWT contenant l'ID du followup et le type de l'email associé est intégré en paramètre de l'url dans la route `/api/email:token` pour générer le rendu de l'email en ligne tout en étant sécurisé.~~

## Solution proposée

[Cf commentaire Thomas](https://github.com/betagouv/aides-jeunes/pull/3680#discussion_r1200521568)

## Point à suivre après la PR

Ajouter une clef sessionSecret en production [cf le commentaire de Baptiste](https://github.com/betagouv/aides-jeunes/pull/3680#discussion_r1198671240)