### PR TITLE
Modifie deux aides de la région CVL : ordinateur portable et premier équipement pro

### DIFF
--- a/data/benefits/javascript/centre-val-de-loire-aide-au-1er-equipement-professionnel.yml
+++ b/data/benefits/javascript/centre-val-de-loire-aide-au-1er-equipement-professionnel.yml
@@ -14,8 +14,8 @@ profils:
       - type: annee_etude
         values:
           - cap_1
+          - seconde
           - premiere
-          - terminale
 conditions:
   - Être en 1ère année de bac pro ou de CAP, ou bien être en 2ème année après avoir
     suivi un autre cursus.

--- a/data/benefits/javascript/centre-val-de-loire-aide-au-1er-equipement-professionnel.yml
+++ b/data/benefits/javascript/centre-val-de-loire-aide-au-1er-equipement-professionnel.yml
@@ -1,7 +1,7 @@
 label: aide au premier équipement professionnel
 institution: region_centre_val_de_loire
-description: L'aide au premier équipement professionnel est une aide financière
-  versée aux lycéens et lycéennes inscrits en bac pro et dont la formation nécessite
+description: L'aide au premier équipement professionnel est versée aux personnes
+  inscrites en 1ère année de bac pro ou de CAP et dont la formation nécessite
   l'achat d'un équipement professionnel (outillage, vêtements ou équipements spéciaux).
 prefix: l’
 conditions_generales:
@@ -9,10 +9,15 @@ conditions_generales:
     values:
       - "24"
 profils:
-  - type: lyceen
-    conditions: []
+  - type: etudiant
+    conditions:
+      - type: annee_etude
+        values:
+          - cap_1
+          - premiere
+          - terminale
 conditions:
-  - Être en 1ère année de bac pro ou bien être en 2ème année après avoir
+  - Être en 1ère année de bac pro ou de CAP, ou bien être en 2ème année après avoir
     suivi un autre cursus.
 type: float
 unit: €

--- a/data/benefits/javascript/centre-val-de-loire-aide-au-1er-equipement-professionnel.yml
+++ b/data/benefits/javascript/centre-val-de-loire-aide-au-1er-equipement-professionnel.yml
@@ -1,9 +1,8 @@
 label: aide au premier équipement professionnel
 institution: region_centre_val_de_loire
 description: L'aide au premier équipement professionnel est une aide financière
-  qui vous est versée si vous êtes lycéen ou lycéenne. Elle vous aidera à acheter
-  l’équipement professionnel indispensable à votre activité (outillage,
-  vêtements ou équipements spéciaux).
+  versée aux lycéens et lycéennes inscrits en bac pro et dont la formation nécessite
+  l'achat d'un équipement professionnel (outillage, vêtements ou équipements spéciaux).
 prefix: l’
 conditions_generales:
   - type: regions
@@ -13,8 +12,7 @@ profils:
   - type: lyceen
     conditions: []
 conditions:
-  - Être lycéen ou lycéenne en 1ère année de bac pro dont la formation professionnelle
-    nécessite l’achat d’équipements, ou bien être en 2ème année après avoir
+  - Être en 1ère année de bac pro ou bien être en 2ème année après avoir
     suivi un autre cursus.
 type: float
 unit: €

--- a/data/benefits/javascript/region-pays-de-la-loire-aide-acquisition-ordinateur-portable.yml
+++ b/data/benefits/javascript/region-pays-de-la-loire-aide-acquisition-ordinateur-portable.yml
@@ -21,5 +21,4 @@ profils:
         values:
           - cap_1
           - seconde
-private: true
 periodicite: ponctuelle


### PR DESCRIPTION
aide acquisition premier équipement : j'ai modifié le texte et les conditions pour cibler spécifiquement les personnes inscrites en première année de bac pro ou de CAP

ordinateur portable : j'ai retiré la condition private:true pour que l'aide soit visible dans le simulateur