### PR TITLE
Supprime la gestion d'erreur sentry sur le tracker matomo

### DIFF
--- a/src/mixins/statistics.ts
+++ b/src/mixins/statistics.ts
@@ -9,7 +9,6 @@ import {
 } from "@/lib/statistics-service/matomo.js"
 import { BehaviourEventTypes } from "@lib/enums/behaviour-event-types.js"
 import { EventCategories } from "@lib/enums/event-categories.js"
-import * as Sentry from "@sentry/vue"
 
 declare global {
   interface Window {
@@ -31,16 +30,9 @@ export default {
         benefitId,
         event_type,
       }
-      try {
-        const matomoTracker = window.Piwik.getTracker()
-        if (matomoTracker) {
-          sendEventToRecorder(event, matomoTracker)
-        } else {
-          throw new Error("matomo tracker is not defined")
-        }
-      } catch (error) {
-        console.error("matomoTracker error: ", error)
-        Sentry.captureException(`matomoTracker error: ${error}`)
+      const matomoTracker = window.Piwik?.getTracker()
+      if (matomoTracker) {
+        sendEventToRecorder(event, matomoTracker)
       }
     },
     sendEventToMatomo: function (
@@ -55,16 +47,9 @@ export default {
         label,
         value,
       }
-      try {
-        const matomoTracker = window.Piwik.getTracker()
-        if (matomoTracker) {
-          sendEventToMatomo(event, matomoTracker)
-        } else {
-          throw new Error("matomo tracker is not defined")
-        }
-      } catch (error) {
-        console.error("matomoTracker error: ", error)
-        Sentry.captureException(`matomoTracker error: ${error}`)
+      const matomoTracker = window.Piwik?.getTracker()
+      if (matomoTracker) {
+        sendEventToMatomo(event, matomoTracker)
       }
     },
     sendBenefitsStatistics: function (


### PR DESCRIPTION
Suite au [post de Willy](https://mattermost.incubateur.net/betagouv/pl/su9d6q6dzfg17m51nhg4myy1ec), on peut supposer que l'origine du bug pour tracker matomo est simplement le fait que l'utilisateur a activé un un ad-blocker.

Je propose donc cette modif pour supprimer la gestion d'erreur avec sentry qui n'est plus utile.