### PR TITLE
fix: Ne pas réassigner si l'A/B-test est déjà tiré

### DIFF
--- a/src/plugins/ab-testing-service.ts
+++ b/src/plugins/ab-testing-service.ts
@@ -64,8 +64,8 @@ function getEnvironment() {
 
   const versions = ["version_actuelle", "version_test_1", "version_test_2"]
   const ctaEmailRecontact = ABTestingEnvironment.CTA_EmailRecontact || {}
-  ctaEmailRecontact.index = 5
-  ctaEmailRecontact.value =
+  ctaEmailRecontact.index ||= 5
+  ctaEmailRecontact.value ||=
     versions[Math.floor(Math.random() * versions.length)]
   ABTestingEnvironment.CTA_EmailRecontact = ctaEmailRecontact
 


### PR DESCRIPTION
fix [:icon-danger: [équipe-tech] La CI a rencontré un problème sur la branche master ([lien](https://github.com/betagouv/aides-jeunes/actions/workflows/ci.yml?query=branch%3Amaster+is%3Afailure))](https://mattermost.incubateur.net/betagouv/pl/xu66k1fh6idw8gsgctp8q1zd1r)