### PR TITLE
Permet le lancement manuel de la CD et empêche son lancement en parallèle

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,7 +1,11 @@
 name: "Continuous Deployment"
 on:
+  workflow_dispatch:
   push:
     branches: [master, dev]
+concurrency:
+  concurrency: ci-${{ github.ref }}
+
 env:
   EQUINOXE_SSH_HOST: equinoxe.mes-aides.1jeune1solution.beta.gouv.fr
   EQUINOXE_SSH_USER: debian


### PR DESCRIPTION
## Détails

Cette PR change 2 comportements au niveau de la CD : 
- elle peut dorénavant être lancée manuellement (je n'ai pas trouvé de filtre au niveau des branches autorisée, mais le déploiement est conditionné par le nom de la branche)
- elle ne peut être exécutée plusieurs fois en parallèle. Si elle est en cours d'exécution et qu'une nouvelle pipeline est exécutée elle aura le statut de `pending` jusqu'à ce que la précédente soit terminée. Si une nouvelle pipeline est exécutée alors qu'une autre est déjà `pending`, celle-ci sera annulée et la nouvelle aura le statut de `pending` ([documentation](https://docs.github.com/en/actions/using-jobs/using-concurrency#overview))

Cette PR est nécessaire avant le merge de https://github.com/betagouv/aides-jeunes-ops/pull/155