### PR TITLE
Supprime un warning sur la page de listing des aides

### DIFF
--- a/src/views/liste-aides.vue
+++ b/src/views/liste-aides.vue
@@ -51,7 +51,7 @@
               path: `/aides`,
               hash: `#${institution.id}`,
             }"
-            :aria-current="none"
+            aria-current="none"
           >
             {{ institution.label }}
           </router-link>
@@ -118,7 +118,7 @@ export default {
               departement.location == this.selectedCommune?.departement
           ),
           epci: institutionsBenefits["epci"].filter((epci) =>
-            epci?.location.includes(this.selectedCommune.code)
+            epci?.location.includes(this.selectedCommune?.code)
           ),
           commune: institutionsBenefits["commune"].filter(
             (commune) => commune?.location == this.selectedCommune?.code


### PR DESCRIPTION
## Détails

Le warning est dû à l'utilisation de l'attribut `:aria-current` au lieu de `aria-current`.

Pour une raison qui m'échappe le `console.warn()` n'est visible qu'en local et est déclenché par chaque titre d'institution : 
<img width="638" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/16650011/71709e32-01bb-4ebc-b864-d6f58fae8418">


Au passage ajout d'un failsafe sur le code de la commune sélectionné de manière à avoir le même comportement sur tous les types d'institution