### PR TITLE
refactor: supprime la step vide de la page d'accueil dans blocks.ts

### DIFF
--- a/lib/answers.ts
+++ b/lib/answers.ts
@@ -17,10 +17,6 @@ export const getAnswer = (answers: Answer[], entity, variable?, id?) => {
   return answer ? answer.value : undefined
 }
 
-export const getAnswerIndexByPath = (answers: Answer[], path) => {
-  return answers.findIndex((answer) => answer.path === path)
-}
-
 export const getAnswerIndex = (
   answers: Answer[],
   entityName,

--- a/lib/chapters.ts
+++ b/lib/chapters.ts
@@ -1,13 +1,14 @@
 import { Chapter } from "./types/chapters.js"
+import { ChapterName, ChapterLabel } from "./enums/chapter.js"
 
 const chapters: Chapter[] = [
-  { label: "Mon profil", name: "profil" },
-  { label: "Mon foyer", name: "foyer" },
-  { label: "Mon logement", name: "logement" },
-  { label: "Mes revenus", name: "revenus" },
-  { label: "Mes projets", name: "projets" },
-  { label: "Récapitulatif", name: "recapitulatif" },
-  { label: "Mes résultats", name: "resultats" },
+  { label: ChapterLabel.MonProfil, name: ChapterName.Profil },
+  { label: ChapterLabel.MonFoyer, name: ChapterName.Foyer },
+  { label: ChapterLabel.MonLogement, name: ChapterName.Logement },
+  { label: ChapterLabel.MesRevenus, name: ChapterName.Revenus },
+  { label: ChapterLabel.MesProjets, name: ChapterName.Projets },
+  { label: ChapterLabel.Recapitulatif, name: ChapterName.Recapitulatif },
+  { label: ChapterLabel.Resultats, name: ChapterName.Resultats },
 ]
 
 function getChapters() {
@@ -15,12 +16,12 @@ function getChapters() {
 }
 
 function getSommaireChapters() {
-  return chapters.filter((c) => c.name !== "resultats")
+  return chapters.filter((c) => c.name !== ChapterName.Resultats)
 }
 
 function getLabel(name: string) {
   const chapter = chapters.find((c) => c.name === name)
-  return chapter?.label || "Mon profil"
+  return chapter?.label || ChapterLabel.MonProfil
 }
 
 const Chapters = {

--- a/lib/enums/chapter.ts
+++ b/lib/enums/chapter.ts
@@ -3,3 +3,23 @@ export enum ChapterState {
   Current = "current",
   Done = "done",
 }
+
+export enum ChapterName {
+  Profil = "profil",
+  Foyer = "foyer",
+  Logement = "logement",
+  Revenus = "revenus",
+  Projets = "projets",
+  Recapitulatif = "recapitulatif",
+  Resultats = "resultats",
+}
+
+export enum ChapterLabel {
+  MonProfil = "Mon profil",
+  MonFoyer = "Mon foyer",
+  MonLogement = "Mon logement",
+  MesRevenus = "Mes revenus",
+  MesProjets = "Mes projets",
+  Recapitulatif = "Récapitulatif",
+  Resultats = "Mes résultats",
+}

--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -8,11 +8,19 @@ import ScolariteCategories from "../scolarite.js"
 import { Activite } from "../enums/activite.js"
 import { Scolarite, Etudiant } from "../enums/scolarite.js"
 import { LogementCategory } from "../enums/logement.js"
+import { ChapterName } from "../enums/chapter.js"
 import { Block } from "../types/blocks.js"
 
-function individuBlockFactory(id, chapter?: string) {
-  const r = (variable, chapter?: string) =>
-    new StepGenerator({ entity: "individu", id, variable, chapter })
+function individuBlockFactory(id, chapter?: ChapterName) {
+  const r = (variable, chapter?: ChapterName) => {
+    return new StepGenerator({
+      entity: "individu",
+      id,
+      variable,
+      chapter,
+    })
+  }
+
   const conjoint = id == "conjoint"
   const demandeur = id == "demandeur"
   const enfant = id.startsWith("enfant")
@@ -23,7 +31,7 @@ function individuBlockFactory(id, chapter?: string) {
       {},
     steps: [
       ...(enfant ? [r("_firstName", chapter)] : []),
-      r("date_naissance", demandeur ? "profil" : chapter),
+      r("date_naissance", demandeur ? ChapterName.Profil : chapter),
       r("nationalite"),
       ...(conjoint ? [r("statut_marital")] : []),
       ...(enfant ? [r("garde_alternee")] : []),
@@ -240,9 +248,9 @@ function extraBlock() {
       situation.enfants?.find((enfant) => enfant.id === id) ||
       {},
     steps: [
-      s("_interetsAidesVelo", "projets"),
-      s("_interetBafa", "projets"),
-      s("_interetPermisDeConduire", "projets"),
+      s("_interetsAidesVelo", ChapterName.Projets),
+      s("_interetBafa", ChapterName.Projets),
+      s("_interetPermisDeConduire", ChapterName.Projets),
       {
         isActive: (subject) => {
           return (
@@ -251,7 +259,7 @@ function extraBlock() {
               .specialites_plurivalentes_sanitaires_et_sociales.value
           )
         },
-        steps: [s("_interetAidesSanitaireSocial", "projets")],
+        steps: [s("_interetAidesSanitaireSocial", ChapterName.Projets)],
       },
       {
         isActive: (subject) => subject.annee_etude === Etudiant.Terminale,
@@ -309,11 +317,11 @@ function kidBlock(situation) {
       ...(situation.enfants?.length
         ? situation.enfants.map((e) => {
             return {
-              steps: [individuBlockFactory(e.id, "foyer")],
+              steps: [individuBlockFactory(e.id, ChapterName.Foyer)],
             }
           })
         : []),
-      new StepGenerator({ entity: "enfants", chapter: "foyer" }),
+      new StepGenerator({ entity: "enfants", chapter: ChapterName.Foyer }),
     ],
   }
 }
@@ -324,7 +332,7 @@ function housingBlock() {
     steps: [
       new StepGenerator({
         entity: "menage",
-        chapter: "logement",
+        chapter: ChapterName.Logement,
         variable: "_logementType",
       }),
       {
@@ -461,7 +469,7 @@ function resourceBlocks(situation) {
       steps: [
         new ComplexStepGenerator({
           route: `individu/${individuId}/ressources/types`,
-          chapter: "revenus",
+          chapter: ChapterName.Revenus,
           entity: "individu",
           variable: "ressources",
           id: individuId,
@@ -632,7 +640,12 @@ export function generateBlocks(situation): Block[] {
     },
     extraBlock(),
     {
-      steps: [new StepGenerator({ entity: "resultats", chapter: "resultats" })],
+      steps: [
+        new StepGenerator({
+          entity: "resultats",
+          chapter: ChapterName.Resultats,
+        }),
+      ],
     },
   ]
 }

--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -507,7 +507,6 @@ function resourceBlocks(situation) {
 
 export function generateBlocks(situation): Block[] {
   return [
-    { steps: [new StepGenerator({})] },
     individuBlockFactory("demandeur"),
     kidBlock(situation),
     {

--- a/lib/state/index.ts
+++ b/lib/state/index.ts
@@ -28,21 +28,19 @@ export function current(
 
 export function getNextStep(
   currentRoute: Route,
-  journey: StepStrict[]
+  allSteps: StepStrict[]
 ): StepStrict {
   const currentPath = currentRoute.path || currentRoute.fullPath
-  const matches = journey
-    .map((element, index) => {
-      return { element, index }
-    })
-    .filter((item) => item.element.path == currentPath)
+  const currentIndex = allSteps.findIndex((step) => step.path === currentPath)
 
-  if (!matches.length) {
-    throw new Error(`Logic missing for ${currentPath}`)
+  if (currentIndex === -1 && currentPath !== "/") {
+    throw new Error(`Current path ${currentPath} not found in all steps array`)
   }
-  return journey
-    .slice(matches[matches.length - 1].index + 1)
-    .filter((step) => step.isActive)[0]
+
+  const nextSteps = allSteps.slice(currentIndex + 1)
+  const nextActiveStep = nextSteps.find((step) => step.isActive)
+
+  return nextActiveStep || allSteps[0]
 }
 
 function getCurrentStep(

--- a/lib/types/chapters.d.ts
+++ b/lib/types/chapters.d.ts
@@ -1,8 +1,8 @@
-import { ChapterState } from "@lib/enums/chapter"
+import { ChapterState, ChapterName } from "@lib/enums/chapter"
 
 export interface Chapter {
   label: string
-  name: string
+  name: ChapterName
   state?: ChapterState
   root?: string
 }

--- a/lib/types/steps.d.ts
+++ b/lib/types/steps.d.ts
@@ -1,7 +1,7 @@
 export interface Step {
   path?: string
   key?: string
-  entity?: string
+  entity: string
   id?: string
   variable?: string
   chapter?: string
@@ -9,7 +9,6 @@ export interface Step {
 }
 
 export interface StepStrict extends Step {
-  entity: string
   id: string
   variable: string
   path: string
@@ -21,13 +20,7 @@ export interface ComplexStep extends Step {
   variables?: Step[]
 }
 
-export interface ComplexStepProperties {
-  path: string
-  key: string
-  entity: string
+export interface ComplexStepProperties extends Step {
   id: string
-  variable: string
-  chapter: string
   substeps: Step[]
-  isActive?: boolean
 }

--- a/src/components/action-buttons.vue
+++ b/src/components/action-buttons.vue
@@ -27,7 +27,6 @@
 <script setup lang="ts">
 import BackButton from "@/components/buttons/back-button.vue"
 import { computed, defineProps, onMounted, onUnmounted } from "vue"
-import { getAnswerIndexByPath } from "@lib/answers.js"
 import { useStore } from "@/stores/index.js"
 import { useRoute, useRouter } from "vue-router"
 import WarningMessage from "@/components/warning-message.vue"
@@ -65,9 +64,8 @@ const localOnSubmit = (event) => {
 const goBack = () => {
   tracker.trackEvent(EventCategory.Parcours, "Bouton précédent", route.fullPath)
 
-  const answerIndex = getAnswerIndexByPath(
-    store.simulation.answers.current,
-    route.fullPath
+  const answerIndex = store.simulation.answers.current.findIndex(
+    (answer) => answer.path === route.fullPath
   )
   if (answerIndex > 0) {
     const previousAnswer = store.simulation.answers.current[answerIndex - 1]

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -148,10 +148,7 @@ export const useStore = defineStore("store", {
     },
     getAllAnsweredSteps(): any[] {
       const allSteps = this.getAllSteps.filter(
-        (step) =>
-          step.path !== "/" &&
-          step.path !== "/simulation/resultats" &&
-          step.isActive
+        (step) => step.path !== "/simulation/resultats" && step.isActive
       )
       return allSteps.filter((step) =>
         isStepAnswered(this.simulation.answers.all, step)
@@ -159,10 +156,7 @@ export const useStore = defineStore("store", {
     },
     lastUnansweredStep(): any {
       const allSteps = this.getAllSteps.filter(
-        (step) =>
-          step.path !== "/" &&
-          step.path !== "/simulation/resultats" &&
-          step.isActive
+        (step) => step.path !== "/simulation/resultats" && step.isActive
       )
       return allSteps.find(
         (step) => !isStepAnswered(this.simulation.answers.all, step)

--- a/src/views/simulation.vue
+++ b/src/views/simulation.vue
@@ -109,7 +109,7 @@ export default {
       return (
         this.$route.query["france-connect-enabled"] === "true" &&
         process.env.VITE_FRANCE_CONNECT_ENABLED &&
-        this.store.getAllSteps[1].path === this.$route.path &&
+        this.store.getAllSteps[0].path === this.$route.path &&
         this.store.simulation.answers.all.length === 0 &&
         !this.franceConnectConnected
       )


### PR DESCRIPTION
Liste de la [tâche Trello associée](https://trello.com/c/Sg7admVD/1380-supprimer-la-step-de-la-page-daccueil-de-blockts) mise à jour avec les derniers refactos TS : 

- [x] Supprimer la ligne ligne sus-mentionnée
- [x] Modifier l’interface Step de manière à rendre les variables variable, entity et chapter obligatoire ⇒ j'en ai profité pour ajouter un enum (à vérifier lors de la review: les chapters indiqués sont-ils les bons?)
- [x] Modifier l’interface ComplexStepProperties de manière à ce qu’elle “extends” l’interface Step
- [x]  Modifier le fichier action-buttons.vue de manière à ce qu’il prenne en compte l’absence de la première étape => je n'ai pas observé de modification nécessaire pour que tout fonctionne comme avant
- [x]  Contrôler les appels de getAllSteps et supprimer les filter de step.path !== "/" ainsi que modifier les références à l’index [1] de la liste retournée par getAllSteps
- [x]  Contrôler que tout fonctionne normalement, notamment en terme d’UI