### PR TITLE
Add back sentry config

### DIFF
--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -80,6 +80,7 @@ const all: ConfigurationLayout = {
   },
   sentry: {
     dsn: process.env.SENTRY_BACKEND_URL || undefined,
+    authToken: process.env.SENTRY_AUTH_TOKEN || undefined,
   },
   sessionSecret: process.env.SESSION_SECRET || "fghjdfjkdf785a-jreu",
   mattermost_post_url: process.env.MATTERMOST_POST_URL || "",

--- a/backend/types/config.d.ts
+++ b/backend/types/config.d.ts
@@ -54,5 +54,6 @@ export interface ConfigurationLayout {
   iframeTitle: string
   sentry: {
     dsn: string | undefined
+    authToken?: string
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.18.6",
-        "@sentry/vite-plugin": "^0.4.0",
+        "@sentry/vite-plugin": "^0.7.2",
         "@types/bluebird": "^3.5.36",
         "@types/errorhandler": "^1.5.0",
         "@types/express": "^4.17.14",
@@ -2645,47 +2645,51 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.49.0",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.57.0.tgz",
+      "integrity": "sha512-tpViyDd8AhQGYYhI94xi2aaDopXOPfL2Apwrtb3qirWkomIQ2K86W1mPmkce+B0cFOnW2Dxv/ZTFKz6ghjK75A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.49.0",
-        "@sentry/types": "7.49.0",
-        "@sentry/utils": "7.49.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.57.0",
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/core": {
-      "version": "7.49.0",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.57.0.tgz",
+      "integrity": "sha512-l014NudPH0vQlzybtXajPxYFfs9w762NoarjObC3gu76D1jzBBFzhdRelkGpDbSLNTIsKhEDDRpgAjBWJ9icfw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.49.0",
-        "@sentry/utils": "7.49.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
-      "version": "7.49.0",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+      "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
-      "version": "7.49.0",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+      "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.49.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
@@ -2705,86 +2709,154 @@
       }
     },
     "node_modules/@sentry/bundler-plugin-core": {
-      "version": "0.4.0",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-0.7.2.tgz",
+      "integrity": "sha512-9d1MxEgRkPCTewQ26Bs+J/GxvnNVIRuQPZrHs70qRLotMiedH4KlHauh2MhbgH5rdgm0DUeOcafhxoBSK7ji3w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sentry/cli": "^2.10.0",
+        "@sentry/cli": "^2.17.0",
         "@sentry/node": "^7.19.0",
         "@sentry/tracing": "^7.19.0",
+        "find-up": "5.0.0",
+        "glob": "9.3.2",
         "magic-string": "0.27.0",
-        "unplugin": "1.0.1"
+        "unplugin": "1.0.1",
+        "webpack-sources": "3.2.3"
       },
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/core": {
-      "version": "7.49.0",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.57.0.tgz",
+      "integrity": "sha512-l014NudPH0vQlzybtXajPxYFfs9w762NoarjObC3gu76D1jzBBFzhdRelkGpDbSLNTIsKhEDDRpgAjBWJ9icfw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.49.0",
-        "@sentry/utils": "7.49.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/node": {
-      "version": "7.49.0",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.57.0.tgz",
+      "integrity": "sha512-63mjyUVM6sfJFVQ5TGVRVGUsoEfESl5ABzIW1W0s9gUiQPaG8SOdaQJglb2VNrkMYxnRHgD8Q9LUh/qcmUyPGw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.49.0",
-        "@sentry/core": "7.49.0",
-        "@sentry/types": "7.49.0",
-        "@sentry/utils": "7.49.0",
+        "@sentry-internal/tracing": "7.57.0",
+        "@sentry/core": "7.57.0",
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/tracing": {
-      "version": "7.49.0",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.57.0.tgz",
+      "integrity": "sha512-D8eKJMYN529mDP9lsOLyhe0Rf9Qiexo7Ul4+MQwDlwRr9c9tc0AdGwFlnKGvCMDh7ucITzvZkMZDHBapU3WHNQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.49.0"
+        "@sentry-internal/tracing": "7.57.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/types": {
-      "version": "7.49.0",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+      "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/utils": {
-      "version": "7.49.0",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+      "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.49.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.2.tgz",
+      "integrity": "sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^7.4.1",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sentry/bundler-plugin-core/node_modules/magic-string": {
       "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.13"
       },
@@ -2792,11 +2864,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sentry/cli": {
-      "version": "2.17.4",
+      "version": "2.19.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.19.4.tgz",
+      "integrity": "sha512-wsSr2O/GVgr/i+DYtie+DNhODyI+HL7F5/0t1HwWMjHJWm4+5XTEauznYgbh2mewkzfUk9+t0CPecA82lEgspg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.7",
@@ -2913,11 +3031,12 @@
       }
     },
     "node_modules/@sentry/vite-plugin": {
-      "version": "0.4.0",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-0.7.2.tgz",
+      "integrity": "sha512-gprT6wyc1JEtjZcWjv1jQSjT2QV62ZCLmXsjK4oKosb0uaaUMR4UgKxorZyNPGSY08YangjumeJZ7UX0/zakkw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@sentry/bundler-plugin-core": "0.4.0"
+        "@sentry/bundler-plugin-core": "0.7.2"
       },
       "engines": {
         "node": ">= 10"
@@ -10993,6 +11112,15 @@
       "version": "1.2.6",
       "license": "MIT"
     },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/mjml": {
       "version": "4.10.4",
       "license": "MIT",
