### PR TITLE
Fix un warning de test unitaire

### DIFF
--- a/data/benefits/javascript/communaute-de-communes-sud-herault-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/communaute-de-communes-sud-herault-bourse-communale-au-permis-de-conduire.yml
@@ -8,9 +8,7 @@ description: Afin de répondre aux difficultés de mobilité des jeunes, la
   dossiers de candidature se fait auprès d’Info Jeunes Sud-Hérault.
 prefix: la
 conditions_generales:
-  - type: epcis
-    values:
-      - "200042653"
+  - type: attached_to_institution
   - type: age
     operator: ">="
     value: 18


### PR DESCRIPTION
Warning détexté : 

```
 PASS  tests/integration/benefits-geographical-constraint-consistency.spec.ts
  ● Console

    console.log
      
            ================================
            Benefit : communaute-de-communes-sud-herault-bourse-communale-au-permis-de-conduire
            Insee code : undefined
            potentially incompatible with conditions :
            {"type":"epcis","values":["200042653"]}

      at tools/test-benefits-geographical-constraint-consistency.ts:14:15
          at Array.forEach (<anonymous>)
```