### PR TITLE
Correction de coquilles sur les aides au permis de conduire

### DIFF
--- a/data/benefits/javascript/ca_grand_verdun_bourse_au_permis_de_conduire.yml
+++ b/data/benefits/javascript/ca_grand_verdun_bourse_au_permis_de_conduire.yml
@@ -23,7 +23,7 @@ conditions:
   - Être suivi par la Mission Locale de Verdun.
   - Résider dans un QPV (quartier prioritaire de la politique de la ville) du Grand Verdun.
 voluntary_conditions:
-  - S'engager à réaliser 70 heures de bénévolat dans une association basée sur le territoire du Grand Verdun.
+  - Vous engager à réaliser 70 heures de bénévolat dans une association basée sur le territoire du Grand Verdun.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/communaute-de-communes-rhone-lez-provence-aide-au-financement-du-permis.yml
+++ b/data/benefits/javascript/communaute-de-communes-rhone-lez-provence-aide-au-financement-du-permis.yml
@@ -17,8 +17,8 @@ conditions_generales:
 profils: []
 conditions:
   - Résider sur une des 5 communes de Rhône Lez Provence depuis plus de 2 ans.
-  - S'engager dans un parcours d’insertion professionnelle.
-  - S'inscrire dans une auto-école basée dans l'une des 5 communes du territoire.
+  - Vous engager dans un parcours d’insertion professionnelle.
+  - Vous inscrire dans une auto-école basée dans l'une des 5 communes du territoire.
   - Signer un engagement de stage dans la collectivité.
 interestFlag: _interetPermisDeConduire
 type: float

--- a/data/benefits/javascript/region-ile-de-france-bourse-installtation-des-étudiants-en-kinésithérapie-et-maïeutique.yml
+++ b/data/benefits/javascript/region-ile-de-france-bourse-installtation-des-étudiants-en-kinésithérapie-et-maïeutique.yml
@@ -6,7 +6,7 @@ description:
   carencées en professionnels de santé.
 conditions:
   - Etre inscrit ou inscrite en avant-dernière année d'études.
-  - S'engager à s'installer pour 3 ans minimum, en secteur 1, dans une zone
+  - Vous engager à vous installer pour 3 ans minimum, en secteur 1, dans une zone
     carencée, dans les 6 mois suivant l'obtention du diplôme.
 conditions_generales:
   - type: regions

--- a/data/benefits/javascript/ville-angers-bourse-communale-pour-le-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/ville-angers-bourse-communale-pour-le-permis-de-conduire-permis-citoyen.yml
@@ -36,7 +36,7 @@ conditions:
   - Etre engagé·e dans un parcours d’insertion professionnelle.
   - Etre inscrit·e dans une auto-école partenaire du CCAS et participer à une journée obligatoire de sécurité routière.
 voluntary_conditions:
-  - S'engager à réaliser au moins 20 heures de bénévolat dans une association ou
+  - Vous engager à réaliser au moins 20 heures de bénévolat dans une association ou
     une collectivité.
 interestFlag: _interetPermisDeConduire
 type: float

--- a/data/benefits/javascript/ville-bethune-aide-permis.yml
+++ b/data/benefits/javascript/ville-bethune-aide-permis.yml
@@ -18,7 +18,7 @@ conditions:
   - Être Béthunois depuis au moins un an à la date du dépôt de dossier.
   - Avoir une situation sociale, professionnelle ou scolaire visant à l’insertion.
   - Avoir un projet dans lequel s’inscrit le besoin de passer le permis de conduire.
-  - Avoir effectué sa journée de défense et de citoyenneté (JDC), pour les personnes âgées
+  - Avoir effectué votre journée de défense et de citoyenneté (JDC), pour les personnes âgées
     de moins de 25 ans.
   - Être titulaire de l'ASSR2, pour les personnes âgées de moins de 21 ans.
 voluntary_conditions:

--- a/data/benefits/javascript/ville-chaumes-en-retz-bourse-communale-au-permis-de-conduire-et-au-bsr.yml
+++ b/data/benefits/javascript/ville-chaumes-en-retz-bourse-communale-au-permis-de-conduire-et-au-bsr.yml
@@ -21,7 +21,7 @@ conditions_generales:
 profils: []
 conditions:
   - Avoir un projet scolaire ou professionnel.
