### PR TITLE
Corrige le code insee du département Lot et Garonne

### DIFF
--- a/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-lot-et-garonne-aide-bafa-approfondissement.yml
@@ -8,7 +8,7 @@ conditions: []
 conditions_generales:
   - type: departements
     values:
-      - 47
+      - "47"
   - type: age
     operator: ">="
     value: 16


### PR DESCRIPTION
afin qu'il soit interprété en string