@@ -12023,6 +12151,40 @@
       "version": "1.0.7",
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.0.tgz",
+      "integrity": "sha512-tZFEaRQbMLjwrsmidsGJ6wDMv0iazJWk6SfIKnY4Xru8auXgmJkOBa5DUbYFcFD2Rzk2+KDlIiF0GVXNCbgC7g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "license": "MIT"
@@ -12295,8 +12457,9 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -13998,8 +14161,9 @@
     },
     "node_modules/unplugin": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+      "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "acorn": "^8.8.1",
         "chokidar": "^3.5.3",
@@ -14872,8 +15036,9 @@
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.5.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+      "dev": true
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -16662,34 +16827,42 @@
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.49.0",
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.57.0.tgz",
+      "integrity": "sha512-tpViyDd8AhQGYYhI94xi2aaDopXOPfL2Apwrtb3qirWkomIQ2K86W1mPmkce+B0cFOnW2Dxv/ZTFKz6ghjK75A==",
       "dev": true,
       "requires": {
-        "@sentry/core": "7.49.0",
-        "@sentry/types": "7.49.0",
-        "@sentry/utils": "7.49.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.57.0",
+        "@sentry/types": "7.57.0",
+        "@sentry/utils": "7.57.0",
+        "tslib": "^2.4.1 || ^1.9.3"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "7.49.0",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.57.0.tgz",
+          "integrity": "sha512-l014NudPH0vQlzybtXajPxYFfs9w762NoarjObC3gu76D1jzBBFzhdRelkGpDbSLNTIsKhEDDRpgAjBWJ9icfw==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.49.0",
-            "@sentry/utils": "7.49.0",
-            "tslib": "^1.9.3"
+            "@sentry/types": "7.57.0",
+            "@sentry/utils": "7.57.0",
+            "tslib": "^2.4.1 || ^1.9.3"
           }
         },
         "@sentry/types": {
-          "version": "7.49.0",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+          "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.49.0",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+          "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.49.0",
-            "tslib": "^1.9.3"
+            "@sentry/types": "7.57.0",
+            "tslib": "^2.4.1 || ^1.9.3"
           }
         }
       }
