### PR TITLE
1459 corriger les tags dans les emails pour quils soient effectivement enregistres dans tipimail

### DIFF
--- a/backend/lib/smtp.ts
+++ b/backend/lib/smtp.ts
@@ -6,7 +6,7 @@ const transporter = nodemailer.createTransport(config.smtp)
 
 export function sendMail(email: Email) {
   const { tags, ...emailParameters } = email
-  const tagsFormatted = tags?.map((tag) => `${tag}`) || []
+  const tagsFormatted = tags?.map((tag) => tag.replace(/-/g, "_")) || []
 
   return transporter.sendMail({
     from: '"Équipe du simulateur 1jeune1solution.gouv.fr" <aides-jeunes@beta.gouv.fr>"',

--- a/backend/lib/smtp.ts
+++ b/backend/lib/smtp.ts
@@ -5,8 +5,14 @@ import { Email } from "../../lib/types/email.js"
 const transporter = nodemailer.createTransport(config.smtp)
 
 export function sendMail(email: Email) {
+  const { tags, ...emailParameters } = email
+  const tagsFormatted = tags?.map((tag) => `${tag}`) || []
+
   return transporter.sendMail({
     from: '"Équipe du simulateur 1jeune1solution.gouv.fr" <aides-jeunes@beta.gouv.fr>"',
-    ...email,
+    headers: {
+      "X-TM-TAGS": JSON.stringify(tagsFormatted),
+    },
+    ...emailParameters,
   })
 }

--- a/backend/models/followup.ts
+++ b/backend/models/followup.ts
@@ -91,9 +91,7 @@ FollowupSchema.method("sendSimulationResultsEmail", function () {
         subject: render.subject,
         text: render.text,
         html: render.html,
-        headers: {
-          "x-tm-tags": `["${EmailCategory.SimulationResults}"]`,
-        },
+        tags: [EmailCategory.SimulationResults],
       })
     })
     .then((response) => {
@@ -189,9 +187,7 @@ FollowupSchema.method("sendSurvey", function (surveyType: SurveyCategory) {
           subject: render.subject,
           text: render.text,
           html: render.html,
-          headers: {
-            "x-tm-tags": `["survey", "${surveyType}"]`,
-          },
+          tags: ["survey", surveyType],
         })
           .then((response) => {
             return response.messageId

--- a/lib/types/email.d.ts
+++ b/lib/types/email.d.ts
@@ -4,7 +4,5 @@ export interface Email {
   subject: string
   text: string
   html: string
-  headers?: {
-    "x-tm-tags": string
-  }
+  tags?: string[]
 }


### PR DESCRIPTION
Ticket: https://trello.com/c/c9jMBEnT/1459-corriger-les-tags-dans-les-emails-pour-quils-soient-effectivement-enregistr%C3%A9s-dans-tipimail

Dans le doc je ne vois pas mentionné que les `-` ne sont pas pris en compte. En revanche je vois bien qu'on a pas les tags qui en contiennent dans l'interface. 

Je vais faire un test en preprod pour vérifier l'hypothèse. 

Quoi qu'il en soit c'est bien de cacher la logique de tags dans le fichier `backend/lib/smtp.ts` à mon avis. 


Edit: good ça marche : 
<img width="529" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/4059803/f14adcdc-123b-41ca-bfd1-a7dee1e34461">
