### PR TITLE
Sécurise le token d'accès github avec un jwt pour la page d'accompagnement

### DIFF
--- a/backend/controllers/github.ts
+++ b/backend/controllers/github.ts
@@ -52,7 +52,7 @@ const retrieveGithubAccessToken = async (code) => {
   }
 }
 
-const getGithubUsername = async (token) => {
+const getGithubHandle = async (token) => {
   try {
     const response = await axios.get(authenticated_url, {
       headers: {
@@ -62,7 +62,7 @@ const getGithubUsername = async (token) => {
     })
     return response.data.login
   } catch (error) {
-    console.error("Error in getGithubUsername: ", error)
+    console.error("Error in getGithubHandle: ", error)
     throw error
   }
 }
@@ -75,11 +75,11 @@ const access = async (req, res, next) => {
 
     if (githubCode) {
       const githubAccessToken = await retrieveGithubAccessToken(githubCode)
-      const login = await getGithubUsername(githubAccessToken)
-      const isAuthorized = authorized_users.includes(login)
+      const githubHandle = await getGithubHandle(githubAccessToken)
+      const isAuthorized = authorized_users.includes(githubHandle)
 
       if (isAuthorized) {
-        github_handle_token = jwt.sign({ login }, sessionSecret, {
+        github_handle_token = jwt.sign({ githubHandle }, sessionSecret, {
           expiresIn: JWT_EXPIRATION_DELAY,
         })
         res.cookie("github_handle_token", github_handle_token)
@@ -90,8 +90,8 @@ const access = async (req, res, next) => {
     }
 
     if (github_handle_token) {
-      const { login } = jwt.verify(github_handle_token, sessionSecret)
-      const isAuthorized = authorized_users.includes(login)
+      const { githubHandle } = jwt.verify(github_handle_token, sessionSecret)
+      const isAuthorized = authorized_users.includes(githubHandle)
 
       if (isAuthorized) {
         return next()

--- a/backend/controllers/github.ts
+++ b/backend/controllers/github.ts
@@ -104,7 +104,7 @@ const access = async (req, res, next) => {
     return authenticate(req, res)
   } catch (error) {
     console.error("Error in access:", error)
-    res.clearCookie("github_signed_token")
+    res.clearCookie("github_handle_token")
     return res.redirect("/accompagnement?error")
   }
 }

--- a/backend/controllers/github.ts
+++ b/backend/controllers/github.ts
@@ -70,7 +70,7 @@ const getGithubUsername = async (token) => {
 const access = async (req, res, next) => {
   try {
     const { cookies } = req
-    let github_login_token = cookies && cookies["github_login_token"]
+    let github_handle_token = cookies && cookies["github_handle_token"]
     const githubCode = req.query.code
 
     if (githubCode) {
@@ -79,24 +79,24 @@ const access = async (req, res, next) => {
       const isAuthorized = authorized_users.includes(login)
 
       if (isAuthorized) {
-        github_login_token = jwt.sign({ login }, sessionSecret, {
+        github_handle_token = jwt.sign({ login }, sessionSecret, {
           expiresIn: JWT_EXPIRATION_DELAY,
         })
-        res.cookie("github_login_token", github_login_token)
+        res.cookie("github_handle_token", github_handle_token)
       } else {
-        res.clearCookie("github_login_token")
+        res.clearCookie("github_handle_token")
         return res.redirect("/accompagnement?unauthorized")
       }
     }
 
-    if (github_login_token) {
-      const { login } = jwt.verify(github_login_token, sessionSecret)
+    if (github_handle_token) {
+      const { login } = jwt.verify(github_handle_token, sessionSecret)
       const isAuthorized = authorized_users.includes(login)
 
       if (isAuthorized) {
         return next()
       } else {
-        res.clearCookie("github_login_token")
+        res.clearCookie("github_handle_token")
         return res.redirect("/accompagnement?unauthorized")
       }
     }

--- a/backend/controllers/github.ts
+++ b/backend/controllers/github.ts
@@ -32,7 +32,7 @@ const authenticate = (req, res) => {
   res.redirect(url.toString())
 }
 
-const postCodeValidation = async (code) => {
+const retrieveGithubAccessToken = async (code) => {
   try {
     const response = await axios.post(
       access_token_url,
@@ -47,12 +47,12 @@ const postCodeValidation = async (code) => {
     )
     return response.data.access_token
   } catch (error) {
-    console.error("Error in postCodeValidation: ", error)
+    console.error("Error in retrieveGithubAccessToken: ", error)
     throw error
   }
 }
 
-const getAccessTokenValidation = async (token) => {
+const getGithubUsername = async (token) => {
   try {
     const response = await axios.get(authenticated_url, {
       headers: {
@@ -62,7 +62,7 @@ const getAccessTokenValidation = async (token) => {
     })
     return response.data.login
   } catch (error) {
-    console.error("Error in getAccessTokenValidation: ", error)
+    console.error("Error in getGithubUsername: ", error)
     throw error
   }
 }
@@ -74,8 +74,8 @@ const access = async (req, res, next) => {
     const githubCode = req.query.code
 
     if (githubCode) {
-      const accessResponse = await postCodeValidation(githubCode)
-      const login = await getAccessTokenValidation(accessResponse)
+      const githubAccessToken = await retrieveGithubAccessToken(githubCode)
+      const login = await getGithubUsername(githubAccessToken)
       const isAuthorized = authorized_users.includes(login)
 
       if (isAuthorized) {

--- a/src/views/confidentialite.vue
+++ b/src/views/confidentialite.vue
@@ -293,7 +293,7 @@ export default {
                 "Simulation : Secret permettant de gérer la légimité des accès",
             },
             {
-              name: "github_token",
+              name: "github_signed_token",
               lifetime: "Session",
               purpose:
                 "Outil d’accompagnement : Secret permettant de gérer les accès",

--- a/src/views/confidentialite.vue
+++ b/src/views/confidentialite.vue
@@ -293,7 +293,7 @@ export default {
                 "Simulation : Secret permettant de gérer la légimité des accès",
             },
             {
-              name: "github_signed_token",
+              name: "github_login_token",
               lifetime: "Session",
               purpose:
                 "Outil d’accompagnement : Secret permettant de gérer les accès",

--- a/src/views/confidentialite.vue
+++ b/src/views/confidentialite.vue
@@ -293,7 +293,7 @@ export default {
                 "Simulation : Secret permettant de gérer la légimité des accès",
             },
             {
-              name: "github_login_token",
+              name: "github_handle_token",
               lifetime: "Session",
               purpose:
                 "Outil d’accompagnement : Secret permettant de gérer les accès",


### PR DESCRIPTION
[Tâche Trello](https://trello.com/c/1EE5v4jx/1289-corriger-la-gestion-dacc%C3%A8s-%C3%A0-loutil-daccompagnement-pour-%C3%A9viter-que-les-usagers-puissent-se-faire-passer-pour-nous-aupr%C3%A8s-de-gh)

J'ai repris la variable d'environnement `sessionSecret` comme pour la Pr #3680 afin de signer le token, il faudra donc s'assurer que celle ci est bien définie en production avant de merger.


## Solution proposée

- [x] On vérifie que le nom d'utilisateur github est dans la liste des utilisateurs autorisés comme actuellement, et si c'est le cas on signe directement ce pseudo avec une clef secrète dans un jwt qu'on stocke dans les cookies
- [x] Le nouveau jwt dispose d'une date d'expiration de 6 mois
- [x] Le github_token n'est plus conservé dans les cookies
- [x] Refacto globale du controller