### PR TITLE
1312 permettre laffichage des resultats pour une simulation anonymisee mais qui a un followup pt2

### DIFF
--- a/backend/routes/simulation.ts
+++ b/backend/routes/simulation.ts
@@ -26,6 +26,7 @@ export default function (api) {
   route.get("/", simulationController.show)
   route.get("/openfisca-response", simulationController.openfiscaResponse)
   route.get("/results", simulationController.results)
+  route.get("/followup", simulationController.getLatestFollowup)
 
   route.get(
     "/redirect",

--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -48,7 +48,9 @@ export default {
       return this.getTitleByRoute(this.$route)
     },
     showEmailButton() {
-      return this.$route.name === "resultats"
+      return (
+        this.$route.name === "resultats" && !this.store.simulationAnonymized
+      )
     },
   },
   methods: {
@@ -66,7 +68,7 @@ export default {
 
       const current = path.replace(/\/en_savoir_plus/, "")
       const step =
-        this.store.passSanityCheck &&
+        (this.store.passSanityCheck || this.store.simulationAnonymized) &&
         this.$state.current(current, this.store.getAllSteps)
       const chapterName = step?.chapter || ""
       return Chapters.getLabel(chapterName)

--- a/src/lib/simulation.ts
+++ b/src/lib/simulation.ts
@@ -1,5 +1,5 @@
 export default {
-  getLatest: function (): string | undefined {
+  getLatestId: function (): string | undefined {
     return document.cookie
       .split("; ")
       .reduce<Record<string, string>>((accum, pair) => {

--- a/src/mixins/resultats.js
+++ b/src/mixins/resultats.js
@@ -52,7 +52,7 @@ export default {
         this.store.calculs.resultats.droitsEligibles
       )
     },
-    restoreLatest() {
+    async restoreLatest() {
       const lastestSimulationId = Simulation.getLatestId()
       if (!lastestSimulationId) {
         this.sendEventToMatomo(
@@ -70,13 +70,13 @@ export default {
         this.$route.path
       )
 
-      this.store.fetch(lastestSimulationId).then(async () => {
-        if (this.simulationAnonymized) {
-          await this.store.retrieveResultsAlreadyComputed()
-        } else {
-          this.store.computeResults()
-        }
-      })
+      await this.store.fetch(lastestSimulationId)
+
+      if (this.simulationAnonymized) {
+        await this.store.retrieveResultsAlreadyComputed()
+      } else {
+        this.store.computeResults()
+      }
     },
     mockResultsNeeded() {
       return this.$route.query.debug !== undefined

--- a/src/mixins/resultats.js
+++ b/src/mixins/resultats.js
@@ -35,12 +35,8 @@ export default {
     },
     shouldDisplayResults() {
       return (
-        !(
-          this.resultatStatus.updating ||
-          this.hasWarning ||
-          this.hasError ||
-          this.simulationAnonymized()
-        ) && this.droits
+        !(this.resultatStatus.updating || this.hasWarning || this.hasError) &&
+        this.droits
       )
     },
     ressourcesYearMinusTwoCaptured() {
@@ -71,8 +67,11 @@ export default {
         "compute",
         this.$route.path
       )
-      this.store.fetch(lastestSimulationId).then(() => {
-        if (!this.simulationAnonymized()) {
+
+      this.store.fetch(lastestSimulationId).then(async () => {
+        if (this.simulationAnonymized) {
+          await this.store.retrieveResultsAlreadyComputed()
+        } else {
           this.store.computeResults()
         }
       })
@@ -87,6 +86,9 @@ export default {
     },
     simulationAnonymized() {
       return this.store.simulation.status === SimulationStatusEnum.ANONYMIZED
+    },
+    displaySimulationUnavailable() {
+      return this.simulationAnonymized() && !this.store.followup
     },
   },
 }

--- a/src/mixins/resultats.js
+++ b/src/mixins/resultats.js
@@ -1,6 +1,5 @@
 import Simulation from "@/lib/simulation.ts"
 import StatisticsMixin from "@/mixins/statistics.ts"
-import { SimulationStatusEnum } from "@lib/enums/simulation.ts"
 import { EventCategories } from "@lib/enums/event-categories.ts"
 
 export default {
@@ -41,6 +40,9 @@ export default {
     },
     ressourcesYearMinusTwoCaptured() {
       return this.store.ressourcesYearMinusTwoCaptured
+    },
+    simulationAnonymized() {
+      return this.store.simulationAnonymized
     },
   },
   methods: {
@@ -84,11 +86,8 @@ export default {
         this.store.mockResults(detail || this.$route.query.debug)
       }
     },
-    simulationAnonymized() {
-      return this.store.simulation.status === SimulationStatusEnum.ANONYMIZED
-    },
     displaySimulationUnavailable() {
-      return this.simulationAnonymized() && !this.store.followup
+      return this.simulationAnonymized && !this.store.followup
     },
   },
 }

--- a/src/mixins/resultats.js
+++ b/src/mixins/resultats.js
@@ -55,8 +55,8 @@ export default {
       )
     },
     restoreLatest() {
-      const lastestSimulation = Simulation.getLatest()
-      if (!lastestSimulation) {
+      const lastestSimulationId = Simulation.getLatestId()
+      if (!lastestSimulationId) {
         this.sendEventToMatomo(
           EventCategories.GENERAL,
           "redirection",
@@ -71,13 +71,11 @@ export default {
         "compute",
         this.$route.path
       )
-      this.store.fetch(lastestSimulation).then(() => {
+      this.store.fetch(lastestSimulationId).then(() => {
         if (!this.simulationAnonymized()) {
-          this.store.compute()
+          this.store.computeResults()
         }
       })
-
-      return lastestSimulation
     },
     mockResultsNeeded() {
       return this.$route.query.debug !== undefined

--- a/src/router.js
+++ b/src/router.js
@@ -55,7 +55,7 @@ const router = createRouter({
           beforeEnter(to, from, next) {
             const store = useStore()
             store
-              .fetch(Simulation.getLatest())
+              .fetch(Simulation.getLatestId())
               .then(() => {
                 next(`/simulation${to.query.to || ""}`)
               })

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -502,6 +502,25 @@ export const useStore = defineStore("store", {
           this.saveComputationFailure(error)
         })
     },
+    async retrieveResultsAlreadyComputed() {
+      try {
+        this.startComputation()
+        const token = this.getSimulationToken
+        const headers = token ? { Authorization: `Bearer ${token}` } : undefined
+
+        const { data } = await axios.get(
+          `/api/simulation/${this.simulationId}/followup`,
+          {
+            headers,
+          }
+        )
+
+        this.followup = data
+        this.setResults({ droitsEligibles: this.followup.benefits })
+      } catch (error) {
+        this.saveComputationFailure(error)
+      }
+    },
     setMessage(message: string, counter?: number) {
       this.message = {
         text: message,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -484,21 +484,16 @@ export const useStore = defineStore("store", {
       this.calculs.error = true
       this.calculs.exception = (error.response && error.response.data) || error
     },
-    compute(showPrivate: boolean) {
+    computeResults() {
       this.startComputation()
       const token = this.getSimulationToken
       const headers = {
         ...(token && { Authorization: `Bearer ${token}` }),
       }
       return axios
-        .get(
-          `/api/simulation/${this.simulationId}/results${
-            showPrivate ? "&showPrivate" : ""
-          }`,
-          {
-            headers,
-          }
-        )
+        .get(`/api/simulation/${this.simulationId}/results`, {
+          headers,
+        })
         .then((response) => {
           return response.data
         })

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -19,6 +19,7 @@ import {
   Situation,
   Store,
 } from "@lib/types/store"
+import { SimulationStatusEnum } from "@lib/enums/simulation.ts"
 
 function defaultCalculs(): Calculs {
   return {
@@ -246,6 +247,9 @@ export const useStore = defineStore("store", {
           answer.fieldName === "userinfo"
       )
       return userinfo?.value["email"]
+    },
+    simulationAnonymized(): boolean {
+      return this.simulation.status === SimulationStatusEnum.ANONYMIZED
     },
   },
   actions: {

--- a/src/views/simulation.vue
+++ b/src/views/simulation.vue
@@ -1,11 +1,15 @@
 <template>
   <ProgressBar></ProgressBar>
   <div class="fr-grid-row aj-column-container">
-    <div class="fr-col-12 fr-col-md-3 aj-main-container">
+    <div v-if="showSummary" class="fr-col-12 fr-col-md-3 aj-main-container">
       <Progress v-if="debug" />
       <Summary v-else />
     </div>
-    <div class="fr-col-12 fr-col-md-9 fr-p-2w">
+    <div
+      :class="`fr-col-12 fr-p-2w ${
+        showSummary ? 'fr-col-md-9' : 'fr-col-md-12'
+      }`"
+    >
       <TitreChapitre />
       <div v-if="debug" class="fr-mb-md-2w">
         <button class="fr-btn fr-btn--sm" @click="disableDebug"
@@ -96,7 +100,7 @@ export default {
   },
   computed: {
     showSummary() {
-      return this.$route.path !== "/simulation/recapitulatif"
+      return !this.store.simulationAnonymized
     },
     debug() {
       return this.store.getDebug

--- a/src/views/simulation/resultats-detail.vue
+++ b/src/views/simulation/resultats-detail.vue
@@ -79,12 +79,12 @@ export default {
       return this.store.ressourcesYearMinusTwoCaptured
     },
   },
-  mounted() {
+  async mounted() {
     if (this.mockResultsNeeded()) {
       this.mock(this.$route.params.benefitId)
       return
     } else if (!this.droits) {
-      this.restoreLatest()
+      await this.restoreLatest()
     } else {
       const benefitId = this.$route.params.benefitId
 

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -136,7 +136,7 @@ export default {
     } else if (this.$route.query?.simulationId) {
       await this.handleSimulationIdQuery()
     } else if (!this.store.passSanityCheck) {
-      this.restoreLatest()
+      await this.restoreLatest()
     } else if (this.store.calculs.dirty) {
       await this.saveSimulation()
     } else if (!this.store.hasResults) {

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -214,7 +214,7 @@ export default {
 
       await this.store.fetch(this.$route.query.simulationId)
 
-      if (this.simulationAnonymized()) {
+      if (this.simulationAnonymized) {
         this.sendAccessToAnonymizedResults()
         await this.store.retrieveResultsAlreadyComputed()
       } else {

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -20,7 +20,10 @@
     </div>
   </WarningMessage>
 
-  <div v-if="simulationAnonymized()" class="fr-alert fr-alert--info fr-my-1w">
+  <div
+    v-if="displaySimulationUnavailable()"
+    class="fr-alert fr-alert--info fr-my-1w"
+  >
     <div>
       <h2 class="fr-text--lead">
         Vos résultats de simulation ne sont plus disponibles
@@ -202,7 +205,10 @@ export default {
       }
     },
     async handleSimulationIdQuery() {
-      if (this.store.simulationId === this.$route.query.simulationId) {
+      if (
+        this.store.simulationId === this.$route.query.simulationId &&
+        this.store.hasResults
+      ) {
         return
       }
 
@@ -210,6 +216,7 @@ export default {
 
       if (this.simulationAnonymized()) {
         this.sendAccessToAnonymizedResults()
+        await this.store.retrieveResultsAlreadyComputed()
       } else {
         this.store.computeResults()
       }

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -140,7 +140,7 @@ export default {
       if (this.store.simulation.teleservice) {
         await this.redirectToTeleservice()
       } else {
-        this.store.compute()
+        this.store.computeResults()
       }
     }
   },
@@ -211,7 +211,7 @@ export default {
       if (this.simulationAnonymized()) {
         this.sendAccessToAnonymizedResults()
       } else {
-        this.store.compute()
+        this.store.computeResults()
       }
 
       this.$router.replace({ simulationId: null })
@@ -222,7 +222,7 @@ export default {
         await this.store.save()
 
         if (!this.store.access.forbidden) {
-          this.store.compute()
+          this.store.computeResults()
         }
       } catch (error) {
         this.store.setSaveSituationError(error.response?.data || error)


### PR DESCRIPTION
Ticket : https://trello.com/c/L5MnjwTc/1312-permettre-laffichage-des-r%C3%A9sultats-pour-une-simulation-anonymis%C3%A9e-mais-qui-a-un-followup

TLDR: pouvoir visualiser les résultats d'un followup même si la simulation est anonymisée.

Pour tester : 
- Avoir l'id d'un followup lié à une simulation anonymisée (possibilité de faire tourner le script `ts-node tools/cleaner.ts`)
- Aller sur l'url `localhost:8080/followups/{followupId}?token={accessToken}`
- La page doit s'afficher correctement sans le Summary ni le bouton pour entrer son address email
- Faire de même avec un followup lié à une simulation non anonymisée et constater qu'il n'y a pas de soucis

Visuel : 
<img width="1217" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/4059803/d1346cee-4775-4b27-8f83-c546ff19f3db">
(cas d'une simulation anoymisée)

<img width="1234" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/4059803/0a5562ac-2cd7-44b8-b2f2-a121e752984f">

(cas où la simulation n'est pas anonyisée)