### PR TITLE
Enrichit l'AB test pour la récupération des résultats par email

### DIFF
--- a/lib/enums/event-categories.ts
+++ b/lib/enums/event-categories.ts
@@ -6,4 +6,5 @@ export enum EventCategories {
   PARCOURS = "Parcours",
   ACCOMPAGNEMENT = "Accompaniment",
   MONTANT_ATTENDU = "Montant attendu",
+  FOLLOWUP = "Followup",
 }

--- a/src/components/buttons/send-recap-email-button.vue
+++ b/src/components/buttons/send-recap-email-button.vue
@@ -20,6 +20,7 @@
 <script>
 import { useStore } from "@/stores/index.ts"
 import ABTestingService from "@/plugins/ab-testing-service.ts"
+import { EventCategories } from "@lib/enums/event-categories.ts"
 
 export default {
   name: "SendRecapEmailButton",
@@ -37,10 +38,19 @@ export default {
     }
   },
   methods: {
+    sendEvent() {
+      this.sendEventToMatomo(
+        EventCategories.GENERAL,
+        "Recap",
+        ABTestingService.getValues().recap_email_form
+      )
+    },
     goToEmailFormPage() {
+      this.sendEvent()
       this.$router.push({ name: "resultatsRecapEmail" })
     },
     goToEmailFormModal() {
+      this.sendEvent()
       this.store.setRecapEmailState("show")
     },
   },

--- a/src/components/buttons/send-recap-email-button.vue
+++ b/src/components/buttons/send-recap-email-button.vue
@@ -21,9 +21,11 @@
 import { useStore } from "@/stores/index.ts"
 import ABTestingService from "@/plugins/ab-testing-service.ts"
 import { EventCategories } from "@lib/enums/event-categories.ts"
+import StatisticsMixin from "@/mixins/statistics.ts"
 
 export default {
   name: "SendRecapEmailButton",
+  mixins: [StatisticsMixin],
   props: {
     text: {
       type: String,
@@ -40,8 +42,8 @@ export default {
   methods: {
     sendEvent() {
       this.sendEventToMatomo(
-        EventCategories.GENERAL,
-        "Clic : bouton d'accès au récapitulatif par email",
+        EventCategories.FOLLOWUP,
+        "Affiche le formulaire",
         ABTestingService.getValues().recap_email_form
       )
     },

--- a/src/components/buttons/send-recap-email-button.vue
+++ b/src/components/buttons/send-recap-email-button.vue
@@ -41,7 +41,7 @@ export default {
     sendEvent() {
       this.sendEventToMatomo(
         EventCategories.GENERAL,
-        "Recap",
+        "Clic : bouton d'accès au récapitulatif par email",
         ABTestingService.getValues().recap_email_form
       )
     },

--- a/src/components/buttons/send-recap-email-button.vue
+++ b/src/components/buttons/send-recap-email-button.vue
@@ -41,7 +41,7 @@ export default {
     sendEvent() {
       this.sendEventToMatomo(
         EventCategories.GENERAL,
-        "Clic : bouton d'accès au récapitulatif par email",
+        "Clic : bouton d'accès au récapitulatif par email",
         ABTestingService.getValues().recap_email_form
       )
     },

--- a/src/components/modals/recap-email-modal.vue
+++ b/src/components/modals/recap-email-modal.vue
@@ -116,6 +116,7 @@ import WarningMessage from "@/components/warning-message.vue"
 import { useStore } from "@/stores/index.ts"
 import StatisticsMixin from "@/mixins/statistics.ts"
 import { EventCategories } from "@lib/enums/event-categories.ts"
+import ABTestingService from "@/plugins/ab-testing-service.ts"
 
 export default {
   name: "RecapEmailModal",
@@ -170,6 +171,11 @@ export default {
         .post(uri, payload)
         .then(() => {
           this.store.setRecapEmailState("ok")
+          this.sendEventToMatomo(
+            EventCategories.FOLLOWUP,
+            "Formulaire validé",
+            ABTestingService.getValues().recap_email_form
+          )
         })
         .catch(() => {
           this.store.setRecapEmailState("error")

--- a/src/views/simulation/resultats/recap-email.vue
+++ b/src/views/simulation/resultats/recap-email.vue
@@ -7,6 +7,7 @@ import BackButton from "@/components/buttons/back-button.vue"
 import { useRouter } from "vue-router"
 import StatisticsMixin from "@/mixins/statistics.js"
 import { EventCategories } from "@lib/enums/event-categories.ts"
+import ABTestingService from "@/plugins/ab-testing-service.ts"
 
 const router = useRouter()
 const store = useStore()
@@ -49,6 +50,11 @@ const sendEmailRecap = async (surveyOptin) => {
     await axios.post(uri, payload)
     store.setRecapEmailState("ok")
     emailValue.value = ""
+    StatisticsMixin.methods.sendEventToMatomo(
+      EventCategories.FOLLOWUP,
+      "Formulaire validé",
+      ABTestingService.getValues().recap_email_form
+    )
   } catch (error) {
     store.setRecapEmailState("error")
   }


### PR DESCRIPTION
Ajoute une étape dans le tunnel de conversion pour la demande de récupération des résultats par email pour comprendre l'important écart mis en avant par les stats de juin et juillet.


|version |simulations |followups |  proportion|
|-|-|-|-|
|modal | 41056 | 4386 | 10.68%|
|page | 41676  | 3580 | 8.59%|
