### PR TITLE
Génération nom du type d'institution en minuscule

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -955,7 +955,7 @@ collections:
     delete: false
     editor:
       preview: false
-    slug: "{{name}}"
+    slug: "{{name | lowercase}}"
     extension: yml
     fields:
       - label: Nom de votre type d'institution


### PR DESCRIPTION
Il s'agit d'une tentative d'amélioration : pour que lors de la génération du nom de type d'institution, lorsqu'on utilise l'outil de contribution, celui-ci soit créé en lowercase. Il ne devrait plus y avoir d'erreur dans la CI.