### PR TITLE
Ajoute le type inactif au profil cible de l'aide au permis de la Gironde

### DIFF
--- a/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
@@ -20,6 +20,7 @@ profils:
   - type: chomeur
   - type: beneficiaire_rsa
   - type: service_civique
+  - type: inactif
 conditions:
   - Etre éligible aux critères du Fonds d'Aide au Jeunes.
   - Résider dans une commune de la Gironde qui ne se situe pas au sein de la Métropole.


### PR DESCRIPTION
Après investigation sur le [ticket de Yasmine ](https://trello.com/c/dR6We8hT/1389-permettre-de-cibler-une-aide-sur-les-personnes-qui-ont-r%C3%A9pondu-autre), la solution est en réalité d'ajouter le type `inactif` (qui correspond à la réponse "Autre" dans la question sur l'activité du demandeur) dans la condition de profil de l'aide.