### PR TITLE
Limite l'envoi de SMS aux numéros français

### DIFF
--- a/backend/config/development.ts
+++ b/backend/config/development.ts
@@ -33,5 +33,6 @@ export default {
     username: process.env.SMS_SERVICE_USERNAME || "",
     password: process.env.SMS_SERVICE_PASSWORD || "",
     url: "https://europe.ipx.com/restapi/v1/sms/send",
+    internationalDiallingCodes: ["33", "262", "508", "590", "594", "596"],
   },
 }

--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -91,6 +91,7 @@ const all: Configuration = {
     username: process.env.SMS_SERVICE_USERNAME || "",
     password: process.env.SMS_SERVICE_PASSWORD || "",
     url: "https://europe.ipx.com/restapi/v1/sms/send",
+    internationalDiallingCodes: ["33", "262", "508", "590", "594", "596"],
   },
 }
 

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -60,7 +60,7 @@ export async function persist(req: Request, res: Response) {
     }
     if (phone) {
       const phoneNumberValidation = (phone) => {
-        const phoneRegex = /^(((\+?|00)33\s?|0)[67])([\s.-]?\d{2}){4}$/
+        const phoneRegex = /^(((\+?|00)33\s?|0)[67])\d{8}$/
         return phoneRegex.test(phone)
       }
 

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -10,7 +10,7 @@ import { SurveyCategory } from "../../lib/enums/survey.js"
 import { FollowupFactory } from "../lib/followup-factory.js"
 import { FetchSurvey } from "../../lib/types/survey.d.js"
 import Request from "../types/express.d.js"
-import config from "../config/index.js"
+import { phoneNumberValidation } from "../../lib/validation.js"
 
 export function followup(
   req: Request,
@@ -60,15 +60,6 @@ export async function persist(req: Request, res: Response) {
       await followup.sendSimulationResultsEmail()
     }
     if (phone) {
-      const phoneNumberValidation = (phone) => {
-        const diallingCodes =
-          config.smsService.internationalDiallingCodes.join("|")
-        const phoneRegex = new RegExp(
-          `^(((\\+?|00)(${diallingCodes})|0)[1-9])(\\d{8})$`
-        )
-        return phoneRegex.test(phone)
-      }
-
       if (phoneNumberValidation(phone)) {
         await followup.sendSimulationResultsSms()
       } else {

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -61,10 +61,10 @@ export async function persist(req: Request, res: Response) {
     }
     if (phone) {
       const phoneNumberValidation = (phone) => {
-        const diallingCodesRegex =
+        const diallingCodes =
           config.smsService.internationalDiallingCodes.join("|")
         const phoneRegex = new RegExp(
-          `^(((\\+?|00)(${diallingCodesRegex})|0)[1-9])(\\d{8})$`
+          `^(((\\+?|00)(${diallingCodes})|0)[1-9])(\\d{8})$`
         )
         return phoneRegex.test(phone)
       }

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -11,6 +11,7 @@ import { FollowupFactory } from "../lib/followup-factory.js"
 import { FetchSurvey } from "../../lib/types/survey.d.js"
 import Request from "../types/express.d.js"
 import { phoneNumberValidation } from "../../lib/phone-number.js"
+import config from "../config/index.js"
 
 export function followup(
   req: Request,
@@ -60,7 +61,12 @@ export async function persist(req: Request, res: Response) {
       await followup.sendSimulationResultsEmail()
     }
     if (phone) {
-      if (phoneNumberValidation(phone)) {
+      if (
+        phoneNumberValidation(
+          phone,
+          config.smsService.internationalDiallingCodes
+        )
+      ) {
         await followup.sendSimulationResultsSms()
       } else {
         return res.status(422).send("Unsupported phone number format")

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -10,7 +10,7 @@ import { SurveyCategory } from "../../lib/enums/survey.js"
 import { FollowupFactory } from "../lib/followup-factory.js"
 import { FetchSurvey } from "../../lib/types/survey.d.js"
 import Request from "../types/express.d.js"
-import { phoneNumberValidation } from "../../lib/validation.js"
+import { phoneNumberValidation } from "../../lib/phone-number.js"
 
 export function followup(
   req: Request,

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -67,7 +67,7 @@ export async function persist(req: Request, res: Response) {
       if (phoneNumberValidation(phone)) {
         await followup.sendSimulationResultsSms()
       } else {
-        return res.status(403).send("Invalid phone number")
+        return res.status(403).send("Unsupported phone number format")
       }
     }
     return res.send({ result: "OK" })

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -60,8 +60,7 @@ export async function persist(req: Request, res: Response) {
     }
     if (phone) {
       const phoneNumberValidation = (phone) => {
-        const phoneRegex =
-          /^(((\+?|00)(33|262|508|590|594|596)\s?|0)[67])\d{8}$/
+        const phoneRegex = /^(((\+?|00)(33|262|508|590|594|596)|0)[67])\d{8}$/
         return phoneRegex.test(phone)
       }
 

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -60,7 +60,8 @@ export async function persist(req: Request, res: Response) {
     }
     if (phone) {
       const phoneNumberValidation = (phone) => {
-        const phoneRegex = /^(((\+?|00)33\s?|0)[67])\d{8}$/
+        const phoneRegex =
+          /^(((\+?|00)(33|262|508|590|594|596)\s?|0)[67])\d{8}$/
         return phoneRegex.test(phone)
       }
 

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -10,6 +10,7 @@ import { SurveyCategory } from "../../lib/enums/survey.js"
 import { FollowupFactory } from "../lib/followup-factory.js"
 import { FetchSurvey } from "../../lib/types/survey.d.js"
 import Request from "../types/express.d.js"
+import config from "../config/index.js"
 
 export function followup(
   req: Request,
@@ -60,7 +61,11 @@ export async function persist(req: Request, res: Response) {
     }
     if (phone) {
       const phoneNumberValidation = (phone) => {
-        const phoneRegex = /^(((\+?|00)(33|262|508|590|594|596)|0)[67])\d{8}$/
+        const diallingCodesRegex =
+          config.smsService.internationalDiallingCodes.join("|")
+        const phoneRegex = new RegExp(
+          `^(((\\+?|00)(${diallingCodesRegex})|0)[1-9])(\\d{8})$`
+        )
         return phoneRegex.test(phone)
       }
 

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -72,7 +72,7 @@ export async function persist(req: Request, res: Response) {
       if (phoneNumberValidation(phone)) {
         await followup.sendSimulationResultsSms()
       } else {
-        return res.status(403).send("Unsupported phone number format")
+        return res.status(422).send("Unsupported phone number format")
       }
     }
     return res.send({ result: "OK" })

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -1,16 +1,13 @@
 import mongoose from "mongoose"
 import validator from "validator"
-
 import { sendMail } from "../lib/smtp.js"
 import axios from "axios"
-
 import { Survey } from "../../lib/types/survey.js"
 import { SurveyCategory } from "../../lib/enums/survey.js"
 import emailRender from "../lib/mes-aides/emails/email-render.js"
 import SurveySchema from "./survey-schema.js"
 import { EmailCategory } from "../enums/email.js"
 import config from "../config/index.js"
-
 import { Followup } from "../../lib/types/followup.d.js"
 import { FollowupModel } from "../types/models.d.js"
 import { phoneNumberFormatting } from "../../lib/phone-number.js"
@@ -115,7 +112,10 @@ FollowupSchema.method(
     const { baseURL } = config
     const { url } = config.smsService
     const { accessToken, phone } = this
-    const formattedPhone = phoneNumberFormatting(phone)
+    const formattedPhone = phoneNumberFormatting(
+      phone,
+      config.smsService.internationalDiallingCodes
+    )
 
     const text = `Bonjour\nRetrouvez les résultats de votre simulation ici ${baseURL}/api/sms/${accessToken}\n1jeune1solution`
     const encodedText = encodeURIComponent(text)

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -116,7 +116,8 @@ FollowupSchema.method(
 
     let phone = this.phone
     const phoneNumberToE164 = () => {
-      if (this.phone.substring(0, 4) === "0033") {
+      const prefixes = ["0033", "00262", "00508", "00590", "00594", "00596"]
+      if (prefixes.some((prefix) => this.phone.startsWith(prefix))) {
         phone = `${this.phone.substring(2)}`
       } else if (this.phone.substring(0, 2) === ("06" || "07")) {
         phone = `33${this.phone.substring(1)}`

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -113,8 +113,18 @@ FollowupSchema.method(
   function (username, password) {
     const text = `Bonjour\nRetrouvez les résultats de votre simulation ici ${config.baseURL}/api/sms/${this.accessToken}\n1jeune1solution`
     const encodedText = encodeURIComponent(text)
-    const phone =
-      this.phone[0] === "0" ? `33${this.phone.slice(1)}` : this.phone
+
+    let phone = this.phone
+    const phoneNumberToE164 = () => {
+      if (this.phone.substring(0, 4) === "0033") {
+        phone = `${this.phone.substring(2)}`
+      } else if (this.phone.substring(0, 2) === ("06" || "07")) {
+        phone = `33${this.phone.substring(1)}`
+      }
+    }
+
+    phoneNumberToE164()
+
     return `${config.smsService.url}?&originatorTON=1&originatingAddress=SIMUL 1J1S&destinationAddress=${phone}&messageText=${encodedText}&username=${username}&password=${password}`
   }
 )
@@ -134,7 +144,6 @@ FollowupSchema.method("sendSimulationResultsSms", async function () {
     if (status !== 200 || data.responseCode !== 0) {
       throw new Error(`SMS request failed. Body: ${JSON.stringify(data)}`)
     }
-    console.log("message ids: ", data.messageIds[0])
     return this.postSimulationResultsSms(data.messageIds[0])
   } catch (err) {
     this.smsError = JSON.stringify(err, null, 2)

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -110,23 +110,25 @@ FollowupSchema.method("sendSimulationResultsEmail", function () {
 
 FollowupSchema.method(
   "renderSimulationResultsSmsUrl",
-  function (username, password) {
-    const text = `Bonjour\nRetrouvez les résultats de votre simulation ici ${config.baseURL}/api/sms/${this.accessToken}\n1jeune1solution`
+  function (username: string, password: string) {
+    const { baseURL } = config
+    const { internationalDiallingCodes, url } = config.smsService
+    const { accessToken, phone } = this
+
+    const isInternational = internationalDiallingCodes.some((code) =>
+      phone.startsWith(`00${code}`)
+    )
+
+    const formattedPhone = isInternational
+      ? phone.substring(2)
+      : phone.startsWith("06") || phone.startsWith("07")
+      ? `33${phone.substring(1)}`
+      : phone
+
+    const text = `Bonjour\nRetrouvez les résultats de votre simulation ici ${baseURL}/api/sms/${accessToken}\n1jeune1solution`
     const encodedText = encodeURIComponent(text)
 
-    let phone = this.phone
-    const phoneNumberToE164 = () => {
-      const prefixes = ["0033", "00262", "00508", "00590", "00594", "00596"]
-      if (prefixes.some((prefix) => this.phone.startsWith(prefix))) {
-        phone = `${this.phone.substring(2)}`
-      } else if (this.phone.substring(0, 2) === ("06" || "07")) {
-        phone = `33${this.phone.substring(1)}`
-      }
-    }
-
-    phoneNumberToE164()
-
-    return `${config.smsService.url}?&originatorTON=1&originatingAddress=SIMUL 1J1S&destinationAddress=${phone}&messageText=${encodedText}&username=${username}&password=${password}`
+    return `${url}?&originatorTON=1&originatingAddress=SIMUL 1J1S&destinationAddress=${formattedPhone}&messageText=${encodedText}&username=${username}&password=${password}`
   }
 )
 

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -13,6 +13,7 @@ import config from "../config/index.js"
 
 import { Followup } from "../../lib/types/followup.d.js"
 import { FollowupModel } from "../types/models.d.js"
+import { phoneNumberFormatting } from "../../lib/phone-number.js"
 
 const FollowupSchema = new mongoose.Schema<Followup, FollowupModel>(
   {
@@ -112,18 +113,9 @@ FollowupSchema.method(
   "renderSimulationResultsSmsUrl",
   function (username: string, password: string) {
     const { baseURL } = config
-    const { internationalDiallingCodes, url } = config.smsService
+    const { url } = config.smsService
     const { accessToken, phone } = this
-
-    const isInternational = internationalDiallingCodes.some((code) =>
-      phone.startsWith(`00${code}`)
-    )
-
-    const formattedPhone = isInternational
-      ? phone.substring(2)
-      : phone.startsWith("06") || phone.startsWith("07")
-      ? `33${phone.substring(1)}`
-      : phone
+    const formattedPhone = phoneNumberFormatting(phone)
 
     const text = `Bonjour\nRetrouvez les résultats de votre simulation ici ${baseURL}/api/sms/${accessToken}\n1jeune1solution`
     const encodedText = encodeURIComponent(text)

--- a/backend/types/config.d.ts
+++ b/backend/types/config.d.ts
@@ -63,5 +63,6 @@ export interface Configuration {
     username: string
     password: string
     url: string
+    internationalDiallingCodes: string[]
   }
 }

--- a/lib/phone-number.ts
+++ b/lib/phone-number.ts
@@ -1,16 +1,20 @@
-import config from "../backend/config/index.js"
-
-export function phoneNumberValidation(phone: string) {
-  const diallingCodes = config.smsService.internationalDiallingCodes.join("|")
+export function phoneNumberValidation(
+  phone: string,
+  internationalDiallingCodes: string[]
+) {
+  const diallingCodes = internationalDiallingCodes.join("|")
   const phoneRegex = new RegExp(
     `^(((\\+?|00)(${diallingCodes})|0)[1-9])(\\d{8})$`
   )
   return phoneRegex.test(phone)
 }
 
-export function phoneNumberFormatting(phone: string) {
-  const isInternational = config.smsService.internationalDiallingCodes.some(
-    (code) => phone.startsWith(`00${code}`)
+export function phoneNumberFormatting(
+  phone: string,
+  internationalDiallingCodes: string[]
+) {
+  const isInternational = internationalDiallingCodes.some((code) =>
+    phone.startsWith(`00${code}`)
   )
   if (isInternational) {
     return phone.substring(2)

--- a/lib/phone-number.ts
+++ b/lib/phone-number.ts
@@ -1,0 +1,24 @@
+import config from "../backend/config/index.js"
+
+export function phoneNumberValidation(phone: string) {
+  const diallingCodes = config.smsService.internationalDiallingCodes.join("|")
+  const phoneRegex = new RegExp(
+    `^(((\\+?|00)(${diallingCodes})|0)[1-9])(\\d{8})$`
+  )
+  return phoneRegex.test(phone)
+}
+
+export function phoneNumberFormatting(phone: string) {
+  const isInternational = config.smsService.internationalDiallingCodes.some(
+    (code) => phone.startsWith(`00${code}`)
+  )
+  if (isInternational) {
+    return phone.substring(2)
+  }
+
+  if (phone.startsWith("06") || phone.startsWith("07")) {
+    return `33${phone.substring(1)}`
+  }
+
+  return phone
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,9 +1,0 @@
-import config from "../backend/config/index.js"
-
-export function phoneNumberValidation(phone: string) {
-  const diallingCodes = config.smsService.internationalDiallingCodes.join("|")
-  const phoneRegex = new RegExp(
-    `^(((\\+?|00)(${diallingCodes})|0)[1-9])(\\d{8})$`
-  )
-  return phoneRegex.test(phone)
-}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,9 @@
+import config from "../backend/config/index.js"
+
+export function phoneNumberValidation(phone: string) {
+  const diallingCodes = config.smsService.internationalDiallingCodes.join("|")
+  const phoneRegex = new RegExp(
+    `^(((\\+?|00)(${diallingCodes})|0)[1-9])(\\d{8})$`
+  )
+  return phoneRegex.test(phone)
+}

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -236,7 +236,7 @@ const ctaText = ref(computeCtaText())
           id="phone"
           ref="phoneRef"
           v-model="phoneValue"
-          pattern="((\+?(00|33))|(0))\s*[1-9]([\s\.\-]?\d{2}){4}"
+          pattern="^(((\+?|00)33\s?|0)[67])([\s\.\-]?\d{2}){4}"
           name="phone"
           required
           :aria-invalid="phoneInputErrorMessage"

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -30,6 +30,12 @@ const simulationId = computed(
   () => !store.calculs.dirty && store.calculs.resultats?._id
 )
 
+const inputPhonePattern = computed(() => {
+  const diallingCodes: string | undefined =
+    process.env.VITE_SMS_DIALLING_CODES?.toString().replaceAll(",", "|")
+  return `^(((\\+?|00)(${diallingCodes})\\s?|0)[67])([\\s\\.\\-]?\\d{2}){4}`
+})
+
 const showSms = process.env.VITE_SHOW_SMS_TAB
 
 StatisticsMixin.methods.sendEventToMatomo(
@@ -239,7 +245,7 @@ const ctaText = ref(computeCtaText())
           id="phone"
           ref="phoneRef"
           v-model="phoneValue"
-          pattern="^(((\+?|00)(33|262|508|590|596|594)\s?|0)[67])([\s\.\-]?\d{2}){4}"
+          :pattern="inputPhonePattern"
           name="phone"
           required
           :aria-invalid="phoneInputErrorMessage"

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -262,7 +262,8 @@ const ctaText = ref(computeCtaText())
         v-if="phoneInputErrorMessage"
         id="invalid-phone-warning"
         class="fr-mt-2w"
-        >Un numéro de téléphone valide doit être indiqué.
+      >
+        Numéro de téléphone non pris en charge, vérifiez sa validité.
       </WarningMessage>
     </form>
   </div>

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -139,7 +139,7 @@ const sendRecapBySms = async (surveyOptin) => {
   store.setFormRecapEmailState(undefined)
   if (!inputPhoneIsValid()) {
     store.setFormRecapPhoneState(undefined)
-    throw new Error("Unsupported phone number format")
+    throw new Error("Invalid phone number")
   }
   try {
     store.setModalState(undefined)
@@ -158,7 +158,7 @@ const sendRecapByEmail = async (surveyOptin) => {
   store.setFormRecapPhoneState(undefined)
   if (!inputEmailIsValid()) {
     store.setFormRecapEmailState(undefined)
-    throw new Error("Unsupported email format")
+    throw new Error("Invalid email")
   }
   try {
     store.setModalState(undefined)

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -139,7 +139,7 @@ const sendRecapBySms = async (surveyOptin) => {
   store.setFormRecapEmailState(undefined)
   if (!inputPhoneIsValid()) {
     store.setFormRecapPhoneState(undefined)
-    throw new Error("Invalid phone number")
+    throw new Error("Unsupported phone number format")
   }
   try {
     store.setModalState(undefined)
@@ -158,7 +158,7 @@ const sendRecapByEmail = async (surveyOptin) => {
   store.setFormRecapPhoneState(undefined)
   if (!inputEmailIsValid()) {
     store.setFormRecapEmailState(undefined)
-    throw new Error("invalid email")
+    throw new Error("Unsupported email format")
   }
   try {
     store.setModalState(undefined)

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -236,7 +236,7 @@ const ctaText = ref(computeCtaText())
           id="phone"
           ref="phoneRef"
           v-model="phoneValue"
-          pattern="^(((\+?|00)33\s?|0)[67])([\s\.\-]?\d{2}){4}"
+          pattern="^(((\+?|00)(33|262|508|590|596|594)\s?|0)[67])([\s\.\-]?\d{2}){4}"
           name="phone"
           required
           :aria-invalid="phoneInputErrorMessage"

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -230,7 +230,10 @@ const ctaText = ref(computeCtaText())
       <div class="fr-form-group">
         <label class="fr-label" for="phone"
           >Votre numéro de téléphone portable
-          <span class="fr-hint-text">Format attendu : 06 12 23 42 78</span>
+          <span class="fr-hint-text"
+            >Format attendu : 06 12 23 42 78 (numéros de France métropolitaine
+            et DROM-COM)</span
+          >
         </label>
         <input
           id="phone"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,6 +69,7 @@ export default defineConfig(async ({ mode }) => {
     // For now FranceConnect require an additional query params to be enabled
     VITE_FRANCE_CONNECT_ENABLED: Boolean(franceConnect.clientId),
     VITE_SHOW_SMS_TAB: smsService.show,
+    VITE_SMS_DIALLING_CODES: smsService.internationalDiallingCodes,
   }
   viteEnvironment.VITE_TITLE = `Évaluez vos droits aux aides avec le simulateur de ${viteEnvironment.VITE_CONTEXT_NAME}`
   viteEnvironment.VITE_DESCRIPTION = `7 minutes suffisent pour évaluer vos droits à ${viteEnvironment.VITE_BENEFIT_COUNT} aides avec le simulateur de ${viteEnvironment.VITE_CONTEXT_NAME}.`


### PR DESCRIPTION
## Problème soulevé 

L'envoi de SMS ailleurs qu'en France ou sur des numéros surtaxés (commençant par 08 par exemple) peuvent engendrer des coûts élevés.

## Modification proposée

Ajout d'une double vérification via une expression régulière plus restrictive:
- Vérification dans l'interface sur le pattern de linput du sms dans la modale d'envoi du récapitulatif 
- Vérification dans le backend

Seuls les numéros commençant par 06, 07, 0033, 336, 337, +336 et +337 seront autorisés. 

Reformatage du numéro en 33XXXXXXXXX requis pour le service de SMS actuellement utilisé.

Le format suggestif du numéro de téléphone dans l'interface utilisateur pourrait être modifié en conséquence dans mais j'ai peur que cela surcharge pour pas grand chose => preneur de vos idées