### PR TITLE
[FIX] version de python spécifique

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   OPENFISCA_BIND_HOST: 127.0.0.1:2000
   LC_ALL: C.UTF-8
   LANG: C.UTF-8
-  PYTHON_VERSION: 3.8
+  PYTHON_VERSION: 3.8.17
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Détails

Cette PR corrige certains problèmes de CI tels que rencontré dans [ce run github-actions](https://github.com/betagouv/aides-jeunes/actions/runs/5585426178)

Le problème est le suivant : 
- la version de Python indiquée dans le fichier `ci.yml` est `PYTHON_VERSION: 3.8`. Le runner de github va pour chaque étape utiliser une image Python `3.8`, mais cela peut être de manière indifférencié `3.8.16` ou `3.8.17`
- l'installation des dépendances d'openfisca est faite durant l'étape `Install` et `Install Openfisca` dans un dossier `venv`
- une fois l'installation terminée, le dossier `venv` est mis en cache en se basant sur le hash du fichier `requirements.txt` et la version de Python définie par `PYTHON_VERSION`

À date les différents échecs de la CI ont lieu lorsque le runner github utilise Python `3.8.16` lorsque l'étape d'installation a eu lieu avec la dernière version (`3.8.17`).

~~La solution proposée par cette PR est d'ajouter l'option `check-latest: true` qui permet au runner de télécharger une version plus récente de Python si elle existe (cf [documentation](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#check-latest-version)).~~

La solution choisie est de hardcoder la version mineure de Python utilisée (ex: `PYTHON_VERSION: 3.8.17`). Les différentes versions de Python disponibles sont listées [sur cette page](https://github.com/actions/python-versions/blob/main/versions-manifest.json)