### PR TITLE
Remove `this.$matomo` and some `_paq.push`

### DIFF
--- a/src/components/action-buttons.vue
+++ b/src/components/action-buttons.vue
@@ -61,12 +61,11 @@ const localOnSubmit = (event) => {
 }
 
 const goBack = () => {
-  window._paq?.push([
-    "trackEvent",
+  window.Piwik?.getTracker()?.trackEvent(
     "Parcours",
     "Bouton précédent",
-    route.fullPath,
-  ])
+    route.fullPath
+  )
   const answerIndex = getAnswerIndexByPath(
     store.simulation.answers.current,
     route.fullPath

--- a/src/plugins/state-service.ts
+++ b/src/plugins/state-service.ts
@@ -24,7 +24,7 @@ const StateService = {
               action: "Navigation cancelled",
               label: failure.toString(),
             },
-            this.$matomo
+            window.Piwik?.getTracker()
           )
         } else {
           throw new Error(failure)


### PR DESCRIPTION
Ticket : https://trello.com/c/MhBnXb1k/1400-%C3%A9tudier-la-mise-en-place-dune-solution-p%C3%A9renne-pour-lacc%C3%A8s-%C3%A0-lobjet-piwik-dans-le-navigateur

Tout les `window._paq` ne peuvent pas être supprimé car les actions sont différentes d'un simple `trackEvent`.

Pour info j'ai testé une nouvelle fois et c'est bien vueMatomo qui initialise Matomo (les deux parties en code JS comme [celle ci](https://github.com/betagouv/aides-jeunes/blob/6b48eacd9b06493bfb6601cc95f2da61674fdb44/contribuer/pages/_document.js#L12-L26) sont uniquement pour la partie contribution)