@@ -16704,69 +16877,155 @@
       }
     },
     "@sentry/bundler-plugin-core": {
-      "version": "0.4.0",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-0.7.2.tgz",
+      "integrity": "sha512-9d1MxEgRkPCTewQ26Bs+J/GxvnNVIRuQPZrHs70qRLotMiedH4KlHauh2MhbgH5rdgm0DUeOcafhxoBSK7ji3w==",
       "dev": true,
       "requires": {
-        "@sentry/cli": "^2.10.0",
+        "@sentry/cli": "^2.17.0",
         "@sentry/node": "^7.19.0",
         "@sentry/tracing": "^7.19.0",
+        "find-up": "5.0.0",
+        "glob": "9.3.2",
         "magic-string": "0.27.0",
-        "unplugin": "1.0.1"
+        "unplugin": "1.0.1",
+        "webpack-sources": "3.2.3"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "7.49.0",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.57.0.tgz",
+          "integrity": "sha512-l014NudPH0vQlzybtXajPxYFfs9w762NoarjObC3gu76D1jzBBFzhdRelkGpDbSLNTIsKhEDDRpgAjBWJ9icfw==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.49.0",
-            "@sentry/utils": "7.49.0",
-            "tslib": "^1.9.3"
+            "@sentry/types": "7.57.0",
+            "@sentry/utils": "7.57.0",
+            "tslib": "^2.4.1 || ^1.9.3"
           }
         },
         "@sentry/node": {
-          "version": "7.49.0",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.57.0.tgz",
+          "integrity": "sha512-63mjyUVM6sfJFVQ5TGVRVGUsoEfESl5ABzIW1W0s9gUiQPaG8SOdaQJglb2VNrkMYxnRHgD8Q9LUh/qcmUyPGw==",
           "dev": true,
           "requires": {
-            "@sentry-internal/tracing": "7.49.0",
-            "@sentry/core": "7.49.0",
-            "@sentry/types": "7.49.0",
-            "@sentry/utils": "7.49.0",
+            "@sentry-internal/tracing": "7.57.0",
+            "@sentry/core": "7.57.0",
+            "@sentry/types": "7.57.0",
+            "@sentry/utils": "7.57.0",
             "cookie": "^0.4.1",
             "https-proxy-agent": "^5.0.0",
             "lru_map": "^0.3.3",
-            "tslib": "^1.9.3"
+            "tslib": "^2.4.1 || ^1.9.3"
           }
         },
         "@sentry/tracing": {
-          "version": "7.49.0",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.57.0.tgz",
+          "integrity": "sha512-D8eKJMYN529mDP9lsOLyhe0Rf9Qiexo7Ul4+MQwDlwRr9c9tc0AdGwFlnKGvCMDh7ucITzvZkMZDHBapU3WHNQ==",
           "dev": true,
           "requires": {
-            "@sentry-internal/tracing": "7.49.0"
+            "@sentry-internal/tracing": "7.57.0"
           }
         },
         "@sentry/types": {
-          "version": "7.49.0",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.57.0.tgz",
+          "integrity": "sha512-D7ifoUfxuVCUyktIr5Gc+jXUbtcUMmfHdTtTbf1XCZHua5mJceK9wtl3YCg3eq/HK2Ppd52BKnTzEcS5ZKQM+w==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "7.49.0",
+          "version": "7.57.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.57.0.tgz",
+          "integrity": "sha512-YXrkMCiNklqkXctn4mKYkrzNCf/dfVcRUQrkXjeBC+PHXbcpPyaJgInNvztR7Skl8lE3JPGPN4v5XhLxK1bUUg==",
           "dev": true,
           "requires": {
-            "@sentry/types": "7.49.0",
-            "tslib": "^1.9.3"
+            "@sentry/types": "7.57.0",
+            "tslib": "^2.4.1 || ^1.9.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob": {
+          "version": "9.3.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.2.tgz",
+          "integrity": "sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "minimatch": "^7.4.1",
+            "minipass": "^4.2.4",
+            "path-scurry": "^1.6.1"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
           }
         },
         "magic-string": {
           "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+          "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
           "dev": true,
           "requires": {
             "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        },
+        "minimatch": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
           }
         }
       }
     },
     "@sentry/cli": {
-      "version": "2.17.4",
+      "version": "2.19.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.19.4.tgz",
+      "integrity": "sha512-wsSr2O/GVgr/i+DYtie+DNhODyI+HL7F5/0t1HwWMjHJWm4+5XTEauznYgbh2mewkzfUk9+t0CPecA82lEgspg==",
       "dev": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",
@@ -16846,10 +17105,12 @@
       }
     },
     "@sentry/vite-plugin": {
-      "version": "0.4.0",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-0.7.2.tgz",
+      "integrity": "sha512-gprT6wyc1JEtjZcWjv1jQSjT2QV62ZCLmXsjK4oKosb0uaaUMR4UgKxorZyNPGSY08YangjumeJZ7UX0/zakkw==",
       "dev": true,
       "requires": {
-        "@sentry/bundler-plugin-core": "0.4.0"
+        "@sentry/bundler-plugin-core": "0.7.2"
       }
     },
     "@sentry/vue": {
@@ -21973,6 +22234,12 @@
     "minimist": {
       "version": "1.2.6"
     },
+    "minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true
+    },
     "mjml": {
       "version": "4.10.4",
       "requires": {
@@ -22693,6 +22960,30 @@
     "path-parse": {
       "version": "1.0.7"
     },
+    "path-scurry": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.0.tgz",
+      "integrity": "sha512-tZFEaRQbMLjwrsmidsGJ6wDMv0iazJWk6SfIKnY4Xru8auXgmJkOBa5DUbYFcFD2Rzk2+KDlIiF0GVXNCbgC7g==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+          "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+          "dev": true
+        },
+        "minipass": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+          "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+          "dev": true
+        }
+      }
+    },
     "path-to-regexp": {
       "version": "0.1.7"
     },
