### PR TITLE
Corrige un warning dans l'import du css du dsfr

### DIFF
--- a/src/plugins/theme-service.ts
+++ b/src/plugins/theme-service.ts
@@ -25,6 +25,7 @@ const options = [
 export default {
   install: (app) => {
     const styleElement = document.createElement("style")
+    styleElement.textContent = defaultDsfr
     document.head.appendChild(styleElement)
 
     app.config.globalProperties.$theme = {


### PR DESCRIPTION
## Détails

Un warning est présent lors du build du front indiquant que l'import de fichier css doit avoir le paramètre `inline`