### PR TITLE
Renomme type géographique en type d'institution

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -914,7 +914,7 @@ collections:
             '(\.png|\.jpg|\.jpeg)',
             "Seul les images au format JPG et PNG sont supportées",
           ]
-      - label: Type géographique
+      - label: Type d'institution
         name: type
         widget: relation
         collection: institution_types


### PR DESCRIPTION
## Détails

Dans l'outil de contribution, le filtre d'institution s'appelait "Type géographique" et listait plusieurs choix incohérents avec cette appelation ; région, commune, CAF, MSA etc.

Cette PR remplace le terme "Type géographique" par "Type d'institution"