-  - S'inscrire dans l'auto-école de la commune.
+  - Être inscrit dans l'auto-école de la commune.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/ville-dunkerque-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-dunkerque-bourse-communale-au-permis-de-conduire.yml
@@ -24,7 +24,6 @@ conditions_generales:
 profils: []
 conditions:
   - Résider dans la ville de Dunkerque ou une commune associée depuis au moins deux ans.
-  - Effectuer 50 heures de bénévolat dans une association partenaire liée à la convention, ou dans une mission d'intérêt général proposé par les services municipaux ou mutualisés.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/ville-nice-bourse-communale-au-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/ville-nice-bourse-communale-au-permis-de-conduire-permis-citoyen.yml
@@ -21,7 +21,7 @@ conditions:
   - Être non-imposable.
   - Avoir préalablement réussi le code de la route.
 voluntary_conditions:
-  - S’engager à la réalisation de 30 heures de bénévolat dans un service public
+  - Réaliser 30 heures de bénévolat dans un service public
     ou un organisme à but non lucratif.
 interestFlag: _interetPermisDeConduire
 type: float

--- a/data/benefits/javascript/ville-vertou-bourse-communale-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-vertou-bourse-communale-permis-de-conduire.yml
@@ -17,7 +17,7 @@ conditions_generales:
 profils: []
 conditions:
   - Effectuer la demande de bourse avant le 20 novembre.
-  - Effectuer sa demande de bourse avant de commencer le permis.
+  - Effectuer la demande de bourse avant de commencer le permis.
 voluntary_conditions:
   - Réaliser 50 heures d'action bénévole dans une association basée à
     Vertou.

--- a/data/benefits/javascript/ville_colomiers_bourse_permis_conduire.yml
+++ b/data/benefits/javascript/ville_colomiers_bourse_permis_conduire.yml
@@ -22,7 +22,7 @@ profils:
 conditions:
   - Être déscolarisé.e.s sans diplôme et en situation d’insertion professionnelle.
   - Être accompagné par la mission locale.
-  - S'engager à réaliser 70 heures de stage au sein des services municipaux.
+  - Vous engager à réaliser 70 heures de stage au sein des services municipaux.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/ville_talence_permis_jeune_et_solidaire.yml
+++ b/data/benefits/javascript/ville_talence_permis_jeune_et_solidaire.yml
@@ -20,10 +20,10 @@ conditions_generales:
 profils: []
 conditions:
   - Résider à Talence depuis au moins trois ans de manière continue.
-  - Avoir obtenu son code de la route.
-  - Passer son permis de conduire dans l’une des sept auto-écoles talençaises.
+  - Avoir obtenu votre code de la route.
+  - Passer votre permis de conduire dans l’une des sept auto-écoles talençaises.
 voluntary_conditions:
-  - S'engager à réaliser 70 heures de bénévolat dans une association basée à Talence.
+  - Vous engager à réaliser 70 heures de bénévolat dans une association basée à Talence.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €

--- a/data/benefits/javascript/ville_villeurbanne_bourse_communale_permis_de_conduire.yml
+++ b/data/benefits/javascript/ville_villeurbanne_bourse_communale_permis_de_conduire.yml
@@ -19,11 +19,11 @@ conditions_generales:
     value: 25
 profils: []
 conditions:
-  - Avoir obtenu son code de la route.
+  - Avoir obtenu le code de la route.
   - Être dans l’impossibilité de payer la totalité du permis.
   - Avoir un projet d'insertion professionnelle.
 voluntary_conditions:
-  - S'engager à réaliser quelques heures de travaux d'utilité collective sous forme de chantier Jeune.
+  - Vous engager à réaliser quelques heures de travaux d'utilité collective sous forme de chantier Jeune.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €


### PR DESCRIPTION
Pour la cohérence de lecture, j'ai corrigé les énoncés des conditions supplémentaires de certaines aides pour lesquelles on employait la 3ème personne au lieu de la 2ème alors que le titre des conditions supplémentaires dit  :
"Pour en bénéficier, vous devez également :"