### PR TITLE
Supprime les numéros de téléphone et email des logs sentry

### DIFF
--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -22,7 +22,7 @@ const FollowupSchema = new mongoose.Schema<Followup, FollowupModel>(
       type: String,
       validate: {
         validator: validator.isEmail,
-        message: "{VALUE} n'est pas un email valide",
+        message: "Email invalide",
         isAsync: false,
       },
     },
@@ -30,7 +30,7 @@ const FollowupSchema = new mongoose.Schema<Followup, FollowupModel>(
       type: String,
       validate: {
         validator: validator.isMobilePhone,
-        message: "{VALUE} n'est pas un numéro de téléphone valide",
+        message: "Numéro de téléphone invalide",
         isAsync: false,
       },
     },


### PR DESCRIPTION
## Détails

PR à débattre, mais aujourd'hui on a la valeur entrée par l'utilisateur pour les emails et numéros de téléphone dans les logs Sentry, ce qui rend leur anonymisation impossible