### PR TITLE
Conversion aide permis nouvelle aquitaine en openfisca

### DIFF
--- a/backend/lib/openfisca/mapping/individu/index.ts
+++ b/backend/lib/openfisca/mapping/individu/index.ts
@@ -16,6 +16,12 @@ import { Activite } from "../../../../../lib/enums/activite.js"
 import { IndividuGenerator } from "../../../../../lib/types/individu.js"
 
 const individuSchema: IndividuGenerator = {
+  service_civique: {
+    src: "activite",
+    fn: function (activite) {
+      return activite === Activite.ServiceCivique
+    },
+  },
   activite: {
     src: "activite",
     fn: function (activite) {

--- a/data/benefits/openfisca/nouvelle_aquitaine_aide_permis.yml
+++ b/data/benefits/openfisca/nouvelle_aquitaine_aide_permis.yml
@@ -17,30 +17,8 @@ instructions: https://les-aides.nouvelle-aquitaine.fr/amenagement-du-territoire/
 prefix: l’
 type: float
 unit: €
-legend: maximum
 floorAt: 10
-interestFlag: _interetPermisDeConduire
-montant: 1200
+entity: individus
+openfiscaPeriod: thisMonth
 periodicite: ponctuelle
-conditions_generales:
-  - type: regions
-    values:
-      - "75"
-  - type: age
-    operator: ">="
-    value: 17
-  - type: age
-    operator: <
-    value: 26
-profils:
-  - type: lyceen
-    conditions:
-      - type: annee_etude
-        values:
-          - cap_2
-          - terminale
-  - type: service_civique
-  - type: chomeur
-  - type: apprenti
-  - type: stagiaire
-  - type: professionnalisation
+interestFlag: _interetPermisDeConduire

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,6 +1,6 @@
 gunicorn>=20.1.0
 pytest==7.2.2
-Openfisca-France==153.0.1
+Openfisca-France==153.1.0
 Openfisca-Core[web-api]==41.0.0
-OpenFisca-France-Local[excel-reader]==6.2.0
+OpenFisca-France-Local[excel-reader]==6.3.0
 Openfisca-Paris==5.2.0


### PR DESCRIPTION
# Description

L'[aide permis de conduire de region Nouvelle Aquitaine](https://github.com/openfisca/openfisca-france-local/pull/181) ajouté sur `openfisca-france-local` necessites : 
- la conversion du fichier JS en openfiscs
- l'envoi de la variable `service_civique` à openfisca