### PR TITLE
Ajoute l'aide pour les étudiants boursiers des Hauts-de-France : 100 repas du crous gratuits

### DIFF
--- a/data/benefits/openfisca/crous_aide_100_repas_gratuits.yml
+++ b/data/benefits/openfisca/crous_aide_100_repas_gratuits.yml
@@ -9,7 +9,7 @@ conditions:
     supérieur, de la recherche et de l’innovation sur le territoire des Hauts-de-France, ou inscrits dans un établissement dispensant une formation
     sanitaire ou sociale gérée par la Région.
   - Être boursier du Crous ou de la Région Hauts-de-France à l’un des échelons de bourse (3, 4, 5, 6, ou 7), ou signalé par le service social du Crous.
-  - Être inscrit dans un établissement autre qu'un lycée (sont exclus les étudiants dont l’établissement d’inscription est un lycée comme les étudiants en BTS ou CPGE)
+  - Être inscrit dans un établissement autre qu'un lycée (sont exclus les étudiants dont l’établissement d’inscription est un lycée comme les étudiants en BTS ou CPGE).
 periodicite: ponctuelle
 link: https://www.ij-hdf.fr/actualite/747/100-repas-gratuits-de-nouveau-attribues-aux-etudiants-boursiers-echelon-3-a-7#:~:text=Le%20Conseil%20R%C3%A9gional%20Hauts-de,en%20restos
 instructions: https://www.ij-hdf.fr/actualite/747/100-repas-gratuits-de-nouveau-attribues-aux-etudiants-boursiers-echelon-3-a-7#:~:text=Le%20Conseil%20R%C3%A9gional%20Hauts-de,en%20restos

--- a/data/benefits/openfisca/crous_aide_100_repas_gratuits.yml
+++ b/data/benefits/openfisca/crous_aide_100_repas_gratuits.yml
@@ -1,0 +1,17 @@
+label: aide du crous et de la région Hauts-de-France de 100 repas gratuits aux étudiants boursiers échelon 3 à 7
+institution: hauts_de_france
+description:
+  Le Conseil Régional Hauts-de-France, en partenariat avec le Crous, reconduit l’« aide à la restauration »
+  pour l’année universitaire 2023-2024 ! Dédiée aux étudiants boursiers échelon 3 à 7, elle permet de bénéficier
+  de 100 repas gratuits pris en restos’U du Crous.
+conditions:
+  - Être inscrit dans un établissement d’enseignement supérieur, public ou privé, partenaire de la Région, reconnu par le ministère de l’Enseignement supérieur, de la recherche et de l’innovation sur le territoire des Hauts-de-France, ou inscrits dans un établissement dispensant une formation sanitaire ou sociale gérée par la Région.
+  - Être boursier du Crous ou de la Région Hauts-de-France à l’un des échelons de bourse (3, 4, 5, 6, ou 7), ou signalé par le service social du Crous.
+periodicite: ponctuelle
+link: https://www.ij-hdf.fr/actualite/747/100-repas-gratuits-de-nouveau-attribues-aux-etudiants-boursiers-echelon-3-a-7#:~:text=Le%20Conseil%20R%C3%A9gional%20Hauts-de,en%20restos
+instructions: https://www.ij-hdf.fr/actualite/747/100-repas-gratuits-de-nouveau-attribues-aux-etudiants-boursiers-echelon-3-a-7#:~:text=Le%20Conseil%20R%C3%A9gional%20Hauts-de,en%20restos
+prefix: l’
+entity: individus
+type: bool
+unit: null
+openfiscaPeriod: thisMonth

--- a/data/benefits/openfisca/crous_aide_100_repas_gratuits.yml
+++ b/data/benefits/openfisca/crous_aide_100_repas_gratuits.yml
@@ -5,8 +5,11 @@ description:
   pour l’année universitaire 2023-2024 ! Dédiée aux étudiants boursiers échelon 3 à 7, elle permet de bénéficier
   de 100 repas gratuits pris en restos’U du Crous.
 conditions:
-  - Être inscrit dans un établissement d’enseignement supérieur, public ou privé, partenaire de la Région, reconnu par le ministère de l’Enseignement supérieur, de la recherche et de l’innovation sur le territoire des Hauts-de-France, ou inscrits dans un établissement dispensant une formation sanitaire ou sociale gérée par la Région.
+  - Être inscrit dans un établissement d’enseignement supérieur, public ou privé, partenaire de la Région, reconnu par le ministère de l’Enseignement
+    supérieur, de la recherche et de l’innovation sur le territoire des Hauts-de-France, ou inscrits dans un établissement dispensant une formation
+    sanitaire ou sociale gérée par la Région.
   - Être boursier du Crous ou de la Région Hauts-de-France à l’un des échelons de bourse (3, 4, 5, 6, ou 7), ou signalé par le service social du Crous.
+  - Être inscrit dans un établissement autre qu'un lycée (sont exclus les étudiants dont l’établissement d’inscription est un lycée comme les étudiants en BTS ou CPGE)
 periodicite: ponctuelle
 link: https://www.ij-hdf.fr/actualite/747/100-repas-gratuits-de-nouveau-attribues-aux-etudiants-boursiers-echelon-3-a-7#:~:text=Le%20Conseil%20R%C3%A9gional%20Hauts-de,en%20restos
 instructions: https://www.ij-hdf.fr/actualite/747/100-repas-gratuits-de-nouveau-attribues-aux-etudiants-boursiers-echelon-3-a-7#:~:text=Le%20Conseil%20R%C3%A9gional%20Hauts-de,en%20restos

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -2,5 +2,5 @@ gunicorn>=20.1.0
 pytest==7.2.2
 Openfisca-France==153.2.0
 Openfisca-Core[web-api]==41.0.0
-OpenFisca-France-Local[excel-reader]==6.4.0
+OpenFisca-France-Local[excel-reader]==6.5.0
 Openfisca-Paris==5.2.0


### PR DESCRIPTION
Tâche associée : https://trello.com/c/6TYcgk1Q/1455-ajouter-laide-100-repas-gratuits-attribu%C3%A9s-aux-%C3%A9tudiants-boursiers-%C3%A9chelon-3-%C3%A0-7-r%C3%A9gion-hauts-de-france

Une revue de code peut déjà être engagée, cette PR est en attente du merge de la [PR associée sur Openfisca-france-local](https://github.com/openfisca/openfisca-france-local/pull/184) 