### PR TITLE
feat: Add enum for event categories sent to matomo

### DIFF
--- a/lib/enums/event-categories.ts
+++ b/lib/enums/event-categories.ts
@@ -1,0 +1,9 @@
+// Notez que toutes les clés sont maintenant en français,
+// mais pour la continuité sur Matomo nous gardons les valeurs anglaises
+export enum EventCategories {
+  DEFAUT = "defaultCategory",
+  GENERAL = "General",
+  PARCOURS = "Parcours",
+  ACCOMPAGNEMENT = "Accompaniment",
+  MONTANT_ATTENDU = "Montant attendu",
+}

--- a/src/components/en-savoir-plus.vue
+++ b/src/components/en-savoir-plus.vue
@@ -13,6 +13,7 @@
 <script>
 import Hint from "@/lib/hint.ts"
 import StatisticsMixin from "@/mixins/statistics.ts"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 export default {
   name: "EnSavoirPlus",
@@ -30,7 +31,11 @@ export default {
   },
   methods: {
     trackInterest() {
-      this.sendEventToMatomo("Parcours", "En savoir plus", this.$route.path)
+      this.sendEventToMatomo(
+        EventCategories.PARCOURS,
+        "En savoir plus",
+        this.$route.path
+      )
     },
   },
 }

--- a/src/components/input-depcom.vue
+++ b/src/components/input-depcom.vue
@@ -70,6 +70,7 @@ import Commune from "@/lib/commune.ts"
 import EnSavoirPlus from "@/components/en-savoir-plus.vue"
 import { useStore } from "@/stores/index.ts"
 import StatisticsMixin from "@/mixins/statistics.ts"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 export default {
   name: "InputDepCom",
@@ -140,7 +141,7 @@ export default {
         .then((communes) => {
           if (communes.length <= 0) {
             this.sendEventToMatomo(
-              "General",
+              EventCategories.GENERAL,
               "Depcom introuvable",
               `Code postal : ${this.codePostalValue}`
             )

--- a/src/components/modals/recap-email-modal.vue
+++ b/src/components/modals/recap-email-modal.vue
@@ -115,6 +115,7 @@ import axios from "axios"
 import WarningMessage from "@/components/warning-message.vue"
 import { useStore } from "@/stores/index.ts"
 import StatisticsMixin from "@/mixins/statistics.ts"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 export default {
   name: "RecapEmailModal",
@@ -149,7 +150,11 @@ export default {
       if (!this.$refs.form.checkValidity()) {
         this.errorMessage = true
         this.$refs.email.focus()
-        this.sendEventToMatomo("General", "Invalid form", this.$route.fullPath)
+        this.sendEventToMatomo(
+          EventCategories.GENERAL,
+          "Invalid form",
+          this.$route.fullPath
+        )
 
         return
       }

--- a/src/directives/analytics.ts
+++ b/src/directives/analytics.ts
@@ -6,6 +6,7 @@ import {
   IMatomoEvent,
   sendEventToMatomo,
 } from "@/lib/statistics-service/matomo.js"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 const AnalyticsDirective = {
   beforeMount(el, binding) {
@@ -19,7 +20,7 @@ const AnalyticsDirective = {
       sendEventToRecorder(recorderEvent, binding?.instance?.$matomo)
 
       const matomoEvent: IMatomoEvent = {
-        category: binding.value.category || "defaultCategory",
+        category: binding.value.category || EventCategories.DEFAUT,
         action: binding.value.action,
         label: binding.value.name,
         value: binding.value.value,

--- a/src/lib/statistics-service/matomo.ts
+++ b/src/lib/statistics-service/matomo.ts
@@ -1,9 +1,10 @@
 import { skipSendStatistics } from "./shared.js"
+import { EventCategories } from "@lib/enums/event-categories.js"
 
 const isProduction = process.env.NODE_ENV === "production"
 
 export interface IMatomoEvent {
-  category: string
+  category: EventCategories
   action: string
   label: string
   value?: string
@@ -11,7 +12,7 @@ export interface IMatomoEvent {
 
 export interface IMatomo {
   trackEvent: (
-    category: string,
+    category: EventCategories,
     action: string,
     label: string,
     value?: string

--- a/src/mixins/resultats.js
+++ b/src/mixins/resultats.js
@@ -1,6 +1,7 @@
 import Simulation from "@/lib/simulation.ts"
 import StatisticsMixin from "@/mixins/statistics.ts"
 import { SimulationStatusEnum } from "@lib/enums/simulation.ts"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 export default {
   mixins: [StatisticsMixin],
@@ -56,12 +57,20 @@ export default {
     restoreLatest() {
       const lastestSimulation = Simulation.getLatest()
       if (!lastestSimulation) {
-        this.sendEventToMatomo("General", "redirection", this.$route.path)
+        this.sendEventToMatomo(
+          EventCategories.GENERAL,
+          "redirection",
+          this.$route.path
+        )
 
         return this.store.redirection((route) => this.$router.push(route))
       }
 
-      this.sendEventToMatomo("General", "compute", this.$route.path)
+      this.sendEventToMatomo(
+        EventCategories.GENERAL,
+        "compute",
+        this.$route.path
+      )
       this.store.fetch(lastestSimulation).then(() => {
         if (!this.simulationAnonymized()) {
           this.store.compute()

--- a/src/mixins/statistics.ts
+++ b/src/mixins/statistics.ts
@@ -8,8 +8,7 @@ import {
   sendEventToMatomo,
 } from "@/lib/statistics-service/matomo.js"
 import { BehaviourEventTypes } from "@lib/enums/behaviour-event-types.js"
-
-const BenefitMatomoEventCategory = "General"
+import { EventCategories } from "@lib/enums/event-categories.js"
 
 export default {
   methods: {
@@ -27,7 +26,7 @@ export default {
       sendEventToRecorder(event, this.$matomo)
     },
     sendEventToMatomo: function (
-      category: string,
+      category: EventCategories,
       action: string,
       label: string,
       value?: string
@@ -53,11 +52,7 @@ export default {
           continue
         }
 
-        this.sendEventToMatomo(
-          BenefitMatomoEventCategory,
-          event_type,
-          benefit.id
-        )
+        this.sendEventToMatomo(EventCategories.GENERAL, event_type, benefit.id)
       }
     },
   },

--- a/src/plugins/state-service.js
+++ b/src/plugins/state-service.js
@@ -2,6 +2,7 @@ import { getNextStep, current, getChapters } from "@lib/state"
 import { isNavigationFailure, NavigationFailureType } from "vue-router"
 import { useStore } from "@/stores/index.ts"
 import { sendEventToMatomo } from "@/lib/statistics-service/matomo.ts"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 const StateService = {
   install(app) {
@@ -19,7 +20,7 @@ const StateService = {
         if (isNavigationFailure(failure, NavigationFailureType.cancelled)) {
           sendEventToMatomo(
             {
-              category: "Parcours",
+              category: EventCategories.PARCOURS,
               action: "Navigation cancelled",
               label: failure.toString(),
             },

--- a/src/views/simulation/resultats.vue
+++ b/src/views/simulation/resultats.vue
@@ -102,6 +102,7 @@ import Recapitulatif from "./recapitulatif.vue"
 import { useStore } from "@/stores/index.ts"
 import { BehaviourEventTypes } from "@lib/enums/behaviour-event-types.ts"
 import { daysSinceDate } from "@lib/utils.ts"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 export default {
   name: "SimulationResultats",
@@ -170,7 +171,7 @@ export default {
     },
     sendAccessToAnonymizedResults() {
       this.sendEventToMatomo(
-        "General",
+        EventCategories.GENERAL,
         "Accès simulation anonymisée",
         daysSinceDate(new Date(this.store.simulation.dateDeValeur))
       )
@@ -187,7 +188,7 @@ export default {
               break
             }
             case "saveComputationFailure": {
-              this.sendEventToMatomo("General", "Error")
+              this.sendEventToMatomo(EventCategories.GENERAL, "Error")
               break
             }
           }
@@ -225,7 +226,10 @@ export default {
         }
       } catch (error) {
         this.store.setSaveSituationError(error.response?.data || error)
-        this.sendEventToMatomo("General", "Erreur sauvegarde simulation")
+        this.sendEventToMatomo(
+          EventCategories.GENERAL,
+          "Erreur sauvegarde simulation"
+        )
       }
     },
   },

--- a/src/views/simulation/resultats/attendu.vue
+++ b/src/views/simulation/resultats/attendu.vue
@@ -182,6 +182,7 @@ import {
 } from "@/lib/contributions.ts"
 import WarningMessage from "@/components/warning-message.vue"
 import { useStore } from "@/stores/index.ts"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 export default {
   name: "Attendu",
@@ -287,7 +288,11 @@ export default {
       this.selection = [].concat(...this.selection).concat({ id: null })
     },
     trackMontantAttendu(type) {
-      this.sendEventToMatomo("Montant attendu", type, this.$route.path)
+      this.sendEventToMatomo(
+        EventCategories.MONTANT_ATTENDU,
+        type,
+        this.$route.path
+      )
     },
     remove(index) {
       const next = this.selection.slice()

--- a/src/views/simulation/resultats/recap-email.vue
+++ b/src/views/simulation/resultats/recap-email.vue
@@ -6,6 +6,7 @@ import { computed, ref } from "vue"
 import BackButton from "@/components/buttons/back-button.vue"
 import { useRouter } from "vue-router"
 import StatisticsMixin from "@/mixins/statistics.js"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 const router = useRouter()
 const store = useStore()
@@ -32,7 +33,7 @@ const sendEmailRecap = async (surveyOptin) => {
       errorMessage.value = true
       emailRef.value.focus()
       StatisticsMixin.methods.sendEventToMatomo(
-        "General",
+        EventCategories.GENERAL,
         "Invalid form",
         router.currentRoute.value.fullPath
       )

--- a/src/views/suivi.vue
+++ b/src/views/suivi.vue
@@ -138,6 +138,7 @@ import LoadingModal from "@/components/loading-modal.vue"
 import DroitHeader from "@/components/droit-header.vue"
 import dayjs from "dayjs"
 import StatisticsMixin from "@/mixins/statistics.ts"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 const choices = [
   { value: "already", label: "Rien, j'en bénéficiais déjà." },
@@ -241,7 +242,7 @@ export default {
 
       if (this.showAccompanimentBlock) {
         this.sendEventToMatomo(
-          "Accompaniment",
+          EventCategories.ACCOMPAGNEMENT,
           "show-accompaniment-link",
           this.currentPath
         )


### PR DESCRIPTION
Ticket : https://trello.com/c/BnPW60P4/1319-mettre-les-types-d%C3%A9v%C3%A8nements-de-statistics-dans-un-enum