### PR TITLE
feat: envoyer une erreur 404 quand les coordonnées ne sont pas trouvées

### DIFF
--- a/backend/controllers/outils.ts
+++ b/backend/controllers/outils.ts
@@ -48,8 +48,20 @@ export default {
     res.send(find(req.params.codePostal))
   },
   centerCoordinatesFromPostalCode: function (req, res) {
-    const postalCode = find(req.params.codePostal)[0].code
-    const commune = communesLonLat.find((c) => c.code === postalCode)
-    res.send(commune.centre.coordinates)
+    try {
+      const postalCode = find(req.params.codePostal)[0].code
+      if (!postalCode) {
+        throw new Error("Postal code not found")
+      }
+
+      const commune = communesLonLat.find((c) => c.code === postalCode)
+      if (!commune?.centre?.coordinates) {
+        throw new Error("Commune coordinates not found")
+      }
+
+      res.send(commune.centre.coordinates)
+    } catch (e) {
+      res.status(404).send("Coordinates not found")
+    }
   },
 }

--- a/tests/unit/backend/outils.spec.ts
+++ b/tests/unit/backend/outils.spec.ts
@@ -1,0 +1,47 @@
+import { expect, jest } from "@jest/globals"
+import outilsController from "@backend/controllers/outils.js"
+
+describe("centerCoordinatesFromPostalCode", () => {
+  it("returns the center coordinates of a commune", () => {
+    const req = {
+      params: {
+        codePostal: "75001",
+      },
+    }
+    const res = {
+      send: jest.fn(),
+    }
+    outilsController.centerCoordinatesFromPostalCode(req, res)
+    expect(res.send).toHaveBeenCalledWith([2.3752, 48.845])
+  })
+
+  it("returns 404 if the commune is not found", () => {
+    const req = {
+      params: {
+        codePostal: "99999",
+      },
+    }
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    }
+    outilsController.centerCoordinatesFromPostalCode(req, res)
+    expect(res.status).toHaveBeenCalledWith(404)
+    expect(res.send).toHaveBeenCalledWith("Coordinates not found")
+  })
+
+  it("returns 404 if the commune coordinates are not found", () => {
+    const req = {
+      params: {
+        codePostal: "97150", // Saint-Martin actuellement n'a pas de coordinates
+      },
+    }
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    }
+    outilsController.centerCoordinatesFromPostalCode(req, res)
+    expect(res.status).toHaveBeenCalledWith(404)
+    expect(res.send).toHaveBeenCalledWith("Coordinates not found")
+  })
+})


### PR DESCRIPTION
Pour le moment une erreur 500 est envoyé : (try: 97150) 
Pas d'impact en front car l'erreur était déjà catch hormis qu'on a une meilleure vision de ce qui se passe avec le code d'erreur.

Sentry: https://sentry.incubateur.net/organizations/betagouv/issues/55332/?project=17&query=is%3Aunresolved+url%3A%22https%3A%2F%2Fmes-aides.1jeune1solution.beta.gouv.fr%2Fapi%2Foutils%2FcodePostal%2F97150%2FcenterCoordinates%22&referrer=issue-stream
