### PR TITLE
Corrige les liens d'aide dans les emails (pré-remplissage)

### DIFF
--- a/backend/lib/mes-aides/emails/simulation-results.ts
+++ b/backend/lib/mes-aides/emails/simulation-results.ts
@@ -33,11 +33,8 @@ export function formatBenefits(benefits, parameters) {
 
     let ctaLink = ""
     let ctaLabel = ""
-    if (droit.teleservice) {
-      ctaLink =
-        droit.teleservice.name === "redirection"
-          ? droit.link
-          : droit.teleservice
+    if (droit.teleservice && droit.teleservice.name !== "redirection") {
+      ctaLink = droit.teleservice
       ctaLabel = "Faire une demande en ligne"
     } else if (droit.form) {
       ctaLink = droit.form

--- a/backend/lib/mes-aides/emails/simulation-results.ts
+++ b/backend/lib/mes-aides/emails/simulation-results.ts
@@ -34,7 +34,10 @@ export function formatBenefits(benefits, parameters) {
     let ctaLink = ""
     let ctaLabel = ""
     if (droit.teleservice) {
-      ctaLink = droit.teleservice
+      ctaLink =
+        droit.teleservice.name === "redirection"
+          ? droit.link
+          : droit.teleservice
       ctaLabel = "Faire une demande en ligne"
     } else if (droit.form) {
       ctaLink = droit.form


### PR DESCRIPTION
Corrige les liens des aides contenant des redirections de pré-remplissange dans les résultats reçus par email

Testé avec l'aide aidde-demonstration-preremplissage, redirection vers le `link`si le `teleservice` de l'aide est un objet de redirection.


Tâche trello : https://trello.com/c/tu9bxUTI/1398-r%C3%A9parer-les-liens-dans-les-emails-vers-des-t%C3%A9l%C3%A9services-d%C3%A9marches-simplifi%C3%A9es-pr%C3%A9remplissables