### PR TITLE
Augmente la taille maximum du titre de chapitre si aucun bouton n'est affiché

### DIFF
--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="fr-container--fluid fr-px-0 fr-py-2w">
-    <div class="fr-grid-row">
+    <div
+      v-if="shouldDisplayResults && hasDroits && showEmailButton"
+      class="fr-grid-row"
+    >
       <div class="fr-col-12 fr-col-md-6 fr-col-lg-6">
         <h1 class="fr-my-0 fr-mx-0">{{ title }}</h1>
       </div>
-      <div
-        v-if="shouldDisplayResults && hasDroits && showEmailButton"
-        class="fr-col-12 fr-col-md-6 fr-col-lg-6"
-      >
+      <div class="fr-col-12 fr-col-md-6 fr-col-lg-6">
         <ul
           class="fr-btns-group fr-btns-group--inline-md fr-btns-group--right fr-mt-1w fr-px-0"
         >
@@ -18,6 +18,11 @@
             ></SendRecapEmailButton>
           </li>
         </ul>
+      </div>
+    </div>
+    <div v-else class="fr-grid-row">
+      <div class="fr-col-12 fr-col-md-12 fr-col-lg-12">
+        <h1 class="fr-my-0 fr-mx-0">{{ title }}</h1>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Détails

Résout les problèmes d'affichage de titre sur la page d'email : 

Avant : 
<img width="812" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/16650011/deb1ee73-f7fd-426f-b6d9-eba874e898ec">


Après : 
<img width="814" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/16650011/3a2aa48a-3438-482d-bfa2-00fbfa00304d">
