### PR TITLE
Met à jour l'aide au permis de conduire de la Mission Locale d'Hénin-Carvin

### DIFF
--- a/data/benefits/javascript/mission-locale-de-lagglomeration-dhenin-carvin-aide-au-financement-du-permis-de-conduire-le-permis-cest-permis.yml
+++ b/data/benefits/javascript/mission-locale-de-lagglomeration-dhenin-carvin-aide-au-financement-du-permis-de-conduire-le-permis-cest-permis.yml
@@ -22,11 +22,10 @@ profils:
     conditions: []
 conditions:
   - Avoir obtenu le code de la route.
-  - Etre inscrit dans une auto-école partenaire.
-  - Effectuer des immersions professionnelles et un
-    atelier de prévention et de sécurité routière.
+  - Être inscrit dans une auto-école partenaire.
+  - Effectuer des immersions professionnelles.
 voluntary_conditions:
-  - Effectuer 35 heures de bénévolat.
+  - Effectuer 35 heures de bénévolat au sein d'une association.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €


### PR DESCRIPTION
à leur demande : l'atelier de sécurité routière n'existe plus