### PR TITLE
fix: Cypress error when page updates

### DIFF
--- a/cypress/e2e/patrimoine.cy.js
+++ b/cypress/e2e/patrimoine.cy.js
@@ -18,12 +18,9 @@ context("Full simulation", () => {
   })
 
   it("accept a basic situation in an iframe", () => {
-    cy.get("@iframe")
-      .its("0.contentDocument")
-      .should("not.be.empty")
-      .its("body")
-      .as("iframeBody")
-
+    cy.get("@iframe").its("0.contentDocument").as("iframeDoc")
+    cy.get("@iframeDoc").should("not.be.empty")
+    cy.get("@iframeDoc").its("body").as("iframeBody")
     cy.get("@iframeBody").should("not.be.empty")
 
     cy.get("@iframeBody")


### PR DESCRIPTION
On a une erreur : 
```
1) Full simulation
       accept a basic situation in an iframe:
     CypressError: Timed out retrying after 4000ms: `cy.should()` failed because the page updated as a result of this command, but you tried to continue the command chain. The subject is no longer attached to the DOM, and Cypress cannot requery the page after commands such as `cy.should()`.

Common situations why this happens:
  - Your JS framework re-rendered asynchronously
  - Your app code reacted to an event firing and removed the element

You can typically solve this by breaking up a chain. For example, rewrite:

> `cy.get('button').click().should('have.class', 'active')`

to

> `cy.get('button').as('btn').click()`
> `cy.get('@btn').should('have.class', 'active')`
```

Qui apparait environs une fois tout les 7 run du test `patrimoine.cy.js:27`  (*)

En appliquant les suggestion, le test semble tenir beaucoup plus (pas de fail après 100 runs d'affilés) (*) => **ça va dans le bon sens**


(*) FYI: j'ai coupé le test dans sa longeur jusqu'a la ligne 27 et fait tourné ce script pour lancer en boucle : 
```
counter=0
while true; do
  if npm run cypress -- --spec cypress/e2e/patrimoine.cy.js; then
    counter=$((counter+1))
    continue
  else
    echo "Test failed after $counter times"
    break
  fi
done
``` 