### PR TITLE
[Fix] Masque le bouton de connexion si l'utilisateur est déjà connecté

### DIFF
--- a/src/views/simulation.vue
+++ b/src/views/simulation.vue
@@ -106,7 +106,8 @@ export default {
         this.$route.query["france-connect-enabled"] === "true" &&
         process.env.VITE_FRANCE_CONNECT_ENABLED &&
         this.store.getAllSteps[1].path === this.$route.path &&
-        this.store.simulation.answers.all.length === 0
+        this.store.simulation.answers.all.length === 0 &&
+        !this.franceConnectConnected()
       )
     },
     franceConnectError() {


### PR DESCRIPTION
## Détails

[Tâche Trello](https://trello.com/c/do4HPWm8/1335-bug-il-est-possible-d%C3%AAtre-connect%C3%A9-avec-france-connect-et-de-voir-le-bouton-de-connexion-de-france-connect)