### PR TITLE
fix: TypeError: this.franceConnectConnected is not a function

### DIFF
--- a/src/views/simulation.vue
+++ b/src/views/simulation.vue
@@ -107,7 +107,7 @@ export default {
         process.env.VITE_FRANCE_CONNECT_ENABLED &&
         this.store.getAllSteps[1].path === this.$route.path &&
         this.store.simulation.answers.all.length === 0 &&
-        !this.franceConnectConnected()
+        !this.franceConnectConnected
       )
     },
     franceConnectError() {


### PR DESCRIPTION
On a introduit un bug en essayant d'en fix un autre : les **computed** ne sont pas des function => on enlève les parenthèses : 
https://github.com/betagouv/aides-jeunes/blob/b911200517d9408a5251917ef38ab2735c4d683d/src/views/simulation.vue#L110