### PR TITLE
Change l'URL de l'API de l'annuaire pour les établissements publics

### DIFF
--- a/lib/benefits/etablissements.ts
+++ b/lib/benefits/etablissements.ts
@@ -53,7 +53,7 @@ export function getBenefitEtablissements(benefit) {
 export async function getEtablissements(depcom, types) {
   return axios
     .get(
-      `https://etablissements-publics.api.gouv.fr/v3/communes/${depcom}/${types.join(
+      `https://plateforme.adresse.data.gouv.fr/api-annuaire/v3/communes/${depcom}/${types.join(
         "+"
       )}`
     )


### PR DESCRIPTION
L'URL actuelle de l'API d'annuaire pour récupérer les établissements n'est plus à jour, cette PR utilise la nouvelle version disponible ici : https://github.com/BaseAdresseNationale/annuaire-api