### PR TITLE
Augmente la fréquence de mise à jour des aides vélo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     rebase-strategy: "disabled"
     versioning-strategy: increase
     open-pull-requests-limit: 1


### PR DESCRIPTION
Salut :) 

Je ne vois pas de raison particulière d'insérer un délai qui peut aller jusqu'à une semaine entre le moment où je publie un paquet de mise à jour des aides vélo, et le moment où vous en êtes notifiés.

Naturellement même si la fréquence de @dependabot augmente vous garder l'entier contrôle sur le rythme d'intégration des mises à jour.