### PR TITLE
Supprime le bootstrap de modèle mongoose

### DIFF
--- a/backend/config/mongoose.ts
+++ b/backend/config/mongoose.ts
@@ -1,5 +1,3 @@
-import path from "path"
-import fs from "fs"
 import bluebird from "bluebird"
 import { Configuration } from "../types/config.js"
 
@@ -16,13 +14,4 @@ export default function (mongoose: any, config: Configuration) {
     .catch((e) => {
       throw new Error(e)
     })
-
-  // Bootstrap models
-  const __dirname = new URL(".", import.meta.url).pathname
-  const modelsPath = path.join(__dirname, "../models")
-  fs.readdirSync(modelsPath).forEach(async (file) => {
-    if (/(.*)\.(js$|coffee$)/.test(file)) {
-      await import(`${modelsPath}/${file}`)
-    }
-  })
 }


### PR DESCRIPTION
## Détails

Dans la continuité de la PR #3993 cette PR supprime les imports dynamiques du backend.

Ce sera à discuter, mais ici les imports semblent ne plus avoir d'utilité. L'import de modèles au sein de la fonction d'instanciation de mongoose semble être une pratique dépassé au vu de la stratégie actuelle de mise en cache de Node et le fait que les modèles sont correctement instanciés lorsqu'ils sont importés dans d'autres fichiers.