### PR TITLE
feat: force no-cache for index page

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -10,6 +10,7 @@ const port = process.env.PORT
 
 app.use(express.static(path.join(__dirname, "../../dist")))
 app.route("/*").get(function (req, res) {
+  res.setHeader("Cache-Control", "no-cache")
   res.sendFile(path.join(__dirname, "../../dist/index.html"))
 })
 const errorMiddleware: ErrorRequestHandler = (err, req, res, next) => {


### PR DESCRIPTION
Note: this is forwarded afterward by nginx

Testé en preprod, on a bien no-cache dans les header.

Chaud pour reparler de la livraison des statics car j'ai l'impression qu'on a deux endroit où on le fait : dans express ET dans nginx. Peut être une partie redondante.