### PR TITLE
Ajoute une page dédiée pour le formulaire d'envoi de récap par email

### DIFF
--- a/cypress/utils/results.js
+++ b/cypress/utils/results.js
@@ -68,7 +68,7 @@ const hasSituationNearbyPlaces = () => {
 const captureFiscalResources = () => {
   const name = /Livret d’épargne populaire/
   const id = "livret_epargne_populaire_taux"
-  cy.get('[data-testid="back-button"]').click()
+  back()
   IdentifyBenefit(id, name)
   getBenefitSummary(id).click()
   cy.get(`div[data-testid="benefit-detail-warning"]`)
@@ -209,6 +209,7 @@ const receiveResultsEmail = () => {
   })
 
   cy.get(".fr-alert__title").should("contain", "Succès")
+  back()
 }
 
 const checkResultsRequests = () => {

--- a/cypress/utils/results.js
+++ b/cypress/utils/results.js
@@ -1,4 +1,4 @@
-import { submit } from "./form"
+import { submit } from "./form.js"
 
 const wait = () => {
   cy.wait("@results")
@@ -196,7 +196,9 @@ const receiveResultsEmail = () => {
   })
     .should("be.visible")
     .click()
-  cy.get("input#email").should("be.visible").type("prenom.nom@beta.gouv.fr")
+  cy.get("input#email")
+    .should("be.visible")
+    .type("prenom.nom@beta.gouv.fr", { force: true })
   cy.get(".fr-btn:contains(J'accepte d'être recontacté)")
     .should("be.visible")
     .click()
@@ -205,6 +207,8 @@ const receiveResultsEmail = () => {
     expect(request.method).to.equal("POST")
     expect(response.statusCode).to.equal(200)
   })
