### PR TITLE
fix: Ab test plus pertinent

### DIFF
--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -65,10 +65,14 @@ const sendRecap = async (surveyOptin) => {
       emailInputErrorMessage.value = true
     }
 
-    if (!phoneInputErrorMessage.value || !emailInputErrorMessage.value) {
+    const sendOptinSurveyEvent =
+      surveyOptin &&
+      (!phoneInputErrorMessage.value || !emailInputErrorMessage.value)
+
+    if (sendOptinSurveyEvent) {
       StatisticsMixin.methods.sendEventToMatomo(
         EventCategory.Followup,
-        "Formulaire validé",
+        "Formulaire validé avec recontact",
         ABTestingService.getValues().CTA_EmailRecontact
       )
     }


### PR DESCRIPTION
L'ab-test en prod actuellement ne différentie pas si on clic sur le bouton visé par l'ab-test ou bien sur celui en dessous.
On a donc sans surprise des versions homogènes sur matomo.

Cette PR fix le problème, Par ailleurs le nom de l'évènement a été changé pour éviter des confusions 