### PR TITLE
Limite l'utilisation du parser JSON dans le serveur express

### DIFF
--- a/backend/routes-loader/api.ts
+++ b/backend/routes-loader/api.ts
@@ -3,7 +3,6 @@ import path from "path"
 import fs from "fs"
 
 const api = express()
-api.use(express.json())
 
 const __dirname = new URL(".", import.meta.url).pathname
 const routesPath = path.join(__dirname, "../routes")

--- a/backend/routes/followups.ts
+++ b/backend/routes/followups.ts
@@ -1,4 +1,6 @@
 import cookieParser from "cookie-parser"
+import express from "express"
+
 import {
   followupByAccessToken,
   postSurvey,
@@ -12,7 +14,9 @@ import githubController from "../controllers/github.js"
 
 const followupsRoutes = function (api) {
   api.route("/followups/surveys/:accessToken").get(getFollowup)
-  api.route("/followups/surveys/:accessToken/answers").post(postSurvey)
+  api
+    .route("/followups/surveys/:accessToken/answers")
+    .post(express.json(), postSurvey)
   api
     .route("/followups/surveys")
     .get(cookieParser(), githubController.access)

--- a/backend/routes/simulation.ts
+++ b/backend/routes/simulation.ts
@@ -13,6 +13,7 @@ export default function (api) {
     .post(
       cors({ origin: "*" }),
       cookieParser(),
+      express.json(),
       simulationController.create,
       simulationController.attachAccessCookie,
       simulationController.show
@@ -41,10 +42,14 @@ export default function (api) {
     simulationController.openfiscaRequest
   )
 
-  route.post("/openfisca-test", simulationController.openfiscaTest)
+  route.post(
+    "/openfisca-test",
+    express.json(),
+    simulationController.openfiscaTest
+  )
   route.get("/openfisca-trace", simulationController.openfiscaTrace)
 
-  route.post("/followup", persist)
+  route.post("/followup", express.json(), persist)
 
   teleservices.names.forEach(function (name) {
     route.get(


### PR DESCRIPTION
Prérequis à l'intégration des notifications par webhook de RDV-Aide-Numérique. En effet, la configuration actuelle déclenche un parsing du JSON trop tôt ce qui empêche le contrôle de la signature du payload avec la clé secrète partagée (entre notre simulateur et RDV-Aide-Numérique).