### PR TITLE
fix: ajoute le support de bouton multi-lignes

### DIFF
--- a/src/components/buttons/send-recap-button.vue
+++ b/src/components/buttons/send-recap-button.vue
@@ -20,7 +20,7 @@ const isDisabled = computed(() => {
 
 <template>
   <button
-    class="fr-btn fr-btn--icon-center fr-icon-mail-line fr-px-3v"
+    class="fr-btn fr-btn--icon-center fr-icon-mail-line fr-px-3v fr-btn--multiline"
     data-fr-opened="false"
     aria-controls="fr-modal-email"
     :disabled="isDisabled"

--- a/src/styles/aides-jeunes.css
+++ b/src/styles/aides-jeunes.css
@@ -145,6 +145,10 @@ textarea {
 .fr-btn--icon-center {
   justify-content: center !important;
 }
+.fr-btn--multiline {
+  white-space: normal !important;
+  max-height: none !important;
+}
 
 .fr-btn-disabled {
   --hover: var(--background-disabled-grey);


### PR DESCRIPTION
## Détails

[Tâche Trello](https://trello.com/c/9g02u9Db/1458-améliorer-lui-de-la-version-mobile-du-récap-des-résultats-de-simulation-le-bouton-recevoir-les-résultats-par-email-sms-est-tronq)

Le [DSFR ne proposant pas d'option](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton) pour afficher un bouton sur plusieurs lignes lorsque le texte est trop important j'ai dû créer une nouvelle classe CSS permettant un affichage correct sur des écrans de petite taille.

| Avant | Après |
|-------|-------|
|  <img width="288" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/16650011/0536709f-5e74-4720-978f-c60173a0331d">  | <img width="289" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/16650011/48399cc9-9fe7-4f18-bd72-1ed180d49555">  |





