### PR TITLE
Temp: emptyOutDir to true

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -100,7 +100,7 @@ export default defineConfig(async ({ mode }) => {
       commonjsOptions: {
         exclude: ["lib"],
       },
-      emptyOutDir: false,
+      emptyOutDir: true,
       sourcemap: true,
     },
     plugins: [


### PR DESCRIPTION
This will empty once the dist dir on server prod.
Another mecanism need to be created to empty timestamped builds on a regular basis.

This commit is temporary and will be reverted