### PR TITLE
1312 Partie 1 - Refacto partielle du composant resultats.vue

### DIFF
--- a/src/mixins/resultats.js
+++ b/src/mixins/resultats.js
@@ -70,11 +70,13 @@ export default {
 
       return lastestSimulation
     },
+    mockResultsNeeded() {
+      return this.$route.query.debug !== undefined
+    },
     mock(detail) {
-      if (this.$route.query.debug !== undefined) {
+      if (this.mockResultsNeeded()) {
         this.store.mockResults(detail || this.$route.query.debug)
       }
-      return this.$route.query.debug !== undefined
     },
     simulationAnonymized() {
       return this.store.simulation.status === SimulationStatusEnum.ANONYMIZED

--- a/src/views/simulation/resultats-detail.vue
+++ b/src/views/simulation/resultats-detail.vue
@@ -80,7 +80,8 @@ export default {
     },
   },
   mounted() {
-    if (this.mock(this.$route.params.droitId)) {
+    if (this.mockResultsNeeded()) {
+      this.mock(this.$route.params.droitId)
       return
     } else if (!this.droits) {
       this.restoreLatest()

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -124,11 +124,8 @@ export default {
   },
   mounted() {
     this.initializeStore()
+    this.handleLegacySituationId()
 
-    // Used for old links containing situationId instead of simulationId
-    if (this.$route.query?.situationId) {
-      this.$route.query.simulationId = this.$route.query.situationId
-    }
     if (this.mock(this.$route.params.droitId)) {
       return
     } else if (this.$route.query?.simulationId) {
@@ -223,6 +220,12 @@ export default {
           }
         })
       })
+    },
+    handleLegacySituationId() {
+      // Used for old links containing situationId instead of simulationId
+      if (this.$route.query?.situationId) {
+        this.store.setSimulationId(this.$route.query.situationId)
+      }
     },
   },
 }

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -137,11 +137,7 @@ export default {
       await this.saveSimulation()
     } else if (!this.store.hasResults) {
       if (this.store.simulation.teleservice) {
-        this.store
-          .fetchRepresentation(this.store.simulation.teleservice)
-          .then((representation) => {
-            window.location.href = representation.destination.url
-          })
+        await this.redirectToTeleservice()
       } else {
         this.store.compute()
       }
@@ -232,6 +228,13 @@ export default {
         this.sendEventToMatomo("General", "Erreur sauvegarde simulation")
       }
     },
