### PR TITLE
fix: Patch la liste des EPCI pour normaliser les metropôles.

### DIFF
--- a/backend/lib/stats/institutions.ts
+++ b/backend/lib/stats/institutions.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs"
-import epci from "@etalab/decoupage-administratif/data/epci.json" assert { type: "json" }
+import epciList from "@etalab/decoupage-administratif/data/epci.json" assert { type: "json" }
 
 import Simulations from "../../models/simulation.js"
 import benefits from "../../../data/all.js"
@@ -63,11 +63,29 @@ function getBenefitCountPerEPCI(): Count {
   )
 }
 
+// Temporary patch to fix MET69 type
+// An issue has been opened on the data repository:
+// https://github.com/etalab/decoupage-administratif/issues/42
+// TODO: remove this patch when the issue is fixed
+function patchEpciList(epci) {
+  return epci.map((epci) => {
+    if (epci.type === "MET69") {
+      return {
+        ...epci,
+        type: "METRO",
+      }
+    }
+
+    return epci
+  })
+}
+
 export default async function getInstitutionsData() {
+  const epciPatched = patchEpciList(epciList)
   const simulationNumberPerEPCI = await getSimulationCountPerEPCI()
   const benefitCountPerEPCI = getBenefitCountPerEPCI()
 
-  return epci.map((epci) => {
+  return epciPatched.map((epci) => {
     return {
       name: epci.nom,
       code: epci.code,


### PR DESCRIPTION
Le type de la metropole de Lyon n'est pas `METRO` mais `MET69` ce qui fait que dans le dashboard des institution la metropole de Lyon se retrouve tout seul dans sa catégorie : 
<img width="716" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/4059803/41f7844d-5743-4b8d-bf39-346eacc1c98f">

Un ticket a été ouvert chez etalab : https://github.com/etalab/decoupage-administratif/issues/42