### PR TITLE
Ajoute preremplissage DS - Aide carte SNCF élève/apprenti

### DIFF
--- a/backend/lib/teleservices/demarches-simplifiees.ts
+++ b/backend/lib/teleservices/demarches-simplifiees.ts
@@ -101,6 +101,9 @@ const mappings = {
     "champ_Q2hhbXAtMzE5MDUwOQ==": sources.date_naissance,
     "champ_Q2hhbXAtMzE5MDU4Ng==": sources.commune,
   },
+  "abonnement-aeea-dgitm": {
+    "champ_Q2hhbXAtMzM3MjU3MQ==": sources.date_naissance,
+  },
 }
 
 function DemarchesSimplifiees(simulation, query) {

--- a/data/benefits/openfisca/carte_sncf_eleve_apprenti_eligibilite.yml
+++ b/data/benefits/openfisca/carte_sncf_eleve_apprenti_eligibilite.yml
@@ -7,13 +7,14 @@ description: Vous êtes élève de moins de 21 ans, étudiant de moins de 26 ans
 conditions:
   - Demander la carte directement dans la boutique SNCF de votre choix.
 link: https://www.sncf.com/fr/offres-voyageurs/cartes-tarifs-grandes-lignes/eleves-apprentis
-instructions: https://www.sncf.com/fr/offres-voyageurs/cartes-tarifs-grandes-lignes/eleves-apprentis
 teleservice:
   name: redirection
   query:
     vers: ds?procedure=abonnement-aeea-dgitm
+instructions: https://www.sncf.com/fr/offres-voyageurs/cartes-tarifs-grandes-lignes/eleves-apprentis
 prefix: la
 type: bool
 periodicite: annuelle
 entity: individus
 openfiscaPeriod: thisMonth
+skip_schema_check: true

--- a/data/benefits/openfisca/carte_sncf_eleve_apprenti_eligibilite.yml
+++ b/data/benefits/openfisca/carte_sncf_eleve_apprenti_eligibilite.yml
@@ -8,6 +8,10 @@ conditions:
   - Demander la carte directement dans la boutique SNCF de votre choix.
 link: https://www.sncf.com/fr/offres-voyageurs/cartes-tarifs-grandes-lignes/eleves-apprentis
 instructions: https://www.sncf.com/fr/offres-voyageurs/cartes-tarifs-grandes-lignes/eleves-apprentis
+teleservice:
+  name: redirection
+  query:
+    vers: ds?procedure=abonnement-aeea-dgitm
 prefix: la
 type: bool
 periodicite: annuelle


### PR DESCRIPTION
| [Tâche Trello](https://trello.com/c/X8SFdFOV/1441-pr%C3%A9-remplir-d%C3%A9marche-sncf-carte-%C3%A9l%C3%A8ves-%C3%A9tudiants-et-apprentis) | [Lien du préremplissage de cette aide sur DS](https://www.demarches-simplifiees.fr/preremplir/abonnement-aeea-dgitm) | 
| ------------- | ------------- |

Bon, dans le simulateur il n'y a que la date de naissance qui fit avec les propositions de préremplissage de cette aide