### PR TITLE
1453 problemes sur les ab tests

### DIFF
--- a/src/components/action-buttons.vue
+++ b/src/components/action-buttons.vue
@@ -32,6 +32,7 @@ import { useStore } from "@/stores/index.js"
 import { useRoute, useRouter } from "vue-router"
 import WarningMessage from "@/components/warning-message.vue"
 import { EventCategory } from "@lib/enums/event-category.js"
+import tracker from "@/plugins/tracker.js"
 
 const props = defineProps({
   onSubmit: {
@@ -62,11 +63,8 @@ const localOnSubmit = (event) => {
 }
 
 const goBack = () => {
-  window.Piwik?.getTracker()?.trackEvent(
-    EventCategory.Parcours,
-    "Bouton précédent",
-    route.fullPath
-  )
+  tracker.trackEvent(EventCategory.Parcours, "Bouton précédent", route.fullPath)
+
   const answerIndex = getAnswerIndexByPath(
     store.simulation.answers.current,
     route.fullPath

--- a/src/components/matomo-opt-out.vue
+++ b/src/components/matomo-opt-out.vue
@@ -32,20 +32,23 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from "vue"
+import tracker from "@/plugins/tracker.js"
 
 const isUserTracked = ref()
 
 const toggleTracking = (event) => {
   isUserTracked.value = event.target.checked
-  window._paq?.push([event.target.checked ? "forgetUserOptOut" : "optUserOut"])
+  if (event.target.checked) {
+    tracker.enableTracking()
+  } else {
+    tracker.disableTracking()
+  }
 }
 
 onMounted(() => {
-  window._paq?.push([
-    function () {
-      // https://developer.matomo.org/guides/tracking-javascript-guide#optional-creating-a-custom-opt-out-form
-      isUserTracked.value = !this.isUserOptedOut()
-    },
-  ])
+  tracker.pushCallback(function () {
+    // https://developer.matomo.org/guides/tracking-javascript-guide#optional-creating-a-custom-opt-out-form
+    isUserTracked.value = !this.isUserOptedOut()
+  })
 })
 </script>

--- a/src/lib/statistics-service/matomo.ts
+++ b/src/lib/statistics-service/matomo.ts
@@ -1,5 +1,6 @@
 import { skipSendStatistics } from "./shared.js"
 import { EventCategory } from "@lib/enums/event-category.js"
+import tracker from "@/plugins/tracker.js"
 
 const isProduction = process.env.NODE_ENV === "production"
 
@@ -10,25 +11,11 @@ export interface MatomoEvent {
   value?: string
 }
 
-export interface Matomo {
-  trackEvent: (
-    category: EventCategory,
-    action: string,
-    label: string,
-    value?: string
-  ) => void
-  getVisitorId: () => string
-}
-
-function skipSendEventToMatomo(matomo: Matomo | undefined): boolean {
-  return skipSendStatistics() || matomo === undefined
-}
-
-export function sendEventToMatomo(event: MatomoEvent, matomo: Matomo): void {
-  if (skipSendEventToMatomo(matomo)) {
+export function sendEventToMatomo(event: MatomoEvent): void {
+  if (skipSendStatistics()) {
     !isProduction && console.debug("Skip sending event to Matomo", event)
     return
   }
 
-  matomo.trackEvent(event.category, event.action, event.label, event.value)
+  tracker.trackEvent(event.category, event.action, event.label, event.value)
 }

--- a/src/mixins/statistics.ts
+++ b/src/mixins/statistics.ts
@@ -6,18 +6,9 @@ import {
 import {
   MatomoEvent,
   sendEventToMatomo,
-  Matomo,
 } from "@/lib/statistics-service/matomo.js"
 import { BehaviourEvent } from "@lib/enums/behaviour-event.js"
 import { EventCategory } from "@lib/enums/event-category.js"
-
-declare global {
-  interface Window {
-    Piwik: {
-      getTracker(): Matomo
-    }
-  }
-}
 
 export default {
   methods: {
@@ -31,10 +22,7 @@ export default {
         benefitId,
         event_type,
       }
-      const matomoTracker = window.Piwik?.getTracker()
-      if (matomoTracker) {
-        sendEventToRecorder(event, matomoTracker)
-      }
+      sendEventToRecorder(event)
     },
     sendEventToMatomo: function (
       category: EventCategory,
@@ -48,10 +36,7 @@ export default {
         label,
         value,
       }
-      const matomoTracker = window.Piwik?.getTracker()
-      if (matomoTracker) {
-        sendEventToMatomo(event, matomoTracker)
-      }
+      sendEventToMatomo(event)
     },
     sendBenefitsStatistics: function (
       benefits: StandardBenefit[] = [],

--- a/src/plugins/ab-testing-service.ts
+++ b/src/plugins/ab-testing-service.ts
@@ -42,7 +42,7 @@ function getEnvironment() {
   // /3 L'utiliser dans le code : ABTestingService.getValues().nom_du_test
   // Le bloc :
   // ABTestingEnvironment.name_of_the_test = ABTestingEnvironment.name_of_the_test || {}
-  // ABTestingEnvironment.name_of_the_test.index = 2
+  // ABTestingEnvironment.name_of_the_test.index = 2 (entre 1 et 5 inclus)
   // ABTestingEnvironment.name_of_the_test.value =
   //   ABTestingEnvironment.name_of_the_test.value ||
   //   (Math.random() > 0.5 ? "A version name" : "B version name")

--- a/src/plugins/ab-testing-service.ts
+++ b/src/plugins/ab-testing-service.ts
@@ -1,17 +1,5 @@
 import storageService from "@/lib/storage-service.js"
 
-declare global {
-  interface Window {
-    _paq?: [
-      string | (() => void),
-      (number | string)?,
-      string?,
-      string?,
-      string?
-    ][]
-  }
-}
-
 interface ABTesting {
   [key: string]: {
     index: number

--- a/src/plugins/ab-testing-service.ts
+++ b/src/plugins/ab-testing-service.ts
@@ -21,9 +21,6 @@ interface ABTesting {
  *      -> ne pas polluer Matomo d'anciennes périodes de tests
  */
 function getEnvironment() {
-  if (!window._paq) {
-    return {}
-  }
   const ABTestingEnvironment: ABTesting =
     storageService.local.getItem("ABTesting") || {}
 
@@ -57,18 +54,6 @@ function getEnvironment() {
     versions[Math.floor(Math.random() * versions.length)]
   ABTestingEnvironment.CTA_EmailRecontact = ctaEmailRecontact
 
-  Object.keys(ABTestingEnvironment).forEach(function (name) {
-    const data = ABTestingEnvironment[name]
-    if (data.deleted) {
-      window._paq!.push(["deleteCustomDimension", data.index])
-    } else {
-      window._paq!.push([
-        "setCustomDimension",
-        data.index,
-        `${name}/${data.value}`,
-      ])
-    }
-  })
   storageService.local.setItem("ABTesting", ABTestingEnvironment)
   return ABTestingEnvironment
 }
@@ -95,6 +80,7 @@ const ABTestingService = {
 
     return extractValueMap(ABTestingEnvironment)
   },
+  getEnvironment,
 }
 
 export default ABTestingService

--- a/src/plugins/state-service.ts
+++ b/src/plugins/state-service.ts
@@ -18,14 +18,11 @@ const StateService = {
       store.updateCurrentAnswers(nextStep.path)
       this.$router.push(nextStep.path).catch((failure) => {
         if (isNavigationFailure(failure, NavigationFailureType.cancelled)) {
-          sendEventToMatomo(
-            {
-              category: EventCategory.Parcours,
-              action: "Navigation cancelled",
-              label: failure.toString(),
-            },
-            window.Piwik?.getTracker()
-          )
+          sendEventToMatomo({
+            category: EventCategory.Parcours,
+            action: "Navigation cancelled",
+            label: failure.toString(),
+          })
         } else {
           throw new Error(failure)
         }

--- a/src/plugins/tracker.ts
+++ b/src/plugins/tracker.ts
@@ -70,6 +70,16 @@ const tracker = {
   setCustomDimension: (index: number, value: string) => {
     window._paq?.push(["setCustomDimension", index, value])
   },
+  getVisitorId: () => {
+    let visitorId: string | undefined
+    window._paq?.push([
+      function () {
+        visitorId = this?.getVisitorId()
+      },
+    ])
+
+    return visitorId
+  },
 }
 
 export default tracker

--- a/src/plugins/tracker.ts
+++ b/src/plugins/tracker.ts
@@ -19,4 +19,13 @@ export default {
   ) => {
     window._paq?.push(["trackEvent", category, action, name, value])
   },
+  disableTracking: () => {
+    window._paq?.push(["optUserOut"])
+  },
+  enableTracking: () => {
+    window._paq?.push(["forgetUserOptOut"])
+  },
+  pushCallback: (callback: () => void) => {
+    window._paq?.push([callback])
+  },
 }

--- a/src/plugins/tracker.ts
+++ b/src/plugins/tracker.ts
@@ -1,0 +1,22 @@
+declare global {
+  interface Window {
+    _paq?: [
+      string | (() => void),
+      (number | string)?,
+      string?,
+      string?,
+      string?
+    ][]
+  }
+}
+
+export default {
+  trackEvent: (
+    category: string,
+    action: string,
+    name?: string,
+    value?: string
+  ) => {
+    window._paq?.push(["trackEvent", category, action, name, value])
+  },
+}


### PR DESCRIPTION
Ticket: https://trello.com/c/iHvZFzDU/1453-probl%C3%A8mes-sur-les-ab-tests

Pour vérifier en local, il faut que toutes les requête Piwik ai le champs `dimension5` : 
<img width="561" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/4059803/a0e5bef9-8605-4ff0-b1b2-b18e2e6e62f2">

L'objectif principal de cette PR c'est de ne plus utilise `getTracker` qui créé un tracker à chaque fois, et donc n'a pas de dimension custom. En effet les dimension custom sont rajoutée seulement à `window._paq` directement