### PR TITLE
Réparer la routine de vérification des liens dans Grist

### DIFF
--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -166,6 +166,9 @@ function determinePullRequestURL() {
     return
   }
   const { GITHUB_REF, GITHUB_REPOSITORY, GITHUB_SERVER_URL } = process.env
+
+  console.log("determinePullRequestURL", { GITHUB_REF })
+
   const pullRequestNumber = GITHUB_REF.match(
     /(?:refs\/pull\/)(?<number>[\d]+)\/merge/
   )?.groups?.number

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -8,6 +8,8 @@ import axios from "axios"
 import https from "https"
 import Bluebird from "bluebird"
 
+const DEFAULT_BRANCH_REF = "refs/heads/master"
+
 // Avoid some errors due to bad tls management
 const httpsAgent = new https.Agent({ rejectUnauthorized: false })
 
@@ -157,7 +159,10 @@ function getBenefitIdsFromCLI(): string[] | undefined {
 }
 
 function determinePullRequestURL() {
-  if (!process.env.GITHUB_REF) {
+  if (
+    !process.env.GITHUB_REF ||
+    process.env.GITHUB_REF === DEFAULT_BRANCH_REF
+  ) {
     return
   }
   const { GITHUB_REF, GITHUB_REPOSITORY, GITHUB_SERVER_URL } = process.env


### PR DESCRIPTION
Ticket : https://trello.com/c/s8Pf0SYM/1424-r%C3%A9parer-la-routine-de-v%C3%A9rification-des-liens-dans-grist

Pas possible de 100% tester sans merger mais voila les indices : 
- La doc dit que les actions scheduled ont comme default ref la ref de la default branche : https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
- Ça expliquerait pourquoi on ne vérifie pas toute la liste des aides ([ici](https://github.com/betagouv/aides-jeunes/actions/runs/5949024453/job/16133969295) très peu d'aide sont testé, en fait seulement celle qui sont à traiter dans le grist)
- Ça explique aussi pourquoi dans le grist les pull request ont un numéro "undefined" ([voir le grist](https://grist.incubateur.net/o/docs/mRipN1JbV6sB/Aides-Jeunes/p/40))
- Ça explique enfin pourquoi les updates/ajouts ne se font pas (hormis ajout de PR) ([cette partie du code](https://github.com/betagouv/aides-jeunes/blob/6a208706231e7108342f2254b3d6e69e855eedd1/lib/benefits/link-validity.ts#L86-L88))

Après le merge il faudrait enlever tous les liens des pull request dans le grist puis vérifier demain matin.