### PR TITLE
Refactor la condition `taux incapacite` pour une gestion affinée

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -200,20 +200,14 @@ fields:
   field_taux_incapacite: &field_taux_incapacite
     label: Taux d'incapacité
     name: taux_incapacite
-    widget: object
     fields:
-      - label: Valeurs
-        name: values
-        widget: select
-        multiple: true
-        required: false
-        options:
-          - label: Inférieur à 50%
-            value: inferieur_50
-          - label: Supérieur ou égal à 50% et inférieur à 80%
-            value: entre_50_et_80
-          - label: Supérieur ou égal à 80%
-            value: superieur_ou_egal_80
+      - *field_numeric_operator
+      - <<: *field_numeric_value
+        label: Taux
+        value_type: float
+        min: 0
+        max: 1
+        hint: Le taux est exprimé par un nombre entre 0 et 1. Exemple 0.8 pour 80%.
   field_formation_sanitaire_social: &field_formation_sanitaire_social
     <<: *field_empty
     label: En formation sanitaire et sociale

--- a/data/benefits/javascript/intercommunalite_bordeaux-tarification-solidaire-des-transports.yml
+++ b/data/benefits/javascript/intercommunalite_bordeaux-tarification-solidaire-des-transports.yml
@@ -15,9 +15,8 @@ profils:
   - type: situation_handicap
     conditions:
       - type: taux_incapacite
-        values:
-          - entre_50_et_80
-          - superieur_ou_egal_80
+        operator: ">="
+        value: 0.5
 type: bool
 periodicite: ponctuelle
 link: https://tarificationsolidaire.bordeaux-metropole.fr/Accueil.aspx

--- a/lib/benefits/compute-javascript.ts
+++ b/lib/benefits/compute-javascript.ts
@@ -265,18 +265,7 @@ export const CONDITION_STRATEGY: ConditionsLayout = {
   taux_incapacite: {
     test: (condition, { situation }: { situation: situationsLayout }) => {
       const taux_incapacite = situation.demandeur?.taux_incapacite || 0
-      return condition.values.some((value) => {
-        switch (value) {
-          case "inferieur_50":
-            return taux_incapacite < 0.5
-          case "entre_50_et_80":
-            return taux_incapacite >= 0.5 && taux_incapacite < 0.8
-          case "superieur_ou_egal_80":
-            return taux_incapacite >= 0.8
-          default:
-            return false
-        }
-      })
+      return OPERATOR[condition.operator](taux_incapacite, condition.value)
     },
   },
 }

--- a/tests/unit/compute-javascript-benefits.spec.ts
+++ b/tests/unit/compute-javascript-benefits.spec.ts
@@ -233,3 +233,81 @@ describe("computeAides", function () {
     ).toBe(0)
   })
 })
+
+describe("Test condition taux_incapacite", function () {
+  let situation_handicap
+  let benefit_situation_handicap
+
+  beforeEach(() => {
+    situation_handicap = {
+      demandeur: {
+        activite: "situation_handicap",
+        taux_incapacite: 0.3,
+      },
+    }
+    benefit_situation_handicap = {
+      profils: [
+        {
+          type: "situation_handicap",
+          conditions: [
+            {
+              type: "taux_incapacite",
+              value: 0.5,
+              operator: ">=",
+            },
+          ],
+        },
+      ],
+    }
+  })
+
+  it("Checks that someone with incapacite 30 is not eligible with 50+", function () {
+    expect(
+      testProfileEligibility(benefit_situation_handicap, {
+        situation: situation_handicap,
+      })
+    ).toBe(false)
+  })
+
+  it("Checks that someone with incapacite 50 is eligible with >= 50", function () {
+    situation_handicap.demandeur.taux_incapacite = 0.5
+
+    expect(
+      testProfileEligibility(benefit_situation_handicap, {
+        situation: situation_handicap,
+      })
+    ).toBe(false)
+  })
+
+  it("Checks that someone with incapacite 50 is not eligible with > 50", function () {
+    situation_handicap.demandeur.taux_incapacite = 0.5
+    benefit_situation_handicap.profils[0].conditions[0].operator = ">"
+
+    expect(
+      testProfileEligibility(benefit_situation_handicap, {
+        situation: situation_handicap,
+      })
+    ).toBe(false)
+  })
+
+  it("Checks that someone with incapacite 81 is not eligible with > 50 AND < 80", function () {
+    situation_handicap.demandeur.taux_incapacite = 0.81
+    benefit_situation_handicap.profils[0].conditions = [
+      {
+        type: "taux_incapacite",
+        value: 0.5,
+        operator: ">",
+      },
+      {
+        type: "taux_incapacite",
+        value: 0.8,
+        operator: "<",
+      },
+    ]
+    expect(
+      testProfileEligibility(benefit_situation_handicap, {
+        situation: situation_handicap,
+      })
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
# Description

La condition `taux incapactite` fonctionne maintenant comme la condition d'age.
On peut spécifier un opérateur et une valeur de son choix.