### PR TITLE
Bump gunicorn to avoid sigterm error in production

### DIFF
--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,6 +1,6 @@
-gunicorn>=20.1.0
+gunicorn>=21.2.0
 pytest==7.2.2
 Openfisca-France==153.2.1
-Openfisca-Core[web-api]==41.1.2
+Openfisca-Core[web-api]==41.2.0
 OpenFisca-France-Local[excel-reader]==6.5.0
 Openfisca-Paris==5.2.0


### PR DESCRIPTION
Permet de faire une mise à jour de Gunicorn qui résout un bug en prod.

Note: https://github.com/openfisca/openfisca-core/issues/1198