### PR TITLE
Met à jout etalab decoupage administratif

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.8.2",
         "@actions/github": "^5.0.3",
-        "@etalab/decoupage-administratif": "^2.1.0",
+        "@etalab/decoupage-administratif": "^3.0.0",
         "@gouvfr/dsfr": "^1.8.5",
         "@sentry/integrations": "^6.14.0",
         "@sentry/node": "^6.14.0",
@@ -2270,8 +2270,9 @@
       }
     },
     "node_modules/@etalab/decoupage-administratif": {
-      "version": "2.1.0",
-      "license": "MIT",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@etalab/decoupage-administratif/-/decoupage-administratif-3.0.0.tgz",
+      "integrity": "sha512-WlXHeArXK7zwcxoPev8NM3ncUjaIiBYiTmY1wh3X6RXITKjTwn3yaYdQqbPplTfFA/ByllG4Y4q4Jt0bCmbEzw==",
       "engines": {
         "node": ">= 10"
       }
@@ -17516,7 +17517,9 @@
       }
     },
     "@etalab/decoupage-administratif": {
-      "version": "2.1.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@etalab/decoupage-administratif/-/decoupage-administratif-3.0.0.tgz",
+      "integrity": "sha512-WlXHeArXK7zwcxoPev8NM3ncUjaIiBYiTmY1wh3X6RXITKjTwn3yaYdQqbPplTfFA/ByllG4Y4q4Jt0bCmbEzw=="
     },
     "@gouvfr/dsfr": {
       "version": "1.8.5",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@actions/core": "^1.8.2",
     "@actions/github": "^5.0.3",
-    "@etalab/decoupage-administratif": "^2.1.0",
+    "@etalab/decoupage-administratif": "^3.0.0",
     "@gouvfr/dsfr": "^1.8.5",
     "@sentry/integrations": "^6.14.0",
     "@sentry/node": "^6.14.0",


### PR DESCRIPTION
## Détails

Le package `@etalab/decoupage-administratif` version `2.1.0` utilisé en prod date de juin 2022.
La version actuelle est la `3.0.0` mais ne dispose pas de changelog et donc pas de visibilité sur d'éventuels breaking-changes.

[L'historique de commits](https://github.com/etalab/decoupage-administratif/commits/master) peut donner des indications sur les modifications effectuées.