### PR TITLE
fix: typo

### DIFF
--- a/src/views/iframe.vue
+++ b/src/views/iframe.vue
@@ -15,7 +15,7 @@ const fullScript = computed(() => {
   }${scriptPath}" ${options.value.join(" ")} data-theme="${
     selectedTheme.value
     // eslint-disable-next-line no-useless-escape
-  }""><\/script>`
+  }"><\/script>`
 })
 
 const setIframeContainer = () => {


### PR DESCRIPTION
## Détails

L'url du script d'inclusion de l'iframe a un `"` en trop