### PR TITLE
Affiche un message pour le code postal des parents

### DIFF
--- a/src/lib/hint.ts
+++ b/src/lib/hint.ts
@@ -5,7 +5,7 @@ const texts = {
     return "Le simulateur n'accepte que les codes postaux français. Si vous vivez à l'étranger, ce simulateur n'est pas encore adapté à votre situation."
   },
   _bourseCriteresSociauxCommuneDomicileFamilial: (): string => {
-    return "Lorsque les parents sont séparés, il faut prendre les ressources du parent ayant à la charge l'étudiant. Si l'étudiant est en garde alternée, il faut faire la somme des ressources des deux foyers fiscaux des parents séparés."
+    return "Lorsque vos parents sont séparés, il faut indiquer le code postal du parent qui vous a à charge. Si vous êtes encore mineur et en garde alternée, il faut indiquer le code postal du parent dont le domicile est le plus proche du votre."
   },
   enfants: (): string => {
     return `« Un enfant à charge » est un enfant dont vous êtes responsable et dont vous vous occupez, qu'il soit votre enfant naturel ou non.`


### PR DESCRIPTION
## Détails

[Tâche trello](https://trello.com/c/eWdvRxTA/1374-parents-s%C3%A9par%C3%A9s-am%C3%A9liorer-la-question-sur-le-code-postal-des-parents)

## Notes

J'avais commencé à faire une refacto pour n'afficher la popup que lorsque l'utilisateur avait indiqué que ses parents étaient séparés / célibataire mais cela impliquait d'intégrer l'étape depcom dans mutualized-step (ou de réintégrer une partie de la logique d'affichage dans depcom). J'ai finalement préféré afficher le message à l'ensemble des utilisateurs à la fois en raison de sa formulation ("lorsque les parents sont séparés") et pour limiter le nombre de fichiers modifiés.

<img width="814" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/16650011/42d96803-7c39-43fe-85ab-800bd15ecddb">