### PR TITLE
rollback: params name

### DIFF
--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -76,7 +76,7 @@ export function getFollowup(req: Request, res: Response) {
 }
 
 export function showFollowup(req: Request, res: Response) {
-  Followups.findById(req.params.followupId)
+  Followups.findById(req.params.surveyId)
     .then((followup: Followup | null) => {
       if (!followup) return res.sendStatus(404)
       res.send([followup])

--- a/backend/routes/followups.ts
+++ b/backend/routes/followups.ts
@@ -22,7 +22,7 @@ const followupsRoutes = function (api: Express) {
     .get(cookieParser(), githubController.access)
     .get(showSurveyResults)
   api
-    .route("/followups/id/:followupId")
+    .route("/followups/id/:surveyId")
     .get(cookieParser(), githubController.access)
     .get(showFollowup)
   api


### PR DESCRIPTION
Mattermost ne marche plus chez moi en ce moment. 

Ça rollback temporairement un change que j'ai fait la semaine passé. En fait on a un conflit avec ce parametre : [ici](https://github.com/betagouv/aides-jeunes/blob/05a8a36fde7a98aad2138dca892f7741d8c0051c/backend/routes/emails.ts#L2)