### PR TITLE
Supprime une marge sur la page d'accueil

### DIFF
--- a/src/styles/aides-jeunes.css
+++ b/src/styles/aides-jeunes.css
@@ -257,7 +257,6 @@ textarea {
   flex: 1;
   display: flex;
   flex-direction: column;
-  
 }
 
 .aj-column-container {


### PR DESCRIPTION
## Détails

Il y a toujours un problème de CSS sur la page d'accueil du simulateur ; une marge blanche s'affiche avant le footer.

| Avant le correctif | Après le correctif |
|------------------|-------------------|
| <img width="1250" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/16650011/372214ca-d0e0-47c5-82e1-2742c4af4817"> |  <img width="1169" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/16650011/f49e5dfe-7414-4413-992c-1b19bd86ae35"> |

À noter que pour valider cette PR il faut : 
- contrôler que l'affichage ne pose pas de problème sur l'ensemble des pages du simulateur
- contrôler l'affichage mobile
- contrôler la page iframe