### PR TITLE
Ajoute le formatting css au hook de pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,9 @@
     ]
   },
   "lint-staged": {
-    "*.(css|js|json|ts|vue|yaml)": "prettier --write",
+    "*": [
+      "prettier --ignore-unknown --write"
+    ],
     "*.(js|ts|vue)": [
       "eslint  --max-warnings 0 --fix"
     ]


### PR DESCRIPTION
## Détails

La configuration de lint-staged ne prenait pas en compte les fichiers css, là où prettier les consultent.

Exemple d'échec de la CI : https://github.com/betagouv/aides-jeunes/actions/runs/5064959655/jobs/9093056560