### PR TITLE
Ajoute le sitemap au fichier robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,5 @@ Disallow: /simulation/*
 Disallow: /tests
 Disallow: /tests/*
 Disallow: /validation
+
+Sitemap: https://mes-aides.1jeune1solution.beta.gouv.fr/sitemap.xml


### PR DESCRIPTION
## Notes

L'url vers le fichier sitemap doit être absolue et non pas relative (cf [documentation sitemap](https://www.sitemaps.org/protocol.html#submit_robots)), ce qui fait que le fichier robots.txt devra être mis à jour manuellement en cas de changement de nom de domaine ou réutilisation externe.

Une autre solution pérenne serait de rendre le contenu du fichier `robots.txt` dynamique via un rollup vite

