### PR TITLE
Corrige le fait que window._paq puisse être undefined

### DIFF
--- a/src/components/action-buttons.vue
+++ b/src/components/action-buttons.vue
@@ -61,7 +61,7 @@ const localOnSubmit = (event) => {
 }
 
 const goBack = () => {
-  window._paq.push([
+  window._paq?.push([
     "trackEvent",
     "Parcours",
     "Bouton précédent",

--- a/src/components/matomo-opt-out.vue
+++ b/src/components/matomo-opt-out.vue
@@ -37,7 +37,7 @@ const isUserTracked = ref()
 
 const toggleTracking = (event) => {
   isUserTracked.value = event.target.checked
-  window._paq.push([event.target.checked ? "forgetUserOptOut" : "optUserOut"])
+  window._paq?.push([event.target.checked ? "forgetUserOptOut" : "optUserOut"])
 }
 
 onMounted(() => {

--- a/src/plugins/ab-testing-service.ts
+++ b/src/plugins/ab-testing-service.ts
@@ -2,7 +2,7 @@ import storageService from "@/lib/storage-service.js"
 
 declare global {
   interface Window {
-    _paq: [string, number, string?][]
+    _paq?: [string, number, string?][]
   }
 }
 
@@ -58,9 +58,9 @@ function getEnvironment() {
   Object.keys(ABTesting).forEach(function (name) {
     const data = ABTesting[name]
     if (data.deleted) {
-      window._paq.push(["deleteCustomDimension", data.index])
+      window._paq!.push(["deleteCustomDimension", data.index])
     } else {
-      window._paq.push([
+      window._paq!.push([
         "setCustomDimension",
         data.index,
         `${name}/${data.value}`,


### PR DESCRIPTION
## Détails

[Erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/34666/?project=18&query=is%3Aunresolved&referrer=issue-stream)

Si l'utilisateur a un bloqueur de pub la méthode `window._paq` peut être undefined, rendant la navigation vers la page précédente impossible via l'interface