@@ -22840,6 +23131,8 @@
     },
     "proxy-from-env": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
     "pseudomap": {
@@ -23893,6 +24186,8 @@
     },
     "unplugin": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+      "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.1",
@@ -24385,6 +24680,8 @@
     },
     "webpack-virtual-modules": {
       "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
       "dev": true
     },
     "websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.18.6",
-    "@sentry/vite-plugin": "^0.4.0",
+    "@sentry/vite-plugin": "^0.7.2",
     "@types/bluebird": "^3.5.36",
     "@types/errorhandler": "^1.5.0",
     "@types/express": "^4.17.14",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,9 @@ function createSentryPlugin() {
     include: "./dist",
     authToken: sentry.authToken,
     url: "https://sentry.incubateur.net/",
+    sourcemaps: {
+      assets: "./dist/**",
+    },
   })
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,11 @@ const {
   netlifyContributionURL,
   statistics,
   franceConnect,
+  sentry,
 } = config
 
 function createSentryPlugin() {
-  if (!process.env.SENTRY_AUTH_TOKEN) {
+  if (!sentry.authToken) {
     return null
   }
 
@@ -32,7 +33,7 @@ function createSentryPlugin() {
     org: "betagouv",
     project: "aides-jeunes-front",
     include: "./dist",
-    authToken: process.env.SENTRY_AUTH_TOKEN,
+    authToken: sentry.authToken,
     url: "https://sentry.incubateur.net/",
   })
 }


### PR DESCRIPTION
On peut revert le revert car il suffit de supprimer le `sentry.authToken` de la config de prod pour que l'upload du sourcMap ne soit pas trigger. 

Par ailleurs une mise à jour de `@sentry/vite-plugin` a été ajouté. J'ai choisi la version maximal avant la version 2 (il n'y a pas de version 1) afin d'éviter de faire un saut trop grand.