### PR TITLE
Réactive l'aide de tarification solidaire des transports de Bordeaux Métropole

### DIFF
--- a/data/benefits/openfisca/bordeaux_metropole_aide_tarification_solidaire_transport.yml
+++ b/data/benefits/openfisca/bordeaux_metropole_aide_tarification_solidaire_transport.yml
@@ -12,4 +12,3 @@ instructions: https://tarificationsolidaire.bordeaux-metropole.fr/infosCreationC
 floorAt: 0.01
 entity: individus
 openfiscaPeriod: thisMonth
-private: true

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -2,5 +2,5 @@ gunicorn>=19.1.1
 pytest == 5.4.2
 Openfisca-France==146.2.0
 Openfisca-Core[web-api]==35.9.0
-OpenFisca-France-Local[excel-reader]==4.6.0
+OpenFisca-France-Local[excel-reader]==4.6.1
 Openfisca-Paris==3.8.0


### PR DESCRIPTION
## Détails

Réactive l'aide tarification solidaire des transports de Bordeaux Métropole suite à l'ajout du filtrage géographique dans `Openfisca-france-local 4.6.1`