### PR TITLE
Ajoute une entrée des données historique dans les stats

### DIFF
--- a/backend/lib/stats/mongodb.ts
+++ b/backend/lib/stats/mongodb.ts
@@ -108,7 +108,7 @@ function extractSurveySummary(db) {
           const { month, answer } = row._id
           set.summary[answer] = (set.summary[answer] || 0) + row.value
           set.total += row.value
- set.historical[month] = set.historical[month] || {};
+          set.historical[month] = set.historical[month] || {}
           set.historical[month][answer] = row.value
           return set
         },


### PR DESCRIPTION
## Détails

Basé sur la PR #3821 et nécessaire pour la [tâche 1367](https://trello.com/c/GaA3mGON/1367-ajouter-une-vue-avec-le-nombre-de-r%C3%A9ponse-au-sondage-par-mois)

## Notes

Cette PR permet d'exposer des stats historiques pour les données de sondages. Le document `dist/documents/stats.json` contient au niveau de la clef `survey` une nouvelle entrée `historical` : 
```json
"historical": {
  "2023-06": {
    "asked": 1,
    "failed": 1,
    "nothing": 1
  },
  "2023-04": {
    "nothing": 1,
    "asked": 1
  },
  "2023-03": {
    "asked": 3,
    "failed": 2,
    "nothing": 3
  },
  "2022-06": {
    "failed": 1
  }
}
```
À noter qu'il n'y a pas de limites d'ancienneté de la donnée exposée là où la tâche Trello cible les 4 derniers mois. Ce choix arbitraire est dû au fait que la donnée exposée n'a pas vocation à être utilisée uniquement par le site de stats mais pourrait être exploitée dans d'autres cas d'usages / par d'autres personnes.

---

Cette PR contient également une refacto partielle `backend/lib/stats/mongodb.ts` en utilisant notamment des `async/await` dans la fonction `getStats` pour gagner en lisibilité.