+  },
+  async redirectToTeleservice() {
+    const representation = await this.store.fetchRepresentation(
+      this.store.simulation.teleservice
+    )
+
+    window.location.href = representation.destination.url
   },
 }
 </script>

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -133,19 +133,17 @@ export default {
       await this.handleSimulationIdQuery()
     } else if (!this.store.passSanityCheck) {
       this.restoreLatest()
-    } else {
-      if (this.store.calculs.dirty) {
-        await this.saveSimulation()
-      } else if (!this.store.hasResults) {
-        if (this.store.simulation.teleservice) {
-          this.store
-            .fetchRepresentation(this.store.simulation.teleservice)
-            .then((representation) => {
-              window.location.href = representation.destination.url
-            })
-        } else {
-          this.store.compute()
-        }
+    } else if (this.store.calculs.dirty) {
+      await this.saveSimulation()
+    } else if (!this.store.hasResults) {
+      if (this.store.simulation.teleservice) {
+        this.store
+          .fetchRepresentation(this.store.simulation.teleservice)
+          .then((representation) => {
+            window.location.href = representation.destination.url
+          })
+      } else {
+        this.store.compute()
       }
     }
   },

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -135,20 +135,7 @@ export default {
       this.restoreLatest()
     } else {
       if (this.store.calculs.dirty) {
-        const vm = this
-        this.store.setSaveSituationError(null)
-        this.store
-          .save()
-          .then(() => {
-            if (vm.store.access.forbidden) {
-              return
-            }
-            return vm.store.compute()
-          })
-          .catch((error) => {
-            this.store.setSaveSituationError(error.response?.data || error)
-            this.sendEventToMatomo("General", "Erreur sauvegarde simulation")
-          })
+        await this.saveSimulation()
       } else if (!this.store.hasResults) {
         if (this.store.simulation.teleservice) {
           this.store
@@ -233,6 +220,19 @@ export default {
       }
 
       this.$router.replace({ simulationId: null })
+    },
+    async saveSimulation() {
+      try {
+        this.store.setSaveSituationError(null)
+        await this.store.save()
+
+        if (!this.store.access.forbidden) {
+          this.store.compute()
+        }
+      } catch (error) {
+        this.store.setSaveSituationError(error.response?.data || error)
+        this.sendEventToMatomo("General", "Erreur sauvegarde simulation")
+      }
     },
   },
 }

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -123,23 +123,7 @@ export default {
     }
   },
   mounted() {
-    this.store.updateCurrentAnswers(this.$route.path)
-
-    this.stopSubscription = this.store.$onAction(({ after, name }) => {
-      after(() => {
-        switch (name) {
-          case "setResults": {
-            this.sendShowStatistics()
-            this.sendDisplayUnexpectedAmountLinkStatistics()
-            break
-          }
-          case "saveComputationFailure": {
-            this.sendEventToMatomo("General", "Error")
-            break
-          }
-        }
-      })
-    })
+    this.initializeStore()
 
     // Used for old links containing situationId instead of simulationId
     if (this.$route.query?.situationId) {
@@ -220,6 +204,25 @@ export default {
         "Accès simulation anonymisée",
         daysSinceDate(new Date(this.store.simulation.dateDeValeur))
       )
+    },
+    initializeStore() {
+      this.store.updateCurrentAnswers(this.$route.path)
+
+      this.stopSubscription = this.store.$onAction(({ after, name }) => {
+        after(() => {
+          switch (name) {
+            case "setResults": {
+              this.sendShowStatistics()
+              this.sendDisplayUnexpectedAmountLinkStatistics()
+              break
+            }
+            case "saveComputationFailure": {
+              this.sendEventToMatomo("General", "Error")
+              break
+            }
+          }
+        })
+      })
     },
   },
 }

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -126,7 +126,8 @@ export default {
     this.initializeStore()
     this.handleLegacySituationId()
 
-    if (this.mock(this.$route.params.droitId)) {
+    if (this.mockResultsNeeded()) {
+      this.mock(this.$route.params.droitId)
       return
     } else if (this.$route.query?.simulationId) {
       if (this.store.simulationId !== this.$route.query.simulationId) {

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -122,7 +122,7 @@ export default {
       store: useStore(),
     }
   },
-  mounted() {
+  async mounted() {
     this.initializeStore()
     this.handleLegacySituationId()
 
@@ -130,16 +130,7 @@ export default {
       this.mock(this.$route.params.droitId)
       return
     } else if (this.$route.query?.simulationId) {
-      if (this.store.simulationId !== this.$route.query.simulationId) {
-        this.store.fetch(this.$route.query.simulationId).then(() => {
-          if (this.simulationAnonymized()) {
-            this.sendAccessToAnonymizedResults()
-          } else {
-            this.store.compute()
-          }
-          this.$router.replace({ simulationId: null })
-        })
-      } // Else nothing to do
+      await this.handleSimulationIdQuery()
     } else if (!this.store.passSanityCheck) {
       this.restoreLatest()
     } else {
@@ -227,6 +218,21 @@ export default {
       if (this.$route.query?.situationId) {
         this.store.setSimulationId(this.$route.query.situationId)
       }
+    },
+    async handleSimulationIdQuery() {
+      if (this.store.simulationId === this.$route.query.simulationId) {
+        return
+      }
+
+      await this.store.fetch(this.$route.query.simulationId)
+
+      if (this.simulationAnonymized()) {
+        this.sendAccessToAnonymizedResults()
+      } else {
+        this.store.compute()
+      }
+
+      this.$router.replace({ simulationId: null })
     },
   },
 }


### PR DESCRIPTION
Première partie pour le ticket : https://trello.com/c/L5MnjwTc/1312-permettre-laffichage-des-r%C3%A9sultats-pour-une-simulation-anonymis%C3%A9e-mais-qui-a-un-followup?search_id=cceb87cc-627c-428e-88c0-a4cd757d1893

Pour le moment que de la "refacto" qui consiste à bouger du code dans des fonctions séparé (1). Lisible commit par commit.

PR à venir : afficher les droits d'une simulation anonymisée si elle a un followup. 
(1) selon moi l'avantage même si ça reste encore pas facile à lire c'est de nommer les cas et d'aplatir un peu le `if` qui est dans `mounted` 