### PR TITLE
Check des liens : fix sur la notification

### DIFF
--- a/.github/workflows/check-links-validity.yaml
+++ b/.github/workflows/check-links-validity.yaml
@@ -16,4 +16,4 @@ jobs:
         env:
           GRIST_DOC_ID: ${{ secrets.GRIST_DOC_ID }}
           GRIST_API_KEY: ${{ secrets.GRIST_API_KEY }}
-          MATTERMOST_POST_URL: ${{ secrets.MATTERMOST_POST_URL }}
+          MATTERMOST_ALERTING_URL: ${{ secrets.MATTERMOST_ALERTING_URL }}

--- a/.github/workflows/check-links-validity.yaml
+++ b/.github/workflows/check-links-validity.yaml
@@ -16,8 +16,4 @@ jobs:
         env:
           GRIST_DOC_ID: ${{ secrets.GRIST_DOC_ID }}
           GRIST_API_KEY: ${{ secrets.GRIST_API_KEY }}
-      - if: steps.invalid_links.outputs.comment
-        name: Send dead links info message
-        shell: bash
-        run: |
-          curl -i -X POST -H 'Content-Type: application/json' -d '{"text": ":icon-info: La liste des aides avec des liens invalides a été mise à jour ici : [lien](https://github.com/betagouv/aides-jeunes/issues/2945)"}' ${{ secrets.MATTERMOST_POST_URL }}
+          MATTERMOST_POST_URL: ${{ secrets.MATTERMOST_POST_URL }}

--- a/backend/lib/mattermost-bot/mattermost.ts
+++ b/backend/lib/mattermost-bot/mattermost.ts
@@ -1,9 +1,9 @@
 import axios from "axios"
 import config from "../../config/index.js"
 
-async function post(text: string) {
+async function post(text: string, postUrl?: string) {
   await axios
-    .post(config.mattermost_post_url, JSON.stringify({ text }), {
+    .post(postUrl || config.mattermost_post_url, JSON.stringify({ text }), {
       headers: {
         "Content-Type": "application/json",
       },

--- a/backend/lib/mattermost-bot/mattermost.ts
+++ b/backend/lib/mattermost-bot/mattermost.ts
@@ -1,9 +1,9 @@
 import axios from "axios"
 import config from "../../config/index.js"
 
-async function post(text) {
+async function post(text: string) {
   await axios
-    .post(config.mattermost_post_url, text, {
+    .post(config.mattermost_post_url, JSON.stringify({ text }), {
       headers: {
         "Content-Type": "application/json",
       },

--- a/backend/lib/mattermost-bot/poll-result.ts
+++ b/backend/lib/mattermost-bot/poll-result.ts
@@ -50,8 +50,7 @@ function postPollResult(simulation, answers) {
     )
   }
 
-  const json = JSON.stringify({ text: result.join("\n") })
-  mattermost.post(json)
+  mattermost.post(result.join("\n"))
 }
 
 export default {

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -263,18 +263,16 @@ async function main() {
   console.log("Terminé")
 
   // Notify on mattermost
-  const gristUpdated =
-    recordsByOperationTypes.add.length > 0 ||
-    recordsByOperationTypes.update.length > 0
+  const invalidLinksAdded = recordsByOperationTypes.add.length > 0
 
-  if (gristUpdated && !dryRun && !processingPR) {
+  if (invalidLinksAdded && !dryRun && !processingPR) {
     const text = [
       ":icon-info: La liste des aides avec des liens invalides a été mise à jour ici : [lien](https://grist.incubateur.net/o/docs/mRipN1JbV6sB/Aides-Jeunes/p/39)",
       `Ajout: ${recordsByOperationTypes.add.length}`,
       `Mise à jour: ${recordsByOperationTypes.update.length}`,
     ].join("\n")
 
-    Mattermost.post(text)
+    Mattermost.post(text, process.env.MATTERMOST_ALERTING_URL)
   }
 }
 

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -3,6 +3,7 @@ import config from "../backend/config/index.js"
 import { determineOperationsOnBenefitLinkError } from "../lib/benefits/link-validity.js"
 import { GristData } from "../lib/types/link-validity.js"
 import { Grist } from "../lib/grist.js"
+import Mattermost from "../backend/lib/mattermost-bot/mattermost.js"
 
 import axios from "axios"
 import https from "https"
@@ -260,6 +261,21 @@ async function main() {
     }
   }
   console.log("Terminé")
+
+  // Notify on mattermost
+  const gristUpdated =
+    recordsByOperationTypes.add.length > 0 ||
+    recordsByOperationTypes.update.length > 0
+
+  if (gristUpdated && !dryRun && !processingPR) {
+    const text = [
+      ":icon-info: La liste des aides avec des liens invalides a été mise à jour ici : [lien](https://grist.incubateur.net/o/docs/mRipN1JbV6sB/Aides-Jeunes/p/39)",
+      `Ajout: ${recordsByOperationTypes.add.length}`,
+      `Mise à jour: ${recordsByOperationTypes.update.length}`,
+    ].join("\n")
+
+    Mattermost.post(text)
+  }
 }
 
 main()


### PR DESCRIPTION
Lisible commit-par-commit

On regardait actuellement `steps.invalid_links.outputs.comment` qui n'était jamais set. Plutôt que de gérer ça avec les outputs, j'ai choisi d'intégrer la notification aux script. 

Test réalisé en lancant le workflow sur github action avec cette branche : https://mattermost.incubateur.net/betagouv/pl/8937um6fw7y3ddku8chyxsa8pa 
<img width="553" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/4059803/db2037e1-59a9-47d8-a9d4-1de11bcaafdd">

Added: pour info ça marchait avant les dernière grosses modifications car le script écrivait dans le fichier `process.env.GITHUB_OUTPUT` ([ici](https://github.com/betagouv/aides-jeunes/blob/726bbf1ff0612288f06655c5519bcf19e189e5f9/tools/check-links-validity.ts#L175)).