### PR TITLE
Ajoute le champ conditions_benevoles dans les détails d'une aide

### DIFF
--- a/backend/controllers/outils.ts
+++ b/backend/controllers/outils.ts
@@ -1,5 +1,6 @@
 import communes from "@etalab/decoupage-administratif/data/communes.json" assert { type: "json" }
 import epci from "@etalab/decoupage-administratif/data/epci.json" assert { type: "json" }
+import communesLonLat from "communes-lonlat"
 
 const communesActuelles = communes.filter((c) => c.type === "commune-actuelle")
 const communeMap = {}
@@ -45,5 +46,10 @@ export default {
   find,
   communes: function (req, res) {
     res.send(find(req.params.codePostal))
+  },
+  centerCoordinates: function (req, res) {
+    const postCode = find(req.params.codePostal)
+    const commune = communesLonLat.find((c) => c.code === postCode[0].code)
+    res.send(commune.centre.coordinates)
   },
 }

--- a/backend/controllers/outils.ts
+++ b/backend/controllers/outils.ts
@@ -47,7 +47,7 @@ export default {
   communes: function (req, res) {
     res.send(find(req.params.codePostal))
   },
-  centerCoordinates: function (req, res) {
+  centerCoordinatesFromPostalCode: function (req, res) {
     const postCode = find(req.params.codePostal)
     const commune = communesLonLat.find((c) => c.code === postCode[0].code)
     res.send(commune.centre.coordinates)

--- a/backend/controllers/outils.ts
+++ b/backend/controllers/outils.ts
@@ -48,8 +48,8 @@ export default {
     res.send(find(req.params.codePostal))
   },
   centerCoordinatesFromPostalCode: function (req, res) {
-    const postCode = find(req.params.codePostal)
-    const commune = communesLonLat.find((c) => c.code === postCode[0].code)
+    const postalCode = find(req.params.codePostal)[0].code
+    const commune = communesLonLat.find((c) => c.code === postalCode)
     res.send(commune.centre.coordinates)
   },
 }

--- a/backend/routes/outils.ts
+++ b/backend/routes/outils.ts
@@ -2,4 +2,7 @@ import outils from "../controllers/outils.js"
 
 export default function (api) {
   api.route("/outils/communes/:codePostal").get(outils.communes)
+  api
+    .route("/outils/communes/:codePostal/centerCoordinates")
+    .get(outils.centerCoordinates)
 }

--- a/backend/routes/outils.ts
+++ b/backend/routes/outils.ts
@@ -4,5 +4,5 @@ export default function (api) {
   api.route("/outils/communes/:codePostal").get(outils.communes)
   api
     .route("/outils/communes/:codePostal/centerCoordinates")
-    .get(outils.centerCoordinates)
+    .get(outils.centerCoordinatesFromPostalCode)
 }

--- a/backend/routes/outils.ts
+++ b/backend/routes/outils.ts
@@ -3,6 +3,6 @@ import outils from "../controllers/outils.js"
 export default function (api) {
   api.route("/outils/communes/:codePostal").get(outils.communes)
   api
-    .route("/outils/communes/:codePostal/centerCoordinates")
+    .route("/outils/codePostal/:codePostal/centerCoordinates")
     .get(outils.centerCoordinatesFromPostalCode)
 }

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -738,6 +738,12 @@ fields:
   field_not_operator: &field_not_operator
     name: not
     widget: hidden
+  field_voluntary_conditions: &field_voluntary_conditions
+    label: Conditions bénévoles à satisfaire
+    name: voluntary_conditions
+    hint: Un lien dynamique vers la plateforme jeveuxaider.gouv.fr s'ajoutera à la suite de ces conditions pour orienter l'utilisateur vers des organismes de bénévolat à proximité
+    required: false
+    widget: string
   # champs propre aux aides javascript
   field_general_conditions: &field_general_conditions
     label: Conditions générales à satisfaire simultanément
@@ -760,12 +766,6 @@ fields:
       - *field_statut_occupation_logement
       - *field_not_operator
       - *field_difficultes_acces_ou_frais_logement
-  field_conditions_benevoles: &field_conditions_benevoles
-    label: Conditions bénévoles à satisfaire
-    name: conditions_benevoles
-    hint: Un lien dynamique vers la plateforme JeVeuxAider s'ajoutera à la suite de ces conditions pour orienter l'utilisateur vers des organismes de bénévolat à proximité
-    required: false
-    widget: string
   # champs propre aux aides openfisca
   field_benefit_position: &field_benefit_position
     label: Pondération de l'aide sur la page de résultat
@@ -829,7 +829,7 @@ collections:
       - *field_description
       - *field_definite_article
       - *field_general_conditions
-      - *field_conditions_benevoles
+      - *field_voluntary_conditions
       - *field_eligibility_profile
       - *field_unmodeled_conditions
       - *field_specific_interest
@@ -867,6 +867,7 @@ collections:
       - *field_description
       - *field_definite_article
       - *field_unmodeled_conditions
+      - *field_voluntary_conditions
       - *field_specific_interest
       - *field_result_type
       - *field_result_unit

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -741,9 +741,19 @@ fields:
   field_voluntary_conditions: &field_voluntary_conditions
     label: Conditions bénévoles à satisfaire
     name: voluntary_conditions
-    hint: Un lien dynamique vers la plateforme jeveuxaider.gouv.fr s'ajoutera à la suite de ces conditions pour orienter l'utilisateur vers des organismes de bénévolat à proximité
+    hint: Un lien dynamique vers la plateforme jeveuxaider.gouv.fr s'ajoutera à la suite de la dernière condition pour orienter l'utilisateur vers des organismes de bénévolat à proximité
     required: false
-    widget: string
+    widget: list
+    collapsed: false
+    field:
+      label: Texte
+      name: text
+      widget: string
+      pattern:
+        [
+          '\.$',
+          "La condition doit commencer par un verbe à l'infinitif et se terminer par un point",
+        ]
   # champs propre aux aides javascript
   field_general_conditions: &field_general_conditions
     label: Conditions générales à satisfaire simultanément

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -760,6 +760,12 @@ fields:
       - *field_statut_occupation_logement
       - *field_not_operator
       - *field_difficultes_acces_ou_frais_logement
+  field_conditions_benevoles: &field_conditions_benevoles
+    label: Conditions bénévoles à satisfaire
+    name: conditions_benevoles
+    hint: Un lien dynamique vers la plateforme JeVeuxAider s'ajoutera à la suite de ces conditions pour orienter l'utilisateur vers des organismes de bénévolat à proximité
+    required: false
+    widget: string
   # champs propre aux aides openfisca
   field_benefit_position: &field_benefit_position
     label: Pondération de l'aide sur la page de résultat
@@ -823,6 +829,7 @@ collections:
       - *field_description
       - *field_definite_article
       - *field_general_conditions
+      - *field_conditions_benevoles
       - *field_eligibility_profile
       - *field_unmodeled_conditions
       - *field_specific_interest

--- a/data/benefits/javascript/departement_charente_maritime-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement_charente_maritime-aide-departementale-au-permis-de-conduire.yml
@@ -22,9 +22,9 @@ conditions:
   - Avoir validé l'examen du code de la route.
   - Avoir un projet d'emploi ou de formation validé par un référent FAJ (Fonds
     d'aide aux jeunes).
-  - "Etre engagé dans une mission bénévole de 40 à 50 heures auprès d’un
-    organisme local à vocation sociale ou humanitaire (ex : Restos du Cœur,
-    Croix Rouge etc.)."
+conditions_benevoles:
+  - "40 à 50 heures de bénévolat auprès d’un organisme local à vocation sociale
+    ou humanitaire (ex : Restos du Cœur, Croix Rouge etc.)."
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/departement_charente_maritime-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement_charente_maritime-aide-departementale-au-permis-de-conduire.yml
@@ -23,8 +23,8 @@ conditions:
   - Avoir un projet d'emploi ou de formation validé par un référent FAJ (Fonds
     d'aide aux jeunes).
 conditions_benevoles:
-  - "Etre engagé dans une mission bénévole de 40 à 50 heures auprès d’un
-    organisme local à vocation sociale ou humanitaire (ex : Restos du Cœur,
+  - "Être engagé dans une mission bénévole de 40 à 50 heures auprès d’un
+    organisme local à vocation sociale ou humanitaire (ex: Restos du Cœur,
     Croix Rouge etc.)."
 interestFlag: _interetPermisDeConduire
 type: float

--- a/data/benefits/javascript/departement_charente_maritime-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement_charente_maritime-aide-departementale-au-permis-de-conduire.yml
@@ -22,7 +22,7 @@ conditions:
   - Avoir validé l'examen du code de la route.
   - Avoir un projet d'emploi ou de formation validé par un référent FAJ (Fonds
     d'aide aux jeunes).
-conditions_benevoles:
+voluntary_conditions:
   - "Être engagé dans une mission bénévole de 40 à 50 heures auprès d’un
     organisme local à vocation sociale ou humanitaire (ex: Restos du Cœur,
     Croix Rouge etc.)."

--- a/data/benefits/javascript/departement_charente_maritime-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement_charente_maritime-aide-departementale-au-permis-de-conduire.yml
@@ -23,8 +23,9 @@ conditions:
   - Avoir un projet d'emploi ou de formation validé par un référent FAJ (Fonds
     d'aide aux jeunes).
 conditions_benevoles:
-  - "40 à 50 heures de bénévolat auprès d’un organisme local à vocation sociale
-    ou humanitaire (ex : Restos du Cœur, Croix Rouge etc.)."
+  - "Etre engagé dans une mission bénévole de 40 à 50 heures auprès d’un
+    organisme local à vocation sociale ou humanitaire (ex : Restos du Cœur,
+    Croix Rouge etc.)."
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/departement_cotes_d_armor-aide-departementale-au-permis-de-conduire-passengagement.yml
+++ b/data/benefits/javascript/departement_cotes_d_armor-aide-departementale-au-permis-de-conduire-passengagement.yml
@@ -20,9 +20,9 @@ profils: []
 conditions:
   - Résider depuis plus de six mois dans le département des Côtes d'Armor.
   - Effectuer votre demande d'aide entre le 1er septembre et le 1er juin.
-conditions_benevoles:
-  - "Etre engagé dans une mission bénévole de 2 heures minimum par semaine dans
-    une association ou un centre social."
+voluntary_conditions:
+  - Être engagé dans une mission bénévole de 2 heures minimum par semaine dans
+    une association ou un centre social.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/departement_cotes_d_armor-aide-departementale-au-permis-de-conduire-passengagement.yml
+++ b/data/benefits/javascript/departement_cotes_d_armor-aide-departementale-au-permis-de-conduire-passengagement.yml
@@ -20,6 +20,9 @@ profils: []
 conditions:
   - Résider depuis plus de six mois dans le département des Côtes d'Armor.
   - Effectuer votre demande d'aide entre le 1er septembre et le 1er juin.
+conditions_benevoles:
+  - "Etre engagé dans une mission bénévole de 2 heures minimum par semaine dans
+    une association ou un centre social."
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/departement_landes-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/departement_landes-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
@@ -15,6 +15,9 @@ conditions_generales:
   - type: age
     operator: <=
     value: 30
+conditions_benevoles:
+  - "Etre engagé dans une mission bénévole de 40 heures minimum dans une
+    collectivité ou une association des Landes."
 profils: []
 interestFlag: _interetPermisDeConduire
 type: float

--- a/data/benefits/javascript/departement_landes-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/departement_landes-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
@@ -15,9 +15,9 @@ conditions_generales:
   - type: age
     operator: <=
     value: 30
-conditions_benevoles:
-  - "Etre engagé dans une mission bénévole de 40 heures minimum dans une
-    collectivité ou une association des Landes."
+voluntary_conditions:
+  - Être engagé dans une mission bénévole de 40 heures minimum dans une
+    collectivité ou une association des Landes.
 profils: []
 interestFlag: _interetPermisDeConduire
 type: float

--- a/data/benefits/javascript/departement_oise-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/departement_oise-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
@@ -21,6 +21,9 @@ conditions:
     obtenu votre permis de manière anticipée, grâce au dispositif de conduite
     accompagnée, durant la période maximale de 12 mois antérieure à l’obtention
     de votre majorité légale.
+conditions_benevoles:
+  - "Etre engagé dans une mission bénévole de 70 heures minimum dans une
+    collectivité ou une association de l’Oise."
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/departement_oise-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/departement_oise-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
@@ -21,9 +21,9 @@ conditions:
     obtenu votre permis de manière anticipée, grâce au dispositif de conduite
     accompagnée, durant la période maximale de 12 mois antérieure à l’obtention
     de votre majorité légale.
-conditions_benevoles:
-  - "Etre engagé dans une mission bénévole de 70 heures minimum dans une
-    collectivité ou une association de l’Oise."
+voluntary_conditions:
+  - Être engagé dans une mission bénévole de 70 heures minimum dans une
+    collectivité ou une association de l’Oise.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/departement_pas_de_calais-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/departement_pas_de_calais-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
@@ -17,6 +17,9 @@ conditions_generales:
   - type: age
     operator: <=
     value: 25
+conditions_benevoles:
+  - "Etre engagé dans une mission bénévole de 35 heures minimum dans une
+    association du Pas-de-Calais."
 profils: []
 conditions:
   - Résider dans le Pas-de-Calais.

--- a/data/benefits/javascript/departement_pas_de_calais-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/departement_pas_de_calais-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
@@ -17,9 +17,9 @@ conditions_generales:
   - type: age
     operator: <=
     value: 25
-conditions_benevoles:
-  - "Etre engagé dans une mission bénévole de 35 heures minimum dans une
-    association du Pas-de-Calais."
+voluntary_conditions:
+  - Être engagé dans une mission bénévole de 35 heures minimum dans une
+    association du Pas-de-Calais.
 profils: []
 conditions:
   - Résider dans le Pas-de-Calais.

--- a/data/benefits/javascript/mission-locale-de-lagglomeration-dhenin-carvin-aide-au-financement-du-permis-de-conduire-le-permis-cest-permis.yml
+++ b/data/benefits/javascript/mission-locale-de-lagglomeration-dhenin-carvin-aide-au-financement-du-permis-de-conduire-le-permis-cest-permis.yml
@@ -23,8 +23,10 @@ profils:
 conditions:
   - Avoir obtenu le code de la route.
   - Etre inscrit dans une auto-école partenaire.
-  - Effectuer 35 heures de bénévolat, des immersions professionnelles et un
+  - Effectuer des immersions professionnelles et un
     atelier de prévention et de sécurité routière.
+conditions_benevoles:
+  - Effectuer 35 heures de bénévolat.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/mission-locale-de-lagglomeration-dhenin-carvin-aide-au-financement-du-permis-de-conduire-le-permis-cest-permis.yml
+++ b/data/benefits/javascript/mission-locale-de-lagglomeration-dhenin-carvin-aide-au-financement-du-permis-de-conduire-le-permis-cest-permis.yml
@@ -25,7 +25,7 @@ conditions:
   - Etre inscrit dans une auto-école partenaire.
   - Effectuer des immersions professionnelles et un
     atelier de prévention et de sécurité routière.
-conditions_benevoles:
+voluntary_conditions:
   - Effectuer 35 heures de bénévolat.
 interestFlag: _interetPermisDeConduire
 type: float

--- a/data/benefits/javascript/region-bourgogne-franche-comte-jeunes-citoyens-du-monde.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-jeunes-citoyens-du-monde.yml
@@ -3,7 +3,7 @@ institution: region_bourgogne_franche_comte
 description: La Région Bourgogne-Franche-Comté offre aux jeunes la possibilité
   d’acquérir une expérience dans le domaine de la solidarité internationale
   grâce à un soutien financier individuel.
-conditions:
+conditions_benevoles:
   - Mener une action de développement ou humanitaire à titre bénévole grâce à
     une structure relevant du secteur public, privé ou mixte.
 conditions_generales:

--- a/data/benefits/javascript/region-bourgogne-franche-comte-jeunes-citoyens-du-monde.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-jeunes-citoyens-du-monde.yml
@@ -3,7 +3,7 @@ institution: region_bourgogne_franche_comte
 description: La Région Bourgogne-Franche-Comté offre aux jeunes la possibilité
   d’acquérir une expérience dans le domaine de la solidarité internationale
   grâce à un soutien financier individuel.
-conditions_benevoles:
+voluntary_conditions:
   - Mener une action de développement ou humanitaire à titre bénévole grâce à
     une structure relevant du secteur public, privé ou mixte.
 conditions_generales:

--- a/data/benefits/javascript/region-corse-aide-au-permis-prima-strada.yml
+++ b/data/benefits/javascript/region-corse-aide-au-permis-prima-strada.yml
@@ -10,7 +10,7 @@ conditions:
   - Ne pas être éligible à l’obtention d’une aide de droit commun ou d’une
     autre aide existante.
   - Ne pas avoir débuté sa formation et ne pas avoir passé l’examen.
-conditions_benevoles:
+voluntary_conditions:
   - Justifier d’un engagement citoyen et/ou bénévole dans une structure de son
     choix (justifier de 20 heures minimum).
 conditions_generales:

--- a/data/benefits/javascript/region-corse-aide-au-permis-prima-strada.yml
+++ b/data/benefits/javascript/region-corse-aide-au-permis-prima-strada.yml
@@ -6,12 +6,13 @@ description: "Grâce à l'aide Prima Strada, financez une partie de votre permis
   les aides existantes."
 conditions:
   - Résider en Corse depuis 2 ans.
-  - Justifier d’un engagement citoyen et/ou bénévole dans une structure de son
-    choix (justifier de 20 heures minimum).
   - Déposer une demande écrite motivée.
   - Ne pas être éligible à l’obtention d’une aide de droit commun ou d’une
     autre aide existante.
   - Ne pas avoir débuté sa formation et ne pas avoir passé l’examen.
+conditions_benevoles:
+  - Justifier d’un engagement citoyen et/ou bénévole dans une structure de son
+    choix (justifier de 20 heures minimum).
 conditions_generales:
   - type: age
     operator: ">="

--- a/data/benefits/javascript/ville-dangers-bourse-communale-pour-le-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/ville-dangers-bourse-communale-pour-le-permis-de-conduire-permis-citoyen.yml
@@ -35,6 +35,7 @@ conditions:
   - Résider à Angers depuis au moins une année de manière continue.
   - Etre engagé·e dans un parcours d’insertion professionnelle.
   - Etre inscrit·e dans une auto-école partenaire du CCAS et participer à une journée obligatoire de sécurité routière.
+conditions_benevoles:
   - S'engager à réaliser au moins 20 heures de bénévolat dans une association ou
     une collectivité.
 interestFlag: _interetPermisDeConduire

--- a/data/benefits/javascript/ville-dangers-bourse-communale-pour-le-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/ville-dangers-bourse-communale-pour-le-permis-de-conduire-permis-citoyen.yml
@@ -35,7 +35,7 @@ conditions:
   - Résider à Angers depuis au moins une année de manière continue.
   - Etre engagé·e dans un parcours d’insertion professionnelle.
   - Etre inscrit·e dans une auto-école partenaire du CCAS et participer à une journée obligatoire de sécurité routière.
-conditions_benevoles:
+voluntary_conditions:
   - S'engager à réaliser au moins 20 heures de bénévolat dans une association ou
     une collectivité.
 interestFlag: _interetPermisDeConduire

--- a/data/benefits/javascript/ville-de-carcassonne-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-de-carcassonne-bourse-communale-au-permis-de-conduire.yml
@@ -19,6 +19,7 @@ conditions_generales:
 profils: []
 conditions:
   - Effectuer la demande de bourse avant de vous inscrire à l'auto-école et obtenir le code de la route.
+conditions_benevoles:
   - Réaliser 60 heures d'action bénévole dans une association basée à
     Carcassonne.
 interestFlag: _interetPermisDeConduire

--- a/data/benefits/javascript/ville-de-carcassonne-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-de-carcassonne-bourse-communale-au-permis-de-conduire.yml
@@ -19,7 +19,7 @@ conditions_generales:
 profils: []
 conditions:
   - Effectuer la demande de bourse avant de vous inscrire à l'auto-école et obtenir le code de la route.
-conditions_benevoles:
+voluntary_conditions:
   - Réaliser 60 heures d'action bénévole dans une association basée à
     Carcassonne.
 interestFlag: _interetPermisDeConduire

--- a/data/benefits/javascript/ville-de-lille-aide-au-financement-du-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-de-lille-aide-au-financement-du-permis-de-conduire.yml
@@ -33,6 +33,7 @@ conditions:
     formation). Etre en situation professionnelle précaire (bulletins de salaire
     / contrat de travail). Etre suivi par la Mission Locale dans le cadre d’un
     parcours d’insertion professionnelle (contrat d’insertion).
+conditions_benevoles:
   - Effectuer 25 heures de travail bénévole auprès d’associations ou
     d’institutions Lilloises.
 interestFlag: _interetPermisDeConduire

--- a/data/benefits/javascript/ville-de-lille-aide-au-financement-du-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-de-lille-aide-au-financement-du-permis-de-conduire.yml
@@ -33,7 +33,7 @@ conditions:
     formation). Etre en situation professionnelle précaire (bulletins de salaire
     / contrat de travail). Etre suivi par la Mission Locale dans le cadre d’un
     parcours d’insertion professionnelle (contrat d’insertion).
-conditions_benevoles:
+voluntary_conditions:
   - Effectuer 25 heures de travail bénévole auprès d’associations ou
     d’institutions Lilloises.
 interestFlag: _interetPermisDeConduire

--- a/data/benefits/javascript/ville-de-roubaix-bourse-communale-au-permis-de-conduire-passpermis.yml
+++ b/data/benefits/javascript/ville-de-roubaix-bourse-communale-au-permis-de-conduire-passpermis.yml
@@ -21,6 +21,8 @@ conditions:
   - Avoir déjà effectué la JAPD (Journée d'Appel de Préparation à la Défense).
   - Etre prêt à participer à un atelier d’éloquence afin de préparer l’oral à la
     commission d’attribution de la bourse.
+conditions_benevoles:
+  - Réaliser 35 heures d'action bénévole dans un service de la Ville de Roubaix.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/ville-de-roubaix-bourse-communale-au-permis-de-conduire-passpermis.yml
+++ b/data/benefits/javascript/ville-de-roubaix-bourse-communale-au-permis-de-conduire-passpermis.yml
@@ -21,7 +21,7 @@ conditions:
   - Avoir déjà effectué la JAPD (Journée d'Appel de Préparation à la Défense).
   - Etre prêt à participer à un atelier d’éloquence afin de préparer l’oral à la
     commission d’attribution de la bourse.
-conditions_benevoles:
+voluntary_conditions:
   - Réaliser 35 heures d'action bénévole dans un service de la Ville de Roubaix.
 interestFlag: _interetPermisDeConduire
 type: float

--- a/data/benefits/javascript/ville_chaumes_en_retz-bourse-communale-au-permis-de-conduire-et-au-bsr.yml
+++ b/data/benefits/javascript/ville_chaumes_en_retz-bourse-communale-au-permis-de-conduire-et-au-bsr.yml
@@ -5,7 +5,7 @@ description:
   leur BSR ou leur permis de conduire en contrepartie d’une mission bénévole de 20 heures
   dans une association de la ville. Pour faire une demande de bourse, adressez-vous à la mairie. Les dossiers reçus sont examinés par le conseil municipal qui rend sa décision.
 prefix: la
-conditions_benevoles:
+voluntary_conditions:
   - Être engagé dans une mission bénévole de 20 heures minimum dans une
     association de la ville.
 conditions_generales:

--- a/data/benefits/javascript/ville_chaumes_en_retz-bourse-communale-au-permis-de-conduire-et-au-bsr.yml
+++ b/data/benefits/javascript/ville_chaumes_en_retz-bourse-communale-au-permis-de-conduire-et-au-bsr.yml
@@ -5,6 +5,9 @@ description:
   leur BSR ou leur permis de conduire en contrepartie d’une mission bénévole de 20 heures
   dans une association de la ville. Pour faire une demande de bourse, adressez-vous à la mairie. Les dossiers reçus sont examinés par le conseil municipal qui rend sa décision.
 prefix: la
+conditions_benevoles:
+  - "Etre engagé dans une mission bénévole de 20 heures minimum dans une
+    association de la ville."
 conditions_generales:
   - type: age
     operator: ">="

--- a/data/benefits/javascript/ville_chaumes_en_retz-bourse-communale-au-permis-de-conduire-et-au-bsr.yml
+++ b/data/benefits/javascript/ville_chaumes_en_retz-bourse-communale-au-permis-de-conduire-et-au-bsr.yml
@@ -6,8 +6,8 @@ description:
   dans une association de la ville. Pour faire une demande de bourse, adressez-vous à la mairie. Les dossiers reçus sont examinés par le conseil municipal qui rend sa décision.
 prefix: la
 conditions_benevoles:
-  - "Etre engagé dans une mission bénévole de 20 heures minimum dans une
-    association de la ville."
+  - Être engagé dans une mission bénévole de 20 heures minimum dans une
+    association de la ville.
 conditions_generales:
   - type: age
     operator: ">="

--- a/data/benefits/javascript/ville_dunkerque-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville_dunkerque-bourse-communale-au-permis-de-conduire.yml
@@ -5,7 +5,7 @@ description:
   d'une partie de leur permis B, en échange de 50 heures de travail bénévole
   dans une association ou un service municipal. L’aide est versée directement à l’auto-école une fois la totalité des heures de bénévolat réalisée.
 prefix: la
-conditions_benevoles:
+voluntary_conditions:
   - Être engagé dans une mission bénévole de 50 heures minimum dans une association ou un service municipal.
 conditions_generales:
   - type: communes

--- a/data/benefits/javascript/ville_dunkerque-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville_dunkerque-bourse-communale-au-permis-de-conduire.yml
@@ -5,6 +5,8 @@ description:
   d'une partie de leur permis B, en échange de 50 heures de travail bénévole
   dans une association ou un service municipal. L’aide est versée directement à l’auto-école une fois la totalité des heures de bénévolat réalisée.
 prefix: la
+conditions_benevoles:
+  - "Etre engagé dans une mission bénévole de 50 heures minimum dans une association ou un service municipal."
 conditions_generales:
   - type: communes
     values:

--- a/data/benefits/javascript/ville_dunkerque-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville_dunkerque-bourse-communale-au-permis-de-conduire.yml
@@ -6,7 +6,7 @@ description:
   dans une association ou un service municipal. L’aide est versée directement à l’auto-école une fois la totalité des heures de bénévolat réalisée.
 prefix: la
 conditions_benevoles:
-  - "Etre engagé dans une mission bénévole de 50 heures minimum dans une association ou un service municipal."
+  - Être engagé dans une mission bénévole de 50 heures minimum dans une association ou un service municipal.
 conditions_generales:
   - type: communes
     values:

--- a/data/benefits/javascript/ville_nice-bourse-communale-au-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/ville_nice-bourse-communale-au-permis-de-conduire-permis-citoyen.yml
@@ -20,7 +20,7 @@ profils: []
 conditions:
   - Être non-imposable.
   - Avoir préalablement réussi le code de la route.
-conditions_benevoles:
+voluntary_conditions:
   - S’engager à la réalisation de 30 heures de bénévolat dans un service public
     ou un organisme à but non lucratif.
 interestFlag: _interetPermisDeConduire

--- a/data/benefits/javascript/ville_nice-bourse-communale-au-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/ville_nice-bourse-communale-au-permis-de-conduire-permis-citoyen.yml
@@ -20,6 +20,7 @@ profils: []
 conditions:
   - Être non-imposable.
   - Avoir préalablement réussi le code de la route.
+conditions_benevoles:
   - S’engager à la réalisation de 30 heures de bénévolat dans un service public
     ou un organisme à but non lucratif.
 interestFlag: _interetPermisDeConduire

--- a/data/benefits/openfisca/iwuy_aide_mobilite_permis.yml
+++ b/data/benefits/openfisca/iwuy_aide_mobilite_permis.yml
@@ -7,7 +7,7 @@ conditions:
   - Avoir obtenu le code de la route.
   - Habiter à Iwuy depuis plus d'un an.
   - Être inscrit en Mission Locale.
-conditions_benevoles:
+voluntary_conditions:
   - Effectuer une mission bénévole au service de la collectivité.
 link: http://www.iwuy.fr/page.php?id=6
 instructions: http://www.iwuy.fr/page.php?id=6

--- a/data/benefits/openfisca/iwuy_aide_mobilite_permis.yml
+++ b/data/benefits/openfisca/iwuy_aide_mobilite_permis.yml
@@ -7,6 +7,7 @@ conditions:
   - Avoir obtenu le code de la route.
   - Habiter à Iwuy depuis plus d'un an.
   - Être inscrit en Mission Locale.
+conditions_benevoles:
   - Effectuer une mission bénévole au service de la collectivité.
 link: http://www.iwuy.fr/page.php?id=6
 instructions: http://www.iwuy.fr/page.php?id=6

--- a/data/benefits/openfisca/vendee_bourses_jeunes_benevoles_montant_max.yml
+++ b/data/benefits/openfisca/vendee_bourses_jeunes_benevoles_montant_max.yml
@@ -8,7 +8,7 @@ conditions:
   - Apporter pour les personnes majeures la preuve d'une responsabilité dans le Bureau
     d'une association depuis au moins un an ou d'une implication régulière d'au
     moins deux ans.
-conditions_benevoles:
+voluntary_conditions:
   - Justifier pour les personnes mineures d'un engagement d'au moins un an dans une ou
     plusieurs associations domiciliées en Vendée.
 interestFlag: null

--- a/data/benefits/openfisca/vendee_bourses_jeunes_benevoles_montant_max.yml
+++ b/data/benefits/openfisca/vendee_bourses_jeunes_benevoles_montant_max.yml
@@ -5,11 +5,12 @@ description: Le Département de la Vendée attribue des bourses d'études ou pou
   actions bénévoles.
 prefix: les
 conditions:
-  - Justifier pour les personnes mineures d'un engagement d'au moins un an dans une ou
-    plusieurs associations domiciliées en Vendée.
   - Apporter pour les personnes majeures la preuve d'une responsabilité dans le Bureau
     d'une association depuis au moins un an ou d'une implication régulière d'au
     moins deux ans.
+conditions_benevoles:
+  - Justifier pour les personnes mineures d'un engagement d'au moins un an dans une ou
+    plusieurs associations domiciliées en Vendée.
 interestFlag: null
 type: float
 unit: €

--- a/src/components/droits-details.vue
+++ b/src/components/droits-details.vue
@@ -21,11 +21,30 @@
         />
       </p>
       <div
-        v-if="droit.conditions?.length"
+        v-if="droit.conditions?.length || droit.voluntary_conditions?.length"
         class="fr-highlight fr-ml-0 fr-py-2w fr-mb-2w"
       >
         <strong>Pour en bénéficier, vous devez également : </strong>
-        <ul class="fr-toggle__list fr-px-0">
+        <ul
+          v-if="droit.voluntary_conditions?.length"
+          class="fr-toggle__list fr-px-0"
+        >
+          <li
+            v-for="(voluntary_condition, index) in droit.voluntary_conditions"
+            :key="index"
+          >
+            <img alt="" src="@/assets/images/doigt.svg" class="fr-mr-1w" />
+            <span v-html="voluntary_condition" />
+            <span v-if="volontaryOrganisationsLink">
+              La liste des associations à proximité est disponible sur la
+              plateforme
+              <a :href="volontaryOrganisationsLink" target="_blank"
+                >JeVeuxAider.gouv.fr</a
+              >
+            </span>
+          </li>
+        </ul>
+        <ul v-if="droit.conditions?.length" class="fr-toggle__list fr-px-0">
           <li v-for="(condition, index) in droit.conditions" :key="index">
             <img alt="" src="@/assets/images/doigt.svg" class="fr-mr-1w" />
             <span v-html="condition" />

--- a/src/components/droits-details.vue
+++ b/src/components/droits-details.vue
@@ -26,7 +26,7 @@
       >
         <strong>Pour en bénéficier, vous devez également : </strong>
         <ul
-          v-if="droit.voluntary_conditions?.length"
+          v-if="droit.voluntary_conditions?.length > 0"
           class="fr-toggle__list fr-px-0"
         >
           <li
@@ -35,7 +35,12 @@
           >
             <img alt="" src="@/assets/images/doigt.svg" class="fr-mr-1w" />
             <span v-html="voluntary_condition" />
-            <span v-if="volontaryOrganisationsLink">
+            <span
+              v-if="
+                volontaryOrganisationsLink &&
+                index === droit.voluntary_conditions.length - 1
+              "
+            >
               La liste des associations à proximité est disponible sur la
               plateforme
               <a :href="volontaryOrganisationsLink" target="_blank"

--- a/src/components/droits-details.vue
+++ b/src/components/droits-details.vue
@@ -149,6 +149,7 @@ import WarningMessage from "@/components/warning-message.vue"
 import { useStore } from "@/stores/index.ts"
 import { BehaviourEventTypes } from "@lib/enums/behaviour-event-types.ts"
 import ABTestingService from "@/plugins/ab-testing-service.ts"
+import { useVolontaryOrganisations } from "@/composables/use-voluntary-organisations.ts"
 
 export default {
   name: "DroitsDetails",
@@ -169,6 +170,7 @@ export default {
   setup() {
     return {
       store: useStore(),
+      volontaryOrganisations: useVolontaryOrganisations(),
     }
   },
   data() {
@@ -186,6 +188,9 @@ export default {
     },
     experimentNewUI() {
       return ABTestingService.getValues().benefit_result_page === "NewUI"
+    },
+    volontaryOrganisationsLink() {
+      return this.volontaryOrganisations.volontaryOrganisationsLink.value
     },
   },
 }

--- a/src/components/droits-details.vue
+++ b/src/components/droits-details.vue
@@ -21,12 +21,12 @@
         />
       </p>
       <div
-        v-if="droit.conditions?.length || droit.voluntary_conditions?.length"
+        v-if="showConditions(droit)"
         class="fr-highlight fr-ml-0 fr-py-2w fr-mb-2w"
       >
         <strong>Pour en bénéficier, vous devez également : </strong>
         <ul
-          v-if="droit.voluntary_conditions?.length > 0"
+          v-if="showVoluntaryConditions(droit)"
           class="fr-toggle__list fr-px-0"
         >
           <li
@@ -35,12 +35,7 @@
           >
             <img alt="" src="@/assets/images/doigt.svg" class="fr-mr-1w" />
             <span v-html="voluntary_condition" />
-            <span
-              v-if="
-                volontaryOrganisationsLink &&
-                index === droit.voluntary_conditions.length - 1
-              "
-            >
+            <span v-if="showVoluntaryOrganisationsLink(droit, index)">
               La liste des associations à proximité est disponible sur la
               plateforme
               <a :href="volontaryOrganisationsLink" target="_blank"
@@ -49,7 +44,7 @@
             </span>
           </li>
         </ul>
-        <ul v-if="droit.conditions?.length" class="fr-toggle__list fr-px-0">
+        <ul v-if="showBaseConditions(droit)" class="fr-toggle__list fr-px-0">
           <li v-for="(condition, index) in droit.conditions" :key="index">
             <img alt="" src="@/assets/images/doigt.svg" class="fr-mr-1w" />
             <span v-html="condition" />
@@ -196,6 +191,21 @@ export default {
     },
     volontaryOrganisationsLink() {
       return this.volontaryOrganisations.volontaryOrganisationsLink.value
+    },
+    showVoluntaryOrganisationsLink() {
+      return (droit, index) =>
+        this.volontaryOrganisationsLink &&
+        index === droit.voluntary_conditions.length - 1
+    },
+    showConditions() {
+      return (droit) =>
+        droit.conditions?.length || droit.voluntary_conditions?.length
+    },
+    showBaseConditions() {
+      return (droit) => droit.conditions?.length
+    },
+    showVoluntaryConditions() {
+      return (droit) => droit.voluntary_conditions?.length
     },
   },
 }

--- a/src/composables/use-voluntary-organisations.ts
+++ b/src/composables/use-voluntary-organisations.ts
@@ -19,7 +19,6 @@ export function useVolontaryOrganisations() {
     }
 
     if (!cityPostalCode) {
-      console.log("No city postal code found")
       volontaryOrganisationsLink.value = `https://www.jeveuxaider.gouv.fr/organisations`
       updating.value = false
       return
@@ -40,6 +39,7 @@ export function useVolontaryOrganisations() {
     }
 
     if (!centerCoordinatesFromPostalCode) {
+      volontaryOrganisationsLink.value = `https://www.jeveuxaider.gouv.fr/organisations`
       updating.value = false
       return
     }

--- a/src/composables/use-voluntary-organisations.ts
+++ b/src/composables/use-voluntary-organisations.ts
@@ -28,7 +28,7 @@ export function useVolontaryOrganisations() {
     let centerCoordinatesFromPostalCode = null
     try {
       const response = await axios.get(
-        `/api/outils/communes/${cityPostalCode}/centerCoordinates`
+        `/api/outils/codePostal/${cityPostalCode}/centerCoordinates`
       )
       centerCoordinatesFromPostalCode = response.data
     } catch (error) {

--- a/src/composables/use-voluntary-organisations.ts
+++ b/src/composables/use-voluntary-organisations.ts
@@ -12,12 +12,12 @@ export function useVolontaryOrganisations() {
 
   const buildVolontaryOrganisationsLink = async () => {
     let cityInseeCode = store.situation.menage.depcom
-    let cityPostcode = store.situation.menage._codePostal
+    let cityPostalCode = store.situation.menage._codePostal
     const simulationId = Simulation.getLatestId()
     if (!store.hasResults && !cityInseeCode && simulationId) {
       await store.fetch(simulationId)
       cityInseeCode = store.situation.menage.depcom
-      cityPostcode = store.situation.menage._codePostal
+      cityPostalCode = store.situation.menage._codePostal
     }
 
     if (!cityInseeCode) {
@@ -28,12 +28,12 @@ export function useVolontaryOrganisations() {
     let centerCoordinatesFromPostalCode = null
     try {
       const response = await axios.get(
-        `/api/outils/communes/${cityPostcode}/centerCoordinates`
+        `/api/outils/communes/${cityPostalCode}/centerCoordinates`
       )
       centerCoordinatesFromPostalCode = response.data
     } catch (error) {
       Sentry.captureMessage(
-        `Center coordinates not found for city postcode ${cityPostcode}`
+        `Center coordinates not found for city postalcode ${cityPostalCode}`
       )
       updating.value = false
       return
@@ -46,7 +46,7 @@ export function useVolontaryOrganisations() {
     const cityLong = centerCoordinatesFromPostalCode[0]
     const cityLat = centerCoordinatesFromPostalCode[1]
 
-    volontaryOrganisationsLink.value = `https://www.jeveuxaider.gouv.fr/organisations?city=${cityPostcode}&aroundLatLng=${cityLat},${cityLong}`
+    volontaryOrganisationsLink.value = `https://www.jeveuxaider.gouv.fr/organisations?city=${cityPostalCode}&aroundLatLng=${cityLat},${cityLong}`
     updating.value = false
   }
 

--- a/src/composables/use-voluntary-organisations.ts
+++ b/src/composables/use-voluntary-organisations.ts
@@ -25,12 +25,12 @@ export function useVolontaryOrganisations() {
       updating.value = false
       return
     }
-    let centerCoordinates = null
+    let centerCoordinatesFromPostalCode = null
     try {
       const response = await axios.get(
         `/api/outils/communes/${cityPostcode}/centerCoordinates`
       )
-      centerCoordinates = response.data
+      centerCoordinatesFromPostalCode = response.data
     } catch (error) {
       Sentry.captureMessage(
         `Center coordinates not found for city postcode ${cityPostcode}`
@@ -39,12 +39,12 @@ export function useVolontaryOrganisations() {
       return
     }
 
-    if (!centerCoordinates) {
+    if (!centerCoordinatesFromPostalCode) {
       updating.value = false
       return
     }
-    const cityLong = centerCoordinates[0]
-    const cityLat = centerCoordinates[1]
+    const cityLong = centerCoordinatesFromPostalCode[0]
+    const cityLat = centerCoordinatesFromPostalCode[1]
 
     volontaryOrganisationsLink.value = `https://www.jeveuxaider.gouv.fr/organisations?city=${cityPostcode}&aroundLatLng=${cityLat},${cityLong}`
     updating.value = false

--- a/src/composables/use-voluntary-organisations.ts
+++ b/src/composables/use-voluntary-organisations.ts
@@ -11,20 +11,20 @@ export function useVolontaryOrganisations() {
   const updating = ref<boolean>(true)
 
   const buildVolontaryOrganisationsLink = async () => {
-    let cityInseeCode = store.situation.menage.depcom
     let cityPostalCode = store.situation.menage._codePostal
     const simulationId = Simulation.getLatestId()
-    if (!store.hasResults && !cityInseeCode && simulationId) {
+    if (!store.hasResults && !cityPostalCode && simulationId) {
       await store.fetch(simulationId)
-      cityInseeCode = store.situation.menage.depcom
       cityPostalCode = store.situation.menage._codePostal
     }
 
-    if (!cityInseeCode) {
+    if (!cityPostalCode) {
+      console.log("No city postal code found")
       volontaryOrganisationsLink.value = `https://www.jeveuxaider.gouv.fr/organisations`
       updating.value = false
       return
     }
+
     let centerCoordinatesFromPostalCode = null
     try {
       const response = await axios.get(

--- a/src/composables/use-voluntary-organisations.ts
+++ b/src/composables/use-voluntary-organisations.ts
@@ -21,7 +21,7 @@ export function useVolontaryOrganisations() {
     }
 
     if (!cityInseeCode) {
-      Sentry.captureMessage(`Depcom required to buildVolontaryOrganisations()`)
+      volontaryOrganisationsLink.value = `https://www.jeveuxaider.gouv.fr/organisations`
       updating.value = false
       return
     }

--- a/src/composables/use-voluntary-organisations.ts
+++ b/src/composables/use-voluntary-organisations.ts
@@ -1,0 +1,54 @@
+import { ref } from "vue"
+import { useStore } from "@/stores/index.js"
+import * as Sentry from "@sentry/vue"
+import Simulation from "@/lib/simulation.js"
+import communesLonLat from "communes-lonlat"
+
+export function useVolontaryOrganisations() {
+  const store = useStore()
+
+  const volontaryOrganisationsLink = ref<string>()
+  const updating = ref<boolean>(true)
+
+  const buildVolontaryOrganisationsLink = async () => {
+    let cityInseeCode = store.situation.menage.depcom
+    let cityPostcode = store.situation.menage._codePostal
+    const simulationId = Simulation.getLatestId()
+    if (!store.hasResults && !cityInseeCode && simulationId) {
+      await store.fetch(simulationId)
+      cityInseeCode = store.situation.menage.depcom
+      cityPostcode = store.situation.menage._codePostal
+    }
+
+    if (!cityInseeCode) {
+      Sentry.captureMessage(`Depcom required to buildVolontaryOrganisations()`)
+      updating.value = false
+      return
+    }
+
+    const longLat = communesLonLat.find(
+      (commune) => commune.code === cityInseeCode
+    )
+
+    if (!longLat) {
+      Sentry.captureMessage(
+        `LongLat not found for cityInseeCode ${cityInseeCode}`
+      )
+      updating.value = false
+      return
+    }
+    const cityLong = longLat.centre.coordinates[0]
+    const cityLat = longLat.centre.coordinates[1]
+
+    volontaryOrganisationsLink.value = `https://www.jeveuxaider.gouv.fr/organisations?city=${cityPostcode}&aroundLatLng=${cityLat},${cityLong}`
+    updating.value = false
+  }
+
+  buildVolontaryOrganisationsLink()
+
+  return {
+    updating,
+    volontaryOrganisationsLink,
+    buildVolontaryOrganisationsLink,
+  }
+}


### PR DESCRIPTION
## Description

[Tâche associée
](https://trello.com/c/6RJe0awL/1362-cr%C3%A9er-un-nouveau-champ-permettant-dindiquer-la-contrepartie-b%C3%A9n%C3%A9vole-dune-aide)

Cette PR est rebase et peut se lire commit par commit 

## Première itération

Structuration de la donnée et proposition d'une première UI et revue suite aux commentaires ci-dessous

## Seconde itération

- UI revue : Les conditions bénévoles sont affichées en premier item de la liste des conditions générales pour ne pas surcharger l'interface
- Un lien est ajouté vers la plateforme JeVeuxAider si un code postal est indiqué (<=> si une simulation a été effectuée) avec le filtrage de la ville via son code postal + les coordonnées du centre (lat/long)
- Le fetch des coordonnées du centre de la ville associée au code postal alourdissait le client: le build en CI et l'intégration Netlify échouaient. Une route en backend a donc été ajoutée pour alléger la mémoire sur le frontend, elle permet de récupérer les coordonnées (lat/long) du centre d'une ville à partir du code postal.