### PR TITLE
Ajout d'une gestion d'erreur pour les InputNumber

### DIFF
--- a/src/components/input-number.vue
+++ b/src/components/input-number.vue
@@ -35,7 +35,7 @@ export default {
     modelValue: { type: [Number, String] },
     emit: { type: Boolean, default: true },
   },
-  emits: ["input", "update:modelValue"],
+  emits: ["input", "update:modelValue", "input-error"],
   data: function () {
     return {
       result: this.result,
@@ -62,6 +62,8 @@ export default {
           this.error = true
           this.$emit("update:modelValue", value)
         }
+
+        this.$emit("input-error", this.error)
       },
     },
   },

--- a/src/views/simulation/mutualized-step.vue
+++ b/src/views/simulation/mutualized-step.vue
@@ -46,6 +46,7 @@
                     :max="step.max"
                     :data-type="step.type"
                     aria-labelled-by="step-question"
+                    @input-error="onInputError"
                   />
                 </div>
                 <InputDate
@@ -123,6 +124,7 @@ export default {
       id,
       value,
       entityName,
+      inputError: false,
     }
   },
   computed: {
@@ -168,6 +170,9 @@ export default {
     },
   },
   methods: {
+    onInputError(hasError) {
+      this.inputError = hasError
+    },
     onSubmit() {
       if (!this.canSubmit(true)) {
         return
@@ -193,7 +198,10 @@ export default {
       return hasError
     },
     canSubmit(submit) {
-      return this.step.optional || !this.requiredValueMissing(submit)
+      return (
+        !this.inputError &&
+        (this.step.optional || !this.requiredValueMissing(submit))
+      )
     },
   },
 }

--- a/tests/unit/components/input-number.spec.ts
+++ b/tests/unit/components/input-number.spec.ts
@@ -1,6 +1,28 @@
 import { expect } from "@jest/globals"
 import InputNumber from "@/components/input-number.vue"
 
+function testInputNumber(
+  input: string | undefined,
+  result: number | string | undefined,
+  error: boolean = false,
+  min: number | undefined = undefined,
+  max: number | undefined = undefined
+): void {
+  const emitted: { [key: string]: any } = {}
+  InputNumber.default.computed.model.set.call(
+    {
+      $emit: (name: string, value: any) => (emitted[name] = value),
+      parseInputString: InputNumber.default.methods.parseInputString,
+      min,
+      max,
+    },
+    input
+  )
+
+  expect(emitted["update:modelValue"]).toEqual(result)
+  expect(emitted["input-error"]).toEqual(error)
+}
+
 describe("input-number.vue", () => {
   it("accept valid numbers", async () => {
     const testSet = [
@@ -13,18 +35,12 @@ describe("input-number.vue", () => {
       { input: "200.0", result: 200 },
       { input: "", result: 0 },
     ]
+
     for (const test of testSet) {
-      let emitted
-      InputNumber.default.computed.model.set.call(
-        {
-          $emit: (name, value) => (emitted = { name, value }),
-          parseInputString: InputNumber.default.methods.parseInputString,
-        },
-        test.input
-      )
-      expect(emitted.value).toEqual(test.result)
+      testInputNumber(test.input, test.result)
     }
   })
+
   it("remove improper input from valid numbers", async () => {
     const testSet = [
       { input: "a1", result: 1 },
@@ -34,63 +50,38 @@ describe("input-number.vue", () => {
       { input: "1a2", result: 12 },
       { input: "1.2.3", result: 1.2 },
     ]
+
     for (const test of testSet) {
-      let emitted
-      InputNumber.default.computed.model.set.call(
-        {
-          $emit: (name, value) => (emitted = { name, value }),
-          parseInputString: InputNumber.default.methods.parseInputString,
-        },
-        test.input
-      )
-      expect(emitted.value).toEqual(test.result)
+      testInputNumber(test.input, test.result)
     }
   })
+
   it("reject invalid numbers", async () => {
     const testSet = [
       { input: "1+2", result: 12 },
       { input: "Infinity", result: 0 },
       { input: "1e25", result: 125 },
-      { input: undefined, result: undefined },
-      { input: null, result: null },
+      { input: undefined, result: undefined, error: true },
     ]
+
     for (const test of testSet) {
-      let emitted
-      InputNumber.default.computed.model.set.call(
-        {
-          $emit: (name, value) => (emitted = { name, value }),
-          parseInputString: InputNumber.default.methods.parseInputString,
-        },
-        test.input
-      )
-      expect(emitted.value).toEqual(test.result)
+      testInputNumber(test.input, test.result, test.error)
     }
   })
+
   it("control numbers following rules", async () => {
     const testSet = [
       { input: "2", result: 2, min: 0 },
-      { input: "-2", result: "-2", min: 0 },
+      { input: "-2", result: "-2", min: 0, error: true },
       { input: "4", result: 4, max: 5 },
       { input: "5", result: 5, max: 5 },
-      { input: "6", result: "6", max: 5 },
+      { input: "6", result: "6", max: 5, error: true },
       { input: "5", result: 5, min: 5, max: 5 },
       { input: "-5", result: -5, min: -5, max: -5 },
     ]
+
     for (const test of testSet) {
-      let emitted
-      const input = InputNumber
-      input.default.computed.model.set.call(
-        {
-          min: test.min,
-          max: test.max,
-          $emit: (name, value) => (emitted = { name, value }),
-          parseInputString: InputNumber.default.methods.parseInputString,
-        },
-        test.input,
-        test.min,
-        test.max
-      )
-      expect(emitted.value).toEqual(test.result)
+      testInputNumber(test.input, test.result, test.error, test.min, test.max)
     }
   })
 })


### PR DESCRIPTION
On avait bien un min/max de défini, cependant cela ne bloquait pas le bouton suivant. 

Perso je suis pas 100% satisfait de la solution (se limiter à un event model, un event error ça va encore, mais faudrait pas qu'on en rajoute dans tout les sens). Au moins ça ouvre la discussion pour commencer.

Ticket : https://trello.com/c/eluHQ5xM/1371-ajouter-une-r%C3%A8gle-de-compl%C3%A9tion-du-champ-nombre-de-parts-fiscales-dans-la-simulation

Note: on a pas ce problème pour les champs date car l'affichage et la valeur retourner ne sont pas les même variables (donc ici on peut pas simplement envoyer undefined comme on le fait pour les dates : https://github.com/betagouv/aides-jeunes/blob/3bd1e3247f9f484dc1107ea680bd94efc9feda63/src/components/input-date.vue#L151)


<img width="863" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/4059803/6ab6b43a-7568-48bd-932b-cdcb7ae77636">
