### PR TITLE
Ajoute une route pour la récupération des RDV pris sur RDV-Aide-Numérique

### DIFF
--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -47,6 +47,7 @@ const config: Configuration = {
     "https://contribuer-aides-jeunes.netlify.app",
   rdvAideNumerique: {
     sharedSecret: process.env.RDV_AIDE_NUMERIQUE_SHARED_SECRET || "",
+    baseUrl: process.env.RDV_AIDE_NUMERIQUE_BASE_URL || "",
   },
   smtp: {
     host: process.env.SMTP_HOST || "localhost",

--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -45,6 +45,9 @@ const config: Configuration = {
   netlifyContributionURL:
     process.env.NETLIFY_CONTRIBUTION_URL ||
     "https://contribuer-aides-jeunes.netlify.app",
+  rdvAideNumerique: {
+    sharedSecret: process.env.RDV_AIDE_NUMERIQUE_SHARED_SECRET || "",
+  },
   smtp: {
     host: process.env.SMTP_HOST || "localhost",
     port: process.env.SMTP_PORT || "7777",

--- a/backend/controllers/webhook.ts
+++ b/backend/controllers/webhook.ts
@@ -1,0 +1,88 @@
+import crypto from "crypto"
+
+import config from "../config/index.js"
+import Mattermost from "../lib/mattermost-bot/mattermost.js"
+import { Request, Response, NextFunction } from "express"
+import { RequestBody, Data } from "../types/rdv-aide-numerique.js"
+
+export const verifyAuthentication = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  const signature = req.get("X-Lapin-Signature")
+  if (!signature) {
+    res.status(401).json({ error: "Signature required" })
+    return
+  }
+
+  const expectedSignature = crypto
+    .createHmac("sha256", config.rdvAideNumerique.sharedSecret)
+    .update(req.body as any)
+    .digest("hex")
+
+  if (signature !== expectedSignature) {
+    res.status(401).json({ error: "Invalid signature" })
+    return
+  }
+
+  next()
+}
+
+const isValidBody = (body: RequestBody): boolean => {
+  return !!(
+    body &&
+    body.meta &&
+    body.meta.model === "Rdv" &&
+    body.meta.event === "created" &&
+    body.data
+  )
+}
+
+const isValidData = (data: Data): boolean => {
+  return !!(
+    data &&
+    data.users &&
+    data.users[0] &&
+    typeof data.users[0].email === "string" &&
+    data.id &&
+    data.organisation &&
+    data.organisation.id
+  )
+}
+
+export const validateRequestPayload = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  req.body = JSON.parse(req.body.toString())
+  if (!isValidBody(req.body)) {
+    console.error("Invalid payload structure", req.body)
+    res.status(400).json({ error: "Invalid payload structure" })
+    return
+  }
+
+  const { data } = req.body
+  if (!isValidData(data)) {
+    console.error("Invalid data in payload", data)
+    res.status(400).json({ error: "Invalid data in payload" })
+    return
+  }
+
+  next()
+}
+
+export async function postOnMattermost(
+  req: Request,
+  res: Response
+): Promise<Response> {
+  const { id: rdvId, organisation } = req.body.data || {}
+  const { id: organisationId } = organisation || {}
+
+  const message = `Une personne vient de prendre RDV.
+Plus d'informations https://www.rdv-aide-numerique.fr/admin/organisations/${organisationId}/rdvs/${rdvId}`
+
+  await Mattermost.post(message)
+  return res.status(200).json({ message: "OK" })
+}

--- a/backend/controllers/webhook.ts
+++ b/backend/controllers/webhook.ts
@@ -16,12 +16,18 @@ export const verifyAuthentication = (
     return
   }
 
-  const expectedSignature = crypto
-    .createHmac("sha256", config.rdvAideNumerique.sharedSecret)
-    .update(req.body as any)
-    .digest("hex")
+  try {
+    const expectedSignature = crypto
+      .createHmac("sha256", config.rdvAideNumerique.sharedSecret)
+      .update(req.body as any)
+      .digest("hex")
 
-  if (signature !== expectedSignature) {
+    if (signature !== expectedSignature) {
+      res.status(401).json({ error: "Invalid signature" })
+      return
+    }
+  } catch (error) {
+    console.error("Error while verifying signature", error)
     res.status(401).json({ error: "Invalid signature" })
     return
   }

--- a/backend/controllers/webhook.ts
+++ b/backend/controllers/webhook.ts
@@ -81,7 +81,7 @@ export async function postOnMattermost(
   const { id: organisationId } = organisation || {}
 
   const message = `Une personne vient de prendre RDV.
-Plus d'informations https://www.rdv-aide-numerique.fr/admin/organisations/${organisationId}/rdvs/${rdvId}`
+Plus d'informations ${config.rdvAideNumerique.baseUrl}/admin/organisations/${organisationId}/rdvs/${rdvId}`
 
   await Mattermost.post(message)
   return res.status(200).json({ message: "OK" })

--- a/backend/routes-loader/api.ts
+++ b/backend/routes-loader/api.ts
@@ -12,6 +12,7 @@ import simulationRoutes from "../routes/simulation.js"
 import smsRoutes from "../routes/sms.js"
 import supportRoutes from "../routes/support.js"
 import teleservicesRoutes from "../routes/teleservices.js"
+import webhookRoutes from "../routes/webhook.js"
 
 const api = express()
 
@@ -27,6 +28,7 @@ simulationRoutes(api)
 smsRoutes(api)
 supportRoutes(api)
 teleservicesRoutes(api)
+webhookRoutes(api)
 
 api.all("*", function (req, res) {
   res.sendStatus(404)

--- a/backend/routes/webhook.ts
+++ b/backend/routes/webhook.ts
@@ -1,0 +1,18 @@
+import express from "express"
+
+import {
+  verifyAuthentication,
+  validateRequestPayload,
+  postOnMattermost,
+} from "../controllers/webhook.js"
+
+const webhookRoutes = function (api: express.Express) {
+  api.post(
+    "/webhook/rdv",
+    express.raw({ type: "*/*" }),
+    verifyAuthentication,
+    validateRequestPayload,
+    postOnMattermost
+  )
+}
+export default webhookRoutes

--- a/backend/types/config.d.ts
+++ b/backend/types/config.d.ts
@@ -24,6 +24,7 @@ export interface Configuration {
   }
   rdvAideNumerique: {
     sharedSecret: string
+    baseUrl: string
   }
   github: {
     repository_url: string

--- a/backend/types/config.d.ts
+++ b/backend/types/config.d.ts
@@ -22,6 +22,9 @@ export interface Configuration {
       pass: string | undefined
     }
   }
+  rdvAideNumerique: {
+    sharedSecret: string
+  }
   github: {
     repository_url: string
     access_token_url: string

--- a/backend/types/rdv-aide-numerique.d.ts
+++ b/backend/types/rdv-aide-numerique.d.ts
@@ -1,0 +1,21 @@
+export interface Meta {
+  model: string
+  event: string
+}
+
+export interface User {
+  email: string
+}
+
+export interface Data {
+  users: User[]
+  id: string
+  organisation: {
+    id: string
+  }
+}
+
+export interface RequestBody {
+  meta?: Meta
+  data?: Data
+}

--- a/tests/unit/backend/webhook.spec.ts
+++ b/tests/unit/backend/webhook.spec.ts
@@ -158,7 +158,7 @@ describe("postOnMattermost", () => {
   it("posts message to Mattermost and responds with 200 OK", async () => {
     const expectedMessage =
       `Une personne vient de prendre RDV.\n` +
-      `Plus d'informations https://www.rdv-aide-numerique.fr/admin/organisations/org456/rdvs/rdv123`
+      `Plus d'informations /admin/organisations/org456/rdvs/rdv123`
 
     await postOnMattermost(req, res)
 

--- a/tests/unit/backend/webhook.spec.ts
+++ b/tests/unit/backend/webhook.spec.ts
@@ -1,0 +1,169 @@
+import { expect, jest } from "@jest/globals"
+import crypto from "crypto"
+
+import {
+  verifyAuthentication,
+  validateRequestPayload,
+  postOnMattermost,
+} from "../../../backend/controllers/webhook.js"
+import config from "../../../backend/config/index.js"
+import Mattermost from "../../../backend/lib/mattermost-bot/mattermost.js"
+
+describe("verifyAuthentication", () => {
+  let req, res, next
+
+  beforeEach(() => {
+    req = {
+      body: "aBody",
+    }
+    res = {
+      status: function (code) {
+        this.statusCode = code
+        return this
+      },
+      json: jest.fn(),
+    }
+    next = jest.fn()
+  })
+
+  it("calls next() when signature is valid", () => {
+    const validSignature = crypto
+      .createHmac("sha256", config.rdvAideNumerique.sharedSecret)
+      .update(req.body)
+      .digest("hex")
+    req.get = (header) =>
+      header === "X-Lapin-Signature" ? validSignature : null
+
+    verifyAuthentication(req, res, next)
+
+    expect(next).toHaveBeenCalled()
+    expect(res.statusCode).toBeUndefined()
+    expect(res.json).not.toHaveBeenCalled()
+  })
+
+  it("returns 401 when signature is missing", () => {
+    req.get = () => undefined
+
+    verifyAuthentication(req, res, next)
+
+    expect(res.statusCode).toBe(401)
+    expect(res.json).toHaveBeenCalledWith({ error: "Signature required" })
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it("returns 401 when signature is invalid", () => {
+    req.get = () => "anInvalidSignature"
+
+    verifyAuthentication(req, res, next)
+
+    expect(res.statusCode).toBe(401)
+    expect(res.json).toHaveBeenCalledWith({ error: "Invalid signature" })
+    expect(next).not.toHaveBeenCalled()
+  })
+})
+
+describe("validateRequestPayload", () => {
+  let req, res, next, consoleSpy
+
+  beforeEach(() => {
+    req = {
+      body: JSON.stringify({
+        meta: {
+          model: "Rdv",
+          event: "created",
+        },
+        data: {
+          users: [{ email: "test@example.com" }],
+          id: "123",
+          organisation: { id: "456" },
+        },
+      }),
+    }
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }
+    next = jest.fn()
+    consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("calls next() when body is valid", () => {
+    validateRequestPayload(req, res, next)
+
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.json).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it("returns 400 when body is not valid", () => {
+    req.body = JSON.stringify({})
+
+    validateRequestPayload(req, res, next)
+
+    expect(consoleSpy).toHaveBeenCalledWith("Invalid payload structure", {})
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Invalid payload structure",
+    })
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it("returns 400 when data is not valid", () => {
+    req.body = JSON.stringify({
+      meta: {
+        model: "Rdv",
+        event: "created",
+      },
+      data: {},
+    })
+
+    validateRequestPayload(req, res, next)
+
+    expect(consoleSpy).toHaveBeenCalledWith("Invalid data in payload", {})
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({ error: "Invalid data in payload" })
+    expect(next).not.toHaveBeenCalled()
+  })
+})
+
+describe("postOnMattermost", () => {
+  let req, res, mattermostSpy
+
+  beforeEach(() => {
+    req = {
+      body: {
+        data: {
+          id: "rdv123",
+          organisation: { id: "org456" },
+        },
+      },
+    }
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }
+    mattermostSpy = jest
+      .spyOn(Mattermost, "post")
+      .mockImplementation(async () => Promise.resolve())
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("posts message to Mattermost and responds with 200 OK", async () => {
+    const expectedMessage =
+      `Une personne vient de prendre RDV.\n` +
+      `Plus d'informations https://www.rdv-aide-numerique.fr/admin/organisations/org456/rdvs/rdv123`
+
+    await postOnMattermost(req, res)
+
+    expect(mattermostSpy).toHaveBeenCalledWith(expectedMessage)
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({ message: "OK" })
+  })
+})


### PR DESCRIPTION
L'ajout d'un message en fil/conversation sera fait dans un second temps.
Il nécessite une rechercher parmi les messages dans le canal et la création d'un message en fil de conversation. Ces deux actions ne sont pas possibles avec les incoming webhooks, il faut nécessairement un compte (mais il existe des bot accounts).

En attendant, ça a quand même de la valeur de rendre visible la prise de RDV avec ça.