### PR TITLE
Met à jour le package aides vélos en 3.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@sentry/vue": "^6.14.0",
         "@vitejs/plugin-legacy": "^4.0.2",
         "@vitejs/plugin-vue": "^4.1.0",
-        "aides-velo": "3.0.9",
+        "aides-velo": "3.0.10",
         "axios": "^0.27.2",
         "communes-lonlat": "^1.1.0",
         "consolidate": "^0.16.0",
@@ -3552,7 +3552,8 @@
     },
     "node_modules/@types/mocha": {
       "version": "9.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "peer": true
     },
     "node_modules/@types/morgan": {
@@ -4452,11 +4453,11 @@
       }
     },
     "node_modules/aides-velo": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/aides-velo/-/aides-velo-3.0.9.tgz",
-      "integrity": "sha512-ts77NSjwKatp2MFbPDXnKzZIBndaYtAiiwQmi2zKSAiJgDtl6GjFn/p/Vp1iXOSYKG+7ehwgKjIP4zHf436H3w==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/aides-velo/-/aides-velo-3.0.10.tgz",
+      "integrity": "sha512-IDsy0QvqaE0IRDWZqmgNWF5v2mAERcWNUCkgO+V3RhF3xC7boseYJaN2oXCdWQpVWBUGjrYWJNl7OtUaFKfVFg==",
       "dependencies": {
-        "publicodes": "^1.0.0-beta.44"
+        "publicodes": "^1.0.0-beta.69"
       }
     },
     "node_modules/ajv": {
@@ -6524,10 +6525,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/discontinuous-range": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
@@ -12238,10 +12235,6 @@
       "version": "2.1.3",
       "license": "MIT"
     },
-    "node_modules/moo": {
-      "version": "0.5.1",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/morgan": {
       "version": "1.10.0",
       "license": "MIT",
@@ -12339,26 +12332,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nearley": {
-      "version": "2.20.1",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      },
-      "bin": {
-        "nearley-railroad": "bin/nearley-railroad.js",
-        "nearley-test": "bin/nearley-test.js",
-        "nearley-unparse": "bin/nearley-unparse.js",
-        "nearleyc": "bin/nearleyc.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://nearley.js.org/#give-to-nearley"
-      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -13183,16 +13156,9 @@
       "dev": true
     },
     "node_modules/publicodes": {
-      "version": "1.0.0-beta.46",
-      "license": "MIT",
-      "dependencies": {
-        "moo": "^0.5.1",
-        "nearley": "^2.19.2",
-        "yaml": "^1.9.2"
-      },
-      "engines": {
-        "node": ">=12.16.1"
-      },
+      "version": "1.0.0-beta.69",
+      "resolved": "https://registry.npmjs.org/publicodes/-/publicodes-1.0.0-beta.69.tgz",
+      "integrity": "sha512-/RuvmEO2+39M9C92dzsugnDzldxq0zf7mJFGok8YPqdKmH2DQ5Qfqdyw6XsOU1oBRPzM8VU7UUqzRIEb/d9wug==",
       "peerDependencies": {
         "@types/mocha": "^9.0.0"
       }
@@ -13244,21 +13210,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/railroad-diagrams": {
-      "version": "1.0.0",
-      "license": "CC0-1.0"
-    },
-    "node_modules/randexp": {
-      "version": "0.4.6",
-      "license": "MIT",
-      "dependencies": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -13503,13 +13454,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/ret": {
-      "version": "0.1.15",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/retry": {
@@ -16093,13 +16037,6 @@
       "version": "2.1.2",
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "license": "MIT",
@@ -18485,6 +18422,8 @@
     },
     "@types/mocha": {
       "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "peer": true
     },
     "@types/morgan": {
@@ -19133,11 +19072,11 @@
       }
     },
     "aides-velo": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/aides-velo/-/aides-velo-3.0.9.tgz",
-      "integrity": "sha512-ts77NSjwKatp2MFbPDXnKzZIBndaYtAiiwQmi2zKSAiJgDtl6GjFn/p/Vp1iXOSYKG+7ehwgKjIP4zHf436H3w==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/aides-velo/-/aides-velo-3.0.10.tgz",
+      "integrity": "sha512-IDsy0QvqaE0IRDWZqmgNWF5v2mAERcWNUCkgO+V3RhF3xC7boseYJaN2oXCdWQpVWBUGjrYWJNl7OtUaFKfVFg==",
       "requires": {
-        "publicodes": "^1.0.0-beta.44"
+        "publicodes": "^1.0.0-beta.69"
       }
     },
     "ajv": {
@@ -20474,9 +20413,6 @@
       "requires": {
         "path-type": "^4.0.0"
       }
-    },
-    "discontinuous-range": {
-      "version": "1.0.0"
     },
     "dns-equal": {
       "version": "1.0.0"
@@ -24323,9 +24259,6 @@
         }
       }
     },
-    "moo": {
-      "version": "0.5.1"
-    },
     "morgan": {
       "version": "1.10.0",
       "requires": {
@@ -24384,15 +24317,6 @@
     "natural-compare": {
       "version": "1.4.0",
       "dev": true
-    },
-    "nearley": {
-      "version": "2.20.1",
-      "requires": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      }
     },
     "negotiator": {
       "version": "0.6.3",
@@ -24907,12 +24831,10 @@
       "dev": true
     },
     "publicodes": {
-      "version": "1.0.0-beta.46",
-      "requires": {
-        "moo": "^0.5.1",
-        "nearley": "^2.19.2",
-        "yaml": "^1.9.2"
-      }
+      "version": "1.0.0-beta.69",
+      "resolved": "https://registry.npmjs.org/publicodes/-/publicodes-1.0.0-beta.69.tgz",
+      "integrity": "sha512-/RuvmEO2+39M9C92dzsugnDzldxq0zf7mJFGok8YPqdKmH2DQ5Qfqdyw6XsOU1oBRPzM8VU7UUqzRIEb/d9wug==",
+      "requires": {}
     },
     "pump": {
       "version": "3.0.0",
@@ -24935,16 +24857,6 @@
     },
     "queue-microtask": {
       "version": "1.2.3"
-    },
-    "railroad-diagrams": {
-      "version": "1.0.0"
-    },
-    "randexp": {
-      "version": "0.4.6",
-      "requires": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -25113,9 +25025,6 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
-    },
-    "ret": {
-      "version": "0.1.15"
     },
     "retry": {
       "version": "0.13.1"
@@ -26778,9 +26687,6 @@
     },
     "yallist": {
       "version": "2.1.2"
-    },
-    "yaml": {
-      "version": "1.10.2"
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@sentry/vue": "^6.14.0",
     "@vitejs/plugin-legacy": "^4.0.2",
     "@vitejs/plugin-vue": "^4.1.0",
-    "aides-velo": "3.0.9",
+    "aides-velo": "3.0.10",
     "axios": "^0.27.2",
     "communes-lonlat": "^1.1.0",
     "consolidate": "^0.16.0",


### PR DESCRIPTION
## Détails

Le package fait échouer les tests unitaires avec le message `Publicodes is not a constructor`.