+
+  cy.get(".fr-alert__title").should("contain", "Succès")
 }
 
 const checkResultsRequests = () => {

--- a/src/components/buttons/send-recap-email-button.vue
+++ b/src/components/buttons/send-recap-email-button.vue
@@ -25,7 +25,7 @@ export default {
     return {
       store: useStore(),
       experimentNewRecapEmail:
-        ABTestingService.getValues().recap_email === "NewPage",
+        ABTestingService.getValues().recap_email_form === "Page",
     }
   },
   methods: {

--- a/src/components/buttons/send-recap-email-button.vue
+++ b/src/components/buttons/send-recap-email-button.vue
@@ -3,7 +3,7 @@
     class="fr-btn fr-icon-mail-line fr-px-3v"
     data-fr-opened="false"
     aria-controls="fr-modal-email"
-    @click="showModal"
+    @click="sendRecapEmailButtonClick"
   >
     {{ text }}
   </button>
@@ -11,6 +11,7 @@
 
 <script>
 import { useStore } from "@/stores/index.ts"
+import ABTestingService from "@/plugins/ab-testing-service.js"
 
 export default {
   name: "SendRecapEmailButton",
@@ -23,11 +24,17 @@ export default {
   setup() {
     return {
       store: useStore(),
+      experimentNewRecapEmail:
+        ABTestingService.getValues().recap_email === "NewPage",
     }
   },
   methods: {
-    showModal() {
-      this.store.setRecapEmailState("show")
+    sendRecapEmailButtonClick() {
+      if (this.experimentNewRecapEmail) {
+        this.$router.push({ name: "resultatsRecapEmail" })
+      } else {
+        this.store.setRecapEmailState("show")
+      }
     },
   },
 }

--- a/src/components/buttons/send-recap-email-button.vue
+++ b/src/components/buttons/send-recap-email-button.vue
@@ -1,9 +1,17 @@
 <template>
   <button
+    v-if="experimentNewRecapEmail"
+    class="fr-btn fr-icon-mail-line fr-px-3v"
+    @click="goToEmailFormPage"
+  >
+    {{ text }}
+  </button>
+  <button
+    v-else
     class="fr-btn fr-icon-mail-line fr-px-3v"
     data-fr-opened="false"
     aria-controls="fr-modal-email"
-    @click="goToEmailForm"
+    @click="goToEmailFormModal"
   >
     {{ text }}
   </button>
@@ -29,12 +37,11 @@ export default {
     }
   },
   methods: {
-    goToEmailForm() {
-      if (this.experimentNewRecapEmail) {
-        this.$router.push({ name: "resultatsRecapEmail" })
-      } else {
-        this.store.setRecapEmailState("show")
-      }
+    goToEmailFormPage() {
+      this.$router.push({ name: "resultatsRecapEmail" })
+    },
+    goToEmailFormModal() {
+      this.store.setRecapEmailState("show")
     },
   },
 }

--- a/src/components/buttons/send-recap-email-button.vue
+++ b/src/components/buttons/send-recap-email-button.vue
@@ -3,7 +3,7 @@
     class="fr-btn fr-icon-mail-line fr-px-3v"
     data-fr-opened="false"
     aria-controls="fr-modal-email"
-    @click="sendRecapEmailButtonClick"
+    @click="goToEmailForm"
   >
     {{ text }}
   </button>
@@ -29,7 +29,7 @@ export default {
     }
   },
   methods: {
-    sendRecapEmailButtonClick() {
+    goToEmailForm() {
       if (this.experimentNewRecapEmail) {
         this.$router.push({ name: "resultatsRecapEmail" })
       } else {

--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -63,7 +63,7 @@ export default {
         return "Montant inattendu"
       }
       if (path === "/simulation/resultats/recapitulatif_email") {
-        return ""
+        return "Recevoir un récapitulatif par email"
       }
 
       const current = path.replace(/\/en_savoir_plus/, "")

--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -62,6 +62,9 @@ export default {
       if (path.includes("simulation/resultat/inattendu/")) {
         return "Montant inattendu"
       }
+      if (path === "/simulation/resultats/recapitulatif_email") {
+        return ""
+      }
 
       const current = path.replace(/\/en_savoir_plus/, "")
       const step =

--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -48,9 +48,7 @@ export default {
       return this.getTitleByRoute(this.$route)
     },
     showEmailButton() {
-      return (
-        this.store.recapEmailState !== "ok" && this.$route.name === "resultats"
-      )
+      return this.$route.name === "resultats"
     },
   },
   methods: {

--- a/src/mixins/resultats.js
+++ b/src/mixins/resultats.js
@@ -12,6 +12,11 @@ export default {
       return this.droits.length > 0
     },
     resultatsId() {
+      console.log("this.store", this.store)
+      console.log(
+        "this.resultats",
+        this.store.calculs.dirty && this.store.calculs.resultats
+      )
       return this.resultats?._id || "???"
     },
     accessStatus() {

--- a/src/mixins/resultats.js
+++ b/src/mixins/resultats.js
@@ -12,11 +12,6 @@ export default {
       return this.droits.length > 0
     },
     resultatsId() {
-      console.log("this.store", this.store)
-      console.log(
-        "this.resultats",
-        this.store.calculs.dirty && this.store.calculs.resultats
-      )
       return this.resultats?._id || "???"
     },
     accessStatus() {

--- a/src/plugins/ab-testing-service.js
+++ b/src/plugins/ab-testing-service.js
@@ -40,10 +40,9 @@ function getEnvironment() {
     (Math.random() > 0.5 ? "OldQuestion" : "NewQuestion")
 
   // Définition de la valeur d'AB testing pour le formulaire du récapitulatif par email
-  ABTesting.recap_email = ABTesting.recap_email || {}
-  ABTesting.recap_email.value =
-    ABTesting.recap_email.value ||
-    (Math.random() > 0.5 ? "ModalComponent" : "NewPage")
+  ABTesting.recap_email_form = ABTesting.recap_email_form || {}
+  ABTesting.recap_email_form.value =
+    ABTesting.recap_email_form.value || (Math.random() > 0.5 ? "Modal" : "Page")
 
   Object.keys(ABTesting).forEach(function (name) {
     const data = ABTesting[name]

--- a/src/plugins/ab-testing-service.js
+++ b/src/plugins/ab-testing-service.js
@@ -39,6 +39,12 @@ function getEnvironment() {
     ABTesting.en_couple_step.value ||
     (Math.random() > 0.5 ? "OldQuestion" : "NewQuestion")
 
+  // Définition de la valeur d'AB testing pour le formulaire du récapitulatif par email
+  ABTesting.recap_email = ABTesting.recap_email || {}
+  ABTesting.recap_email.value =
+    ABTesting.recap_email.value ||
+    (Math.random() > 0.5 ? "ModalComponent" : "NewPage")
+
   Object.keys(ABTesting).forEach(function (name) {
     const data = ABTesting[name]
     if (data.deleted) {

--- a/src/router.js
+++ b/src/router.js
@@ -302,7 +302,7 @@ const router = createRouter({
       redirect: () => {
         ABTestingService.setVariant("benefit_result_page", "NewUI")
         ABTestingService.setVariant("en_couple_step", "NewQuestion")
-        ABTestingService.setVariant("recap_email", "NewPage")
+        ABTestingService.setVariant("recap_email_form", "Page")
         return "/"
       },
     },

--- a/src/router.js
+++ b/src/router.js
@@ -302,6 +302,7 @@ const router = createRouter({
       redirect: () => {
         ABTestingService.setVariant("benefit_result_page", "NewUI")
         ABTestingService.setVariant("en_couple_step", "NewQuestion")
+        ABTestingService.setVariant("recap_email", "NewPage")
         return "/"
       },
     },

--- a/src/router.js
+++ b/src/router.js
@@ -241,6 +241,15 @@ const router = createRouter({
           path: "resultats/:droitId",
           component: () => import("./views/simulation/resultats-detail.vue"),
         },
+        {
+          name: "resultatsRecapEmail",
+          path: "resultats/recapitulatif_email",
+          component: () =>
+            import("./views/simulation/resultats/recap-email.vue"),
+          meta: {
+            headTitle: `Recevez par email le récapitulatif de vos réponses avec le simulateur d'aides ${context.name}`,
+          },
+        },
       ],
     },
     {

--- a/src/views/simulation/resultats/recap-email.vue
+++ b/src/views/simulation/resultats/recap-email.vue
@@ -25,7 +25,7 @@ const goBack = () => {
   router.push({ path: "/simulation/resultats" })
 }
 
-const getRecap = async (surveyOptin) => {
+const sendEmailRecap = async (surveyOptin) => {
   try {
     store.setRecapEmailState("waiting")
     if (emailRef.value && !emailRef.value.checkValidity()) {
@@ -92,7 +92,7 @@ const getRecap = async (surveyOptin) => {
             ><span class="fr-ml-2w">Envoi en cours…</span></p
           >
         </div>
-        <form class="fr-form fr-my-2w" @submit.prevent="getRecap(true)">
+        <form class="fr-form fr-my-2w" @submit.prevent="sendEmailRecap(true)">
           <div class="fr-form-group">
             <label class="fr-label" for="email"
               >Votre email
@@ -126,7 +126,7 @@ const getRecap = async (surveyOptin) => {
             <button
               :disabled="recapEmailState === 'waiting'"
               class="fr-btn"
-              @click.prevent="getRecap(true)"
+              @click.prevent="sendEmailRecap(true)"
             >
               J'accepte d'être recontacté ou recontactée par email
             </button>
@@ -135,7 +135,7 @@ const getRecap = async (surveyOptin) => {
             <button
               :disabled="recapEmailState === 'waiting'"
               class="fr-btn fr-btn--secondary"
-              @click.prevent="getRecap(false)"
+              @click.prevent="sendEmailRecap(false)"
             >
               Non merci, je préfère ne recevoir que le récapitulatif
             </button>

--- a/src/views/simulation/resultats/recap-email.vue
+++ b/src/views/simulation/resultats/recap-email.vue
@@ -55,93 +55,85 @@ const sendEmailRecap = async (surveyOptin) => {
 </script>
 
 <template>
-  <div class="fr-container">
-    <div class="fr-grid-row">
-      <BackButton
-        class="fr-btn--secondary fr-btn--sm fr-mb-2w"
-        data-testid="back-button"
-        @click="goBack"
-        >Retour aux résultats</BackButton
-      >
-      <div class="">
-        <h1 id="fr-modal-email-title" class="fr-modal__title"
-          >Recevoir un récapitulatif par email</h1
-        >
-        <p>
-          Si vous le souhaitez nous pouvons vous recontacter à deux reprises
-          pour faire le point sur les démarches que vous avez faites et les
-          blocages que vous avez rencontrés.
-        </p>
+  <div class="fr-grid-row">
+    <BackButton
+      class="fr-btn--secondary fr-btn--sm fr-mb-2w"
+      data-testid="back-button"
+      @click="goBack"
+      >Retour aux résultats</BackButton
+    >
+    <div>
+      <p>
+        Si vous le souhaitez nous pouvons vous recontacter à deux reprises pour
+        faire le point sur les démarches que vous avez faites et les blocages
+        que vous avez rencontrés.
+      </p>
 
-        <div
-          v-if="recapEmailState === 'error'"
-          class="fr-alert fr-alert--error"
+      <div v-if="recapEmailState === 'error'" class="fr-alert fr-alert--error">
+        <p>Une erreur s'est produite</p>
+      </div>
+      <div v-if="recapEmailState === 'ok'" class="fr-alert fr-alert--success">
+        <h3 class="fr-alert__title">Succès de l'envoi</h3>
+        <p>Un récapitulatif vous a été envoyé par email</p>
+      </div>
+      <div v-if="recapEmailState === 'waiting'">
+        <p
+          ><span
+            class="fr-icon--ml fr-icon-refresh-line fr-icon-spin"
+            aria-hidden="true"
+          ></span
+          ><span class="fr-ml-2w">Envoi en cours…</span></p
         >
-          <p>Une erreur s'est produite</p>
+      </div>
+      <form class="fr-form fr-my-2w" @submit.prevent="sendEmailRecap(true)">
+        <div class="fr-form-group">
+          <label class="fr-label" for="email"
+            >Votre email
+            <span class="fr-hint-text">Format attendu : nom@domaine.fr</span>
+          </label>
+          <input
+            id="email"
+            ref="emailRef"
+            v-model="emailValue"
+            name="email"
+            required
+            :aria-invalid="errorMessage"
+            :aria-describedBy="errorMessage ? 'invalid-email-warning' : null"
+            type="email"
+            class="fr-input"
+            autocomplete="email"
+            :disabled="recapEmailState === 'waiting'"
+          />
         </div>
-        <div v-if="recapEmailState === 'ok'" class="fr-alert fr-alert--success">
-          <h3 class="fr-alert__title">Succès de l'envoi</h3>
-          <p>Un récapitulatif vous a été envoyé par email</p>
-        </div>
-        <div v-if="recapEmailState === 'waiting'">
-          <p
-            ><span
-              class="fr-icon--ml fr-icon-refresh-line fr-icon-spin"
-              aria-hidden="true"
-            ></span
-            ><span class="fr-ml-2w">Envoi en cours…</span></p
+        <WarningMessage
+          v-if="errorMessage"
+          id="invalid-email-warning"
+          class="fr-mt-2w"
+          >Une adresse email valide doit être indiquée.
+        </WarningMessage>
+      </form>
+    </div>
+    <div class="">
+      <ul class="fr-btns-group">
+        <li>
+          <button
+            :disabled="recapEmailState === 'waiting'"
+            class="fr-btn"
+            @click.prevent="sendEmailRecap(true)"
           >
-        </div>
-        <form class="fr-form fr-my-2w" @submit.prevent="sendEmailRecap(true)">
-          <div class="fr-form-group">
-            <label class="fr-label" for="email"
-              >Votre email
-              <span class="fr-hint-text">Format attendu : nom@domaine.fr</span>
-            </label>
-            <input
-              id="email"
-              ref="emailRef"
-              v-model="emailValue"
-              name="email"
-              required
-              :aria-invalid="errorMessage"
-              :aria-describedBy="errorMessage ? 'invalid-email-warning' : null"
-              type="email"
-              class="fr-input"
-              autocomplete="email"
-              :disabled="recapEmailState === 'waiting'"
-            />
-          </div>
-          <WarningMessage
-            v-if="errorMessage"
-            id="invalid-email-warning"
-            class="fr-mt-2w"
-            >Une adresse email valide doit être indiquée.
-          </WarningMessage>
-        </form>
-      </div>
-      <div class="">
-        <ul class="fr-btns-group">
-          <li>
-            <button
-              :disabled="recapEmailState === 'waiting'"
-              class="fr-btn"
-              @click.prevent="sendEmailRecap(true)"
-            >
-              J'accepte d'être recontacté ou recontactée par email
-            </button>
-          </li>
-          <li>
-            <button
-              :disabled="recapEmailState === 'waiting'"
-              class="fr-btn fr-btn--secondary"
-              @click.prevent="sendEmailRecap(false)"
-            >
-              Non merci, je préfère ne recevoir que le récapitulatif
-            </button>
-          </li>
-        </ul>
-      </div>
+            J'accepte d'être recontacté ou recontactée par email
+          </button>
+        </li>
+        <li>
+          <button
+            :disabled="recapEmailState === 'waiting'"
+            class="fr-btn fr-btn--secondary"
+            @click.prevent="sendEmailRecap(false)"
+          >
+            Non merci, je préfère ne recevoir que le récapitulatif
+          </button>
+        </li>
+      </ul>
     </div>
   </div>
 </template>

--- a/src/views/simulation/resultats/recap-email.vue
+++ b/src/views/simulation/resultats/recap-email.vue
@@ -109,6 +109,7 @@ const getRecap = async (surveyOptin) => {
               type="email"
               class="fr-input"
               autocomplete="email"
+              :disabled="recapEmailState === 'waiting'"
             />
           </div>
           <WarningMessage

--- a/src/views/simulation/resultats/recap-email.vue
+++ b/src/views/simulation/resultats/recap-email.vue
@@ -145,5 +145,3 @@ const getRecap = async (surveyOptin) => {
     </div>
   </div>
 </template>
-
-<script></script>

--- a/src/views/simulation/resultats/recap-email.vue
+++ b/src/views/simulation/resultats/recap-email.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import axios from "axios"
+import WarningMessage from "@/components/warning-message.vue"
+import { useStore } from "@/stores/index.js"
+import { computed, ref } from "vue"
+import BackButton from "@/components/buttons/back-button.vue"
+import { useRouter } from "vue-router"
+import StatisticsMixin from "@/mixins/statistics.js"
+
+const router = useRouter()
+const store = useStore()
+const emailValue = ref(store.getFCUserInfoEmailValue)
+const emailRef = ref<HTMLFormElement>()
+const errorMessage = ref<boolean>()
+
+const recapEmailState = computed(() => {
+  return store.recapEmailState
+})
+
+const simulationId = computed(() => {
+  return !store.calculs.dirty && store.calculs.resultats?._id
+})
+
+const goBack = () => {
+  router.push({ path: "/simulation/resultats" })
+}
+
+const getRecap = async (surveyOptin) => {
+  try {
+    store.setRecapEmailState("waiting")
+    if (emailRef.value && !emailRef.value.checkValidity()) {
+      errorMessage.value = true
+      emailRef.value.focus()
+      StatisticsMixin.methods.sendEventToMatomo(
+        "General",
+        "Invalid form",
+        router.currentRoute.value.fullPath
+      )
+      return
+    }
+    errorMessage.value = false
+
+    const uri = `/api/simulation/${simulationId.value}/followup`
+    const payload = {
+      email: emailValue.value,
+      surveyOptin,
+    }
+    await axios.post(uri, payload)
+    store.setRecapEmailState("ok")
+    emailValue.value = ""
+  } catch (error) {
+    store.setRecapEmailState("error")
+  }
+}
+</script>
+
+<template>
+  <div class="fr-container">
+    <div class="fr-grid-row">
+      <BackButton
+        class="fr-btn--secondary fr-btn--sm fr-mb-2w"
+        data-testid="back-button"
+        @click="goBack"
+        >Retour aux résultats</BackButton
+      >
+      <div class="">
+        <h1 id="fr-modal-email-title" class="fr-modal__title"
+          >Recevoir un récapitulatif par email</h1
+        >
+        <p>
+          Si vous le souhaitez nous pouvons vous recontacter à deux reprises
+          pour faire le point sur les démarches que vous avez faites et les
+          blocages que vous avez rencontrés.
+        </p>
+
+        <div
+          v-if="recapEmailState === 'error'"
+          class="fr-alert fr-alert--error"
+        >
+          <p>Une erreur s'est produite</p>
+        </div>
+        <div v-if="recapEmailState === 'ok'" class="fr-alert fr-alert--success">
+          <h3 class="fr-alert__title">Succès de l'envoi</h3>
+          <p>Un récapitulatif vous a été envoyé par email</p>
+        </div>
+        <div v-if="recapEmailState === 'waiting'">
+          <p
+            ><span
+              class="fr-icon--ml fr-icon-refresh-line fr-icon-spin"
+              aria-hidden="true"
+            ></span
+            ><span class="fr-ml-2w">Envoi en cours…</span></p
+          >
+        </div>
+        <form class="fr-form fr-my-2w" @submit.prevent="getRecap(true)">
+          <div class="fr-form-group">
+            <label class="fr-label" for="email"
+              >Votre email
+              <span class="fr-hint-text">Format attendu : nom@domaine.fr</span>
+            </label>
+            <input
+              id="email"
+              ref="emailRef"
+              v-model="emailValue"
+              name="email"
+              required
+              :aria-invalid="errorMessage"
+              :aria-describedBy="errorMessage ? 'invalid-email-warning' : null"
+              type="email"
+              class="fr-input"
+              autocomplete="email"
+            />
+          </div>
+          <WarningMessage
+            v-if="errorMessage"
+            id="invalid-email-warning"
+            class="fr-mt-2w"
+            >Une adresse email valide doit être indiquée.
+          </WarningMessage>
+        </form>
+      </div>
+      <div class="">
+        <ul class="fr-btns-group">
+          <li>
+            <button
+              :disabled="recapEmailState === 'waiting'"
+              class="fr-btn"
+              @click.prevent="getRecap(true)"
+            >
+              J'accepte d'être recontacté ou recontactée par email
+            </button>
+          </li>
+          <li>
+            <button
+              :disabled="recapEmailState === 'waiting'"
+              class="fr-btn fr-btn--secondary"
+              @click.prevent="getRecap(false)"
+            >
+              Non merci, je préfère ne recevoir que le récapitulatif
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script></script>


### PR DESCRIPTION
[Tâche associée](https://trello.com/c/oSWLFtKi/1324-sortir-l%C3%A9cran-denvoi-dun-r%C3%A9cap-vers-une-vraie-page):


- [x]  Ajout d'une nouvelle page pour accéder au formulaire de récapitulatif de simulation par email
- [x] Ajout de l'AB testing: formulaire dans une fenêtre modale VS formulaire dans une nouvelle page
- [x] Modification de l'affichage du bouton d'accès au formulaire de recap (-> conservé même après l'envoi)
- [x] Correction et ajout de test e2e fixé sur la nouvelle version (nouvelle page)
