### PR TITLE
Correct links

### DIFF
--- a/data/benefits/javascript/caf-haute-marne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-bafa-generale.yml
@@ -16,8 +16,8 @@ conditions_generales:
     values:
       - "52"
 profils: []
-link: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/enfance-et-jeunesse
-instructions: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/enfance-et-jeunesse
+link: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/vie-personnelle/enfance-et-jeunesse/bafa-et-bafd
+instructions: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/vie-personnelle/enfance-et-jeunesse/bafa-et-bafd
 prefix: l’
 type: float
 unit: €

--- a/data/benefits/javascript/caf-haute-marne-aide-bafd.yml
+++ b/data/benefits/javascript/caf-haute-marne-aide-bafd.yml
@@ -15,9 +15,9 @@ conditions_generales:
     values:
       - "52"
 profils: []
-link: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/enfance-et-jeunesse
-form: https://www.caf.fr/sites/default/files/caf/521/IMPRIME%20BAFD.pdf
-instructions: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/enfance-et-jeunesse
+link: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/vie-personnelle/enfance-et-jeunesse/bafa-et-bafd
+form: https://www.caf.fr/sites/default/files/medias/521/enfance%20et%20jeunesse/IMPRIME%20BAFD.pdf
+instructions: https://www.caf.fr/allocataires/caf-de-la-haute-marne/offre-de-service/vie-personnelle/enfance-et-jeunesse/bafa-et-bafd
 prefix: l’
 type: float
 unit: €

--- a/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-hautes-pyrenees-aide-bafa-generale.yml
@@ -18,9 +18,9 @@ conditions_generales:
     value: 750
     operator: "<="
 profils: []
-link: https://www.caf.fr/allocataires/caf-des-hautes-pyrenees/offre-de-service/solidarite-et-insertion/vous-souhaitez-financer-votre-formation-d-animateur
-form: https://www.caf.fr/sites/default/files/caf/651/Images/Actualite/Plaquette%20social/FORMULAIRE%20DEMANDE%20AIDE%20EXCEPTIONNELLE%20A%20LA%20FORMATION%20BAFA%20proposition.pdf
-instructions: https://www.caf.fr/allocataires/caf-des-hautes-pyrenees/offre-de-service/solidarite-et-insertion/vous-souhaitez-financer-votre-formation-d-animateur
+link: https://www.caf.fr/allocataires/caf-des-hautes-pyrenees/offre-de-service/vie-personnelle/vous-souhaitez-financer-votre-formation-d-animateur-bafa-brevet-d-aptitude-aux-fonctions-d-animateur#:~:text=La%20Caf%20des%20Hautes%2DPyr%C3%A9n%C3%A9es,en%20fonction%20de%20votre%20situation
+form: https://www.caf.fr/sites/default/files/medias/651/formulaire%20BAFA%20-%20feverier%202023_0.pdf
+instructions: https://www.caf.fr/allocataires/caf-des-hautes-pyrenees/offre-de-service/vie-personnelle/vous-souhaitez-financer-votre-formation-d-animateur-bafa-brevet-d-aptitude-aux-fonctions-d-animateur#:~:text=La%20Caf%20des%20Hautes%2DPyr%C3%A9n%C3%A9es,en%20fonction%20de%20votre%20situation
 prefix: l’
 type: float
 unit: €

--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-generale.yml
@@ -17,8 +17,8 @@ conditions_generales:
     value: 856
     operator: "<="
 profils: []
-link: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/enfance-et-jeunesse/bafa
-instructions: https://www.caf.fr/sites/default/files/caf/471/Bafa_conditions_2021.pdf
+link: https://www.caf.fr/allocataires/caf-du-lot-et-garonne/offre-de-service/vie-personnelle/je-suis-jeune-la-caf-est-mes-cotes/je-passe-le-bafa
+instructions: https://www.caf.fr/sites/default/files/medias/471/Vie%20perso/Je%20suis%20jeune/Bafa_0.pdf
 prefix: l’
 type: float
 unit: €

--- a/data/benefits/javascript/caf_eure-aide-au-brevet-daptitude-aux-fonctions-de-directeur-bafd.yml
+++ b/data/benefits/javascript/caf_eure-aide-au-brevet-daptitude-aux-fonctions-de-directeur-bafd.yml
@@ -26,5 +26,6 @@ type: float
 unit: €
 periodicite: ponctuelle
 montant: 250
-link: https://www.caf.fr/allocataires/caf-de-l-eure/offre-de-service/vie-professionnelle/je-suis-assistant-maternel-agree/le-brevet-d-aptitude-aux-fonctions-d-animateur-bafa-et-aux-fonctions-de-directeur-bafd
-instructions: https://www.caf.fr/allocataires/caf-de-l-eure/offre-de-service/vie-professionnelle/je-suis-assistant-maternel-agree/le-brevet-d-aptitude-aux-fonctions-d-animateur-bafa-et-aux-fonctions-de-directeur-bafd
+link: https://caf.fr/partenaires/caf-de-l-eure/partenaires-locaux/la-newsletter-partenaires-de-la-caf-de-l-eure/la-newsletter-de-avril-2022/la-caf-aide-financer-le-bafa-et-le-bafd
+form: https://caf.fr/sites/default/files/medias/271/2022/AS/DEM_BAFA_BAFD.pdf
+instructions: https://caf.fr/partenaires/caf-de-l-eure/partenaires-locaux/la-newsletter-partenaires-de-la-caf-de-l-eure/la-newsletter-de-avril-2022/la-caf-aide-financer-le-bafa-et-le-bafd


### PR DESCRIPTION
correction des liens cassés sur : 
caf-hautes-pyrenees-aide-bafa-generale
--
caf-haute-marne-aide-bafa-generale
--
caf-lot-et-garonne-aide-bafa-generale
--
caf-haute-marne-aide-bafd
--
caf_eure-aide-au-brevet-daptitude-aux-fonctions-de-directeur-bafd
--