### PR TITLE
Remove tracker timeout error

### DIFF
--- a/src/plugins/tracker.ts
+++ b/src/plugins/tracker.ts
@@ -1,4 +1,5 @@
 import ABTestingService from "@/plugins/ab-testing-service.js"
+const isProduction = process.env.VITE_CONTEXT === "production"
 
 declare global {
   interface Window {
@@ -42,9 +43,13 @@ function initializeABTestingDimensions() {
   }
 }
 
-waitForPaq().then(() => {
-  initializeABTestingDimensions()
-})
+waitForPaq()
+  .then(() => {
+    initializeABTestingDimensions()
+  })
+  .catch((error) => {
+    !isProduction && console.error("Error while loading Matomo:", error)
+  })
 
 const tracker = {
   trackEvent: (

--- a/src/plugins/tracker.ts
+++ b/src/plugins/tracker.ts
@@ -25,7 +25,7 @@ function waitForPaq(timeout = 10000): Promise<void> {
         resolve()
       } else if (Date.now() - startTime > timeout) {
         clearInterval(intervalId)
-        reject(new Error("Timeout reached."))
+        reject("Timeout reached.")
       }
     }, 100)
   })


### PR DESCRIPTION
Cette PR catch l'erreur liée au timeout de l'initialisation de matomo. Cela faisait trop de bruit dans sentry dû au adblock par exemple