### PR TITLE
feat: Ajoute des statistiques sur les EPCI

### DIFF
--- a/backend/lib/stats/funnel-service.ts
+++ b/backend/lib/stats/funnel-service.ts
@@ -1,14 +1,9 @@
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc.js"
-import mongoose from "mongoose"
 
 import { callMatomoAPI } from "./piwik.js"
-import mongooseConfig from "../../config/mongoose.js"
-import config from "../../config/index.js"
 import Followups from "../../models/followup.js"
 import Simulations from "../../models/simulation.js"
-
-mongooseConfig(mongoose, config)
 
 dayjs.extend(utc)
 
@@ -123,8 +118,6 @@ const getFunnelData = async () => {
       getFollowupsData(beginRange, endRange),
       getMatomoEventsData(beginRange, endRange),
     ]).then((results) => results.map(returnEmptyDataIfError))
-
-  await mongoose.connection.close()
 
   return {
     [dateKey]: {

--- a/backend/lib/stats/index.ts
+++ b/backend/lib/stats/index.ts
@@ -6,6 +6,7 @@ import Sentry from "@sentry/node"
 
 import { getUsageData } from "./piwik.js"
 import mongodb from "./mongodb.js"
+import mongoose from "../../lib/mongo-connector.js"
 import getFunnelData from "./funnel-service.js"
 import getInstitutionsData from "./institutions.js"
 
@@ -42,4 +43,5 @@ try {
   process.exitCode = 1
 } finally {
   mongodb.closeClient()
+  mongoose.connection.close()
 }

--- a/backend/lib/stats/institutions.ts
+++ b/backend/lib/stats/institutions.ts
@@ -1,16 +1,11 @@
 import dayjs from "dayjs"
-import mongoose from "mongoose"
 import epci from "@etalab/decoupage-administratif/data/epci.json" assert { type: "json" }
 
-import config from "../../config/index.js"
-import mongooseConfig from "../../config/mongoose.js"
 import Simulations from "../../models/simulation.js"
 import benefits from "../../../data/all.js"
 import { StandardBenefit } from "../../../data/types/benefits.js"
 
 // Note: for now, only EPCI are supported
-
-mongooseConfig(mongoose, config)
 
 const sixMonthsAgo = dayjs().subtract(6, "month").toDate()
 
@@ -43,8 +38,6 @@ async function getSimulationCountPerEPCI(): Promise<Count> {
       },
     },
   ])
-
-  await mongoose.connection.close()
 
   return simulationCount.reduce(
     (count: Count, result: { _id: string; count: number }): Count => {

--- a/backend/lib/stats/institutions.ts
+++ b/backend/lib/stats/institutions.ts
@@ -1,0 +1,87 @@
+import dayjs from "dayjs"
+import mongoose from "mongoose"
+import epci from "@etalab/decoupage-administratif/data/epci.json" assert { type: "json" }
+
+import config from "../../config/index.js"
+import mongooseConfig from "../../config/mongoose.js"
+import Simulations from "../../models/simulation.js"
+import benefits from "../../../data/all.js"
+import { StandardBenefit } from "../../../data/types/benefits.js"
+
+// Note: for now, only EPCI are supported
+
+mongooseConfig(mongoose, config)
+
+const sixMonthsAgo = dayjs().subtract(6, "month").toDate()
+
+interface Count {
+  [key: string]: number
+}
+
+async function getSimulationCountPerEPCI(): Promise<Count> {
+  const simulationCount = await Simulations.aggregate([
+    {
+      $match: {
+        createdAt: {
+          $gt: sixMonthsAgo,
+        },
+      },
+    },
+    {
+      $unwind: "$answers.all",
+    },
+    {
+      $match: {
+        "answers.all.entityName": "menage",
+        "answers.all.fieldName": "depcom",
+      },
+    },
+    {
+      $group: {
+        _id: "$answers.all.value._epci",
+        count: { $sum: 1 },
+      },
+    },
+  ])
+
+  await mongoose.connection.close()
+
+  return simulationCount.reduce(
+    (count: Count, result: { _id: string; count: number }): Count => {
+      count[result._id] = result.count
+      return count
+    },
+    {} as Count
+  )
+}
+
+function getBenefitCountPerEPCI(): Count {
+  return benefits.all.reduce(
+    (count: Count, benefit: StandardBenefit): Count => {
+      const { institution } = benefit
+      if (institution.type !== "epci" || !institution.code_siren) {
+        return count
+      }
+
+      count[institution.code_siren] = count[institution.code_siren] + 1 || 1
+      return count
+    },
+    {} as Count
+  )
+}
+
+export default async function getInstitutionsData() {
+  const simulationNumberPerEPCI = await getSimulationCountPerEPCI()
+  const benefitCountPerEPCI = getBenefitCountPerEPCI()
+
+  return epci.map((epci) => {
+    return {
+      name: epci.nom,
+      code: epci.code,
+      type: epci.type,
+      population: epci.populationTotale,
+      simulationCount: simulationNumberPerEPCI[epci.code] || 0,
+      benefitCount: benefitCountPerEPCI[epci.code] || 0,
+    }
+  })
+}


### PR DESCRIPTION
Ticket: https://trello.com/c/TvwI345k/1460-en-tant-que-charg%C3%A9e-de-d%C3%A9ploiement-je-veux-savoir-dans-quels-epci-jai-des-aides-et-dans-lesquels-je-nen-ai-pas-encore

Cette PR peut se lire commit par commit : 
- Elle ajout un calcul sur les institutions (seulement EPCI pour le moment) avec la population, le nombre de simulations sur les 6 derniers mois et le nombre d'aides directement reliées à l'institution. 
- Elle rationalise un peu les connexions à mongoose pour les stats

Ces nouvelles statistiques sur les institutions ont vocation d'être utilisées dans le site https://betagouv.github.io/mes-aides-analytics/

Un ticket à l'issue de cette PR a été créé pour enlever les MapReduce et utilisé la connexion mongoose dans le fichier https://github.com/betagouv/aides-jeunes/blob/e56c91220c26aef111ed0dbfb7411817c7603fbe/backend/lib/stats/mongodb.ts
ticket : https://trello.com/c/kzEKJRTR/1472-suppression-des-mapreduce-dans-les-stats