### PR TITLE
feat: use config to get sentry auth token

### DIFF
--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -80,6 +80,7 @@ const all: ConfigurationLayout = {
   },
   sentry: {
     dsn: process.env.SENTRY_BACKEND_URL || undefined,
+    authToken: process.env.SENTRY_AUTH_TOKEN || undefined,
   },
   sessionSecret: process.env.SESSION_SECRET || "fghjdfjkdf785a-jreu",
   mattermost_post_url: process.env.MATTERMOST_POST_URL || "",

--- a/backend/types/config.d.ts
+++ b/backend/types/config.d.ts
@@ -54,5 +54,6 @@ export interface ConfigurationLayout {
   iframeTitle: string
   sentry: {
     dsn: string | undefined
+    authToken: string | undefined
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,11 @@ const {
   netlifyContributionURL,
   statistics,
   franceConnect,
+  sentry,
 } = config
 
 function createSentryPlugin() {
-  if (!process.env.SENTRY_AUTH_TOKEN) {
+  if (!sentry.authToken) {
     return null
   }
 
@@ -32,7 +33,7 @@ function createSentryPlugin() {
     org: "betagouv",
     project: "aides-jeunes-front",
     include: "./dist",
-    authToken: process.env.SENTRY_AUTH_TOKEN,
+    authToken: sentry.authToken,
     url: "https://sentry.incubateur.net/",
   })
 }


### PR DESCRIPTION
Le but de cette PR c'est de pouvoir modifier les `prodution.ts/js` sur eclipse pour ajouter un token Sentry. Cela va normalement permettre que pendant le `npm run prestart` le SourceMap soit envoyé à Sentry.

Comment tester : 
Mis à part de tenter du push le sourceMap sur sentry (a priori pas d'impact car il l'utilise seulement si la prod l'envoi, enfin dans le pire des cas on aura un warning).
- Récupérer un token sentry : https://sentry.incubateur.net/settings/account/api/auth-tokens/
- Modifier / Ajouter les fichiers `production.js` et `production.ts` dans `backend/config` avec le token au bon endroit. Ça peut être pas mal de partir du fichier `development.ts` afin de ciblé la base de donnée local (sinon faudra mettre la variable d'env)
- Faire une `NODE_ENV=production npm run prestart` 
- Vérifier qu'on a bien un nouveau sourceMap ici : https://sentry.incubateur.net/settings/betagouv/projects/aides-jeunes-front/source-maps/ (attention, si quelqu'un a push la même version que vous en amont ça apparaîtra pas)

C'est aussi ce qu'il faudra faire sur eclipse une fois la PR merge