### PR TITLE
Ajoute l'aide au permis de conduire de la gironde pour les jeunes ruraux

### DIFF
--- a/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
@@ -20,7 +20,6 @@ profils:
   - type: chomeur
   - type: beneficiaire_rsa
   - type: service_civique
-  - type: profils.autre
 conditions:
   - Etre éligible aux critères du Fonds d'Aide au Jeunes.
   - Résider dans une commune de la Gironde qui ne se situe pas au sein de la Métropole.

--- a/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
@@ -25,7 +25,10 @@ conditions:
   - Résider dans une commune de la Gironde qui ne se situe pas au sein de la Métropole.
   - Réaliser 70 heures de bénévolat auprès d’une association ou d'une collectivité locale.
 interestFlag: _interetPermisDeConduire
-type: bool
+type: float
+montant: 75
+unit: "%"
+legend: "du prix du permis"
 periodicite: ponctuelle
 link: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire
 instructions: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire

--- a/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
@@ -18,7 +18,6 @@ conditions_generales:
     value: 25
 profils:
   - type: chomeur
-  - type: autre
   - type: beneficiaire_rsa
   - type: service_civique
 conditions:

--- a/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
@@ -1,0 +1,33 @@
+label: Aide départementale au Permis de conduire
+institution: departement_gironde
+description: Le Département facilite l’accès au permis de conduire pour des
+  jeunes en difficultés sociale et financière, domiciliés sur les territoires
+  ruraux où l’offre de transport collectif est peu développée. Cette aide est
+  versée en contrepartie d'un engagement bénévole au sein d'une association ou
+  d'une collectivité.
+prefix: l’
+conditions_generales:
+  - type: departements
+    values:
+      - "33"
+  - type: age
+    operator: ">="
+    value: 18
+  - type: age
+    operator: <=
+    value: 25
+profils:
+  - type: chomeur
+  - type: autre
+  - type: beneficiaire_rsa
+  - type: service_civique
+conditions:
+  - Etre éligible aux critères du Fonds d'Aide au Jeunes.
+  - Résider dans une commune de la Gironde qui ne se situe pas au sein de la Métropole.
+  - Réaliser 70 heures de bénévolat auprès d’une association ou d'une collectivité locale.
+interestFlag: _interetPermisDeConduire
+type: float
+unit: €
+periodicite: ponctuelle
+link: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire
+instructions: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire

--- a/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
@@ -25,9 +25,7 @@ conditions:
   - Résider dans une commune de la Gironde qui ne se situe pas au sein de la Métropole.
   - Réaliser 70 heures de bénévolat auprès d’une association ou d'une collectivité locale.
 interestFlag: _interetPermisDeConduire
-type: float
-unit: €
+type: boolean
 periodicite: ponctuelle
-montant: 800
 link: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire
 instructions: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire

--- a/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
@@ -29,5 +29,6 @@ interestFlag: _interetPermisDeConduire
 type: float
 unit: €
 periodicite: ponctuelle
+montant: 800
 link: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire
 instructions: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire

--- a/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
@@ -25,7 +25,7 @@ conditions:
   - Résider dans une commune de la Gironde qui ne se situe pas au sein de la Métropole.
   - Réaliser 70 heures de bénévolat auprès d’une association ou d'une collectivité locale.
 interestFlag: _interetPermisDeConduire
-type: boolean
+type: bool
 periodicite: ponctuelle
 link: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire
 instructions: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire

--- a/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
@@ -20,6 +20,7 @@ profils:
   - type: chomeur
   - type: beneficiaire_rsa
   - type: service_civique
+  - type: profils.autre
 conditions:
   - Etre éligible aux critères du Fonds d'Aide au Jeunes.
   - Résider dans une commune de la Gironde qui ne se situe pas au sein de la Métropole.


### PR DESCRIPTION
étape 1 : ajouter l'aide
étape 2 : coder le montant de l'aide (75% du prix du permis est financé par le département)