### PR TITLE
Transmet un RNI égale au RFR lorsque le demandeur est à la charge de ses parents

### DIFF
--- a/backend/lib/openfisca/mapping/index.ts
+++ b/backend/lib/openfisca/mapping/index.ts
@@ -210,6 +210,9 @@ export function applyHeuristicsAndFix(testCase, sourceSituation) {
       testCase.foyers_fiscaux._.rfr = {
         [periods.fiscalYear]: parents.rfr,
       }
+      testCase.foyers_fiscaux._.rni = {
+        [periods.lastYear]: parents.rfr,
+      }
     }
     if (parents.nbptr) {
       testCase.foyers_fiscaux._.nbptr = {


### PR DESCRIPTION
Pour calculer l'éligibilité au CEJ, on a besoin d'un `Revenu Net Imposable`
On peut le calculer à partir de salaires mais si la personne est à la charge de ses parents alors le simulateur demande un `RFR`.
Openfisca ne sait pas estimer le `RNI` à partir du `RFR`.

Dans ce contexte, la différence entre les 2 est négligeable et nous avons décidé (avec @guillett) de transmettre à openfisca un `RNI` valant le `RFR` dans ce cas précis.

[Ticket trello](https://trello.com/c/AwW66EtY)
