### PR TITLE
Ajoute une step pour modifier les enfants en cas de retour en arrière

### DIFF
--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -509,6 +509,7 @@ export function generateBlocks(situation): Block[] {
   return [
     { steps: [new StepGenerator({})] },
     individuBlockFactory("demandeur"),
+    new StepGenerator({ entity: "enfants", chapter: "foyer" }),
     kidBlock(situation),
     {
       steps: [


### PR DESCRIPTION
**Bug constaté** : en cas d'ajout d'un enfant, on ne pouvait pas retourner à la page d'ajout/modification des enfants `/simulation/enfants` car elle était dynamiquement ajoutée via la méthode `kidBlock`. 

**Solution apportée** : j'ai ajouté la step dans le flux normal de la simulation pour qu'elle soit bien stockée dans les `answers` du store et qu'on puisse retourner dessus après l'ajout d'un premier enfant.

[Tâche Trello](https://trello.com/c/b3NgwEdm/1430-si-on-ajoute-un-premier-enfant-et-quon-souhaite-revenir-en-arri%C3%A8re-pour-corriger-lajout-ne-pas-ajouter-denfant-on-ne-peut-pas)