### PR TITLE
Fix erreur sentry - depcom required to loadLieux()

### DIFF
--- a/src/composables/use-lieux.ts
+++ b/src/composables/use-lieux.ts
@@ -7,6 +7,7 @@ import { ActiviteType } from "@lib/enums/activite.js"
 import { lieuLayout } from "@lib/types/lieu.d.js"
 import * as Sentry from "@sentry/vue"
 import { benefitLayout } from "@data/types/benefits"
+import Simulation from "@/lib/simulation.js"
 
 export function useLieux() {
   const store = useStore()
@@ -15,8 +16,6 @@ export function useLieux() {
   const lieux = ref<lieuLayout[]>([])
   const benefit = ref<benefitLayout | null>(null)
   const updating = ref<boolean>(true)
-
-  const city = store.situation.menage.depcom
 
   const currentLieu = computed(() => {
     return lieux.value.find(
@@ -78,6 +77,13 @@ export function useLieux() {
   }
 
   const loadLieux = async () => {
+    let city = store.situation.menage.depcom
+    const simulationId = Simulation.getLatestId()
+    if (!store.hasResults && !city && simulationId) {
+      await store.fetch(simulationId)
+      city = store.situation.menage.depcom
+    }
+
     if (!city) {
       Sentry.captureMessage(`Depcom required to loadLieux()`)
       updating.value = false
@@ -121,5 +127,6 @@ export function useLieux() {
     currentLieu,
     updating,
     benefit,
+    loadLieux,
   }
 }

--- a/src/router.js
+++ b/src/router.js
@@ -155,15 +155,6 @@ const router = createRouter({
           meta: {
             headTitle: `Trouver de l'aide près de chez vous avec le simulateur d'aides ${context.name}`,
           },
-          beforeEnter(_to, _from, next) {
-            const store = useStore()
-            if (!store.hasResults) {
-              store.fetch(Simulation.getLatestId()).then(() => {
-                next()
-              })
-            }
-            next()
-          },
         },
         {
           name: "resultatsLieuxDedies",

--- a/src/router.js
+++ b/src/router.js
@@ -155,6 +155,15 @@ const router = createRouter({
           meta: {
             headTitle: `Trouver de l'aide près de chez vous avec le simulateur d'aides ${context.name}`,
           },
+          beforeEnter(_to, _from, next) {
+            const store = useStore()
+            if (!store.hasResults) {
+              store.fetch(Simulation.getLatestId()).then(() => {
+                next()
+              })
+            }
+            next()
+          },
         },
         {
           name: "resultatsLieuxDedies",


### PR DESCRIPTION
- [Tâche trello](https://trello.com/c/KIzrtsIf/1348-depcom-required-to-loadlieux)
- [Erreur Sentry associée ](https://sentry.incubateur.net/organizations/betagouv/issues/50109/?query=is%3Aunresolved&referrer=issue-stream)

### Reproduction du bug (pas forcément exhaustive)

Cliquer sur le bouton “Trouver de l’aide' dans fin de simulation et faire en sorte que ça s’ouvre dans un nouvel onglet

### Explication du bug (pas forcément exhaustive non plus)

La simulation n'étant pas partagée à travers le navigateur, elle n’est pas fetchée non plus à l’ouverture de cette page comme elle le serait pour la page /simulation/resultats et par conséquent le store est vide et le depcom est undefined

### Correction proposée (exhaustive pour le bug reproduit ci dessus)

Je propose de fetch la simulation quand il n'y pas de résultats sauvegardé (via l'id de simulation stocké dans les cookies) juste avant l'accès à la route listant les lieux de manière générique pour récupérer le depcom requis