### PR TITLE
Extraction de service civique de la question activité

### DIFF
--- a/backend/lib/migrations/simulations/to-v15.ts
+++ b/backend/lib/migrations/simulations/to-v15.ts
@@ -71,8 +71,18 @@ function transformAnswersWithServiceCivique(answers, age) {
     return answer.id === "demandeur" && answer.fieldName === "handicap"
   })
 
+  // Si il n'y a pas de question handicap, on l'ajoute apres la question activite
+  // p.e. anonymisation
+  const activityAnswerIndex = answers.findIndex((answer) => {
+    return answer.id === "demandeur" && answer.fieldName === "activite"
+  })
+
   // Warning: splice modifie l'array en place
-  answers.splice(handicapAnswerIndex, 0, serviceCiviqueAnswer)
+  answers.splice(
+    handicapAnswerIndex !== -1 ? handicapAnswerIndex : activityAnswerIndex + 1,
+    0,
+    serviceCiviqueAnswer
+  )
   return answers
 }
 

--- a/backend/lib/migrations/simulations/to-v15.ts
+++ b/backend/lib/migrations/simulations/to-v15.ts
@@ -1,0 +1,59 @@
+/*
+ * Extrait une question service_civique à partir
+ * de la question activite
+ */
+
+const VERSION = 15
+
+function transformAnswersWithServiceCivique(answers) {
+  if (
+    answers.find(
+      (answer) =>
+        answer.id === "demandeur" && answer.fieldName === "service_civique"
+    )
+  ) {
+    return answers
+  }
+
+  const activityAnswer = answers.find((answer) => {
+    return answer.id === "demandeur" && answer.fieldName === "activite"
+  })
+
+  if (!activityAnswer) {
+    return answers
+  }
+
+  const isServiceCivique = activityAnswer.value === "service_civique"
+
+  activityAnswer.value = isServiceCivique ? "inactif" : activityAnswer.value
+
+  const serviceCiviqueAnswer = {
+    entityName: "individu",
+    fieldName: "service_civique",
+    id: "demandeur",
+    value: isServiceCivique,
+  }
+
+  // La question service_civique est ajouté juste avant la question handicap
+  const handicapAnswerIndex = answers.findIndex((answer) => {
+    return answer.id === "demandeur" && answer.fieldName === "handicap"
+  })
+
+  // Warning: splice modifie l'array en place
+  answers.splice(handicapAnswerIndex, 0, serviceCiviqueAnswer)
+  return answers
+}
+
+export default {
+  apply(simulation) {
+    simulation.answers.all = transformAnswersWithServiceCivique(
+      simulation.answers.all
+    )
+    simulation.answers.current = transformAnswersWithServiceCivique(
+      simulation.answers.current
+    )
+
+    return simulation
+  },
+  version: VERSION,
+}

--- a/backend/lib/openfisca/mapping/individu/index.ts
+++ b/backend/lib/openfisca/mapping/individu/index.ts
@@ -18,12 +18,6 @@ import { Activite } from "../../../../../lib/enums/activite.js"
 import { IndividuGenerator } from "../../../../../lib/types/individu.js"
 
 const individuSchema: IndividuGenerator = {
-  service_civique: {
-    src: "activite",
-    fn: function (activite) {
-      return activite === Activite.ServiceCivique
-    },
-  },
   activite: {
     src: "activite",
     fn: function (activite) {

--- a/cypress/utils/profil.js
+++ b/cypress/utils/profil.js
@@ -43,6 +43,10 @@ const fill_agence_travail_temporaire = (agence_travail_temporaire) => {
   fillRadio("agence_travail_temporaire", agence_travail_temporaire)
 }
 
+const fill_service_civique = (service_civique) => {
+  fillRadio("service_civique", service_civique)
+}
+
 const fill_scolarite = (level) => {
   fillRadio("scolarite", level)
 }
@@ -155,6 +159,7 @@ const publicStudent = () => {
   fill_stagiaire(false)
   fill_alternant(false)
   fill_groupe_specialites_formation(GroupeSpecialite.Groupe330)
+  fill_service_civique(true)
   fillHandicap(false)
   fill_enfant_a_charge(false)
   fill_regime_securite_sociale("regime_general")

--- a/lib/activite.ts
+++ b/lib/activite.ts
@@ -1,9 +1,5 @@
 import { Activite } from "./enums/activite.js"
-const ACTIVITES_ACTIF = [
-  Activite.ServiceCivique,
-  Activite.Salarie,
-  Activite.Independant,
-]
+const ACTIVITES_ACTIF = [Activite.Salarie, Activite.Independant]
 
 function estActif(activite: Activite): boolean {
   return ACTIVITES_ACTIF.includes(activite)

--- a/lib/benefits/compute-javascript.ts
+++ b/lib/benefits/compute-javascript.ts
@@ -61,7 +61,7 @@ const PROFILE_STRATEGY = {
     return situation.demandeur?.activite === Activite.Salarie
   },
   service_civique: ({ situation }: { situation: Situation }): boolean => {
-    return situation.demandeur?.activite === Activite.ServiceCivique
+    return situation.demandeur?.service_civique === true
   },
   stagiaire: ({ situation }: { situation: Situation }): boolean => {
     return situation.demandeur?.stagiaire === true

--- a/lib/cleaner-functions.ts
+++ b/lib/cleaner-functions.ts
@@ -38,6 +38,7 @@ function getAnonymizedAnswer(answer, simulation) {
           case "_interetPermisDeConduire":
           case "_interetsAidesVelo":
           case "activite":
+          case "service_civique":
           case "age":
           case "alternant":
           case "boursier":

--- a/lib/enums/activite.ts
+++ b/lib/enums/activite.ts
@@ -9,7 +9,6 @@ export enum Activite {
   Professionnalisation = "professionnalisation",
   Retraite = "retraite",
   Salarie = "salarie",
-  ServiceCivique = "service_civique",
   SituationHandicap = "situation_handicap",
   Stagiaire = "stagiaire",
 }

--- a/lib/properties/individu-properties.ts
+++ b/lib/properties/individu-properties.ts
@@ -55,10 +55,6 @@ export default {
         label: "Indépendant ou indépendante",
       },
       {
-        value: Activite.ServiceCivique,
-        label: "En service civique",
-      },
-      {
         value: Activite.Chomeur,
         label: "Inscrit ou inscrite comme demandeur d’emploi",
       },
@@ -75,6 +71,12 @@ export default {
     ],
     moreInfo:
       "Lorsque vous étudiez et que vous travaillez, vous devez sélectionner « En étude ou en alternance ».",
+  }),
+
+  service_civique: new BooleanProperty({
+    question: ({ individu }) => {
+      return `${IndividuMethods.label(individu, "être")} en service civique ?`
+    },
   }),
 
   alternant: new BooleanProperty({

--- a/lib/simulation.ts
+++ b/lib/simulation.ts
@@ -1,1 +1,1 @@
-export const version = 14
+export const version = 15

--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -216,6 +216,7 @@ function individuBlockFactory(id, chapter?: ChapterName) {
                     subject.activite
                   ) &&
                   !subject.ass_precondition_remplie &&
+                  !subject.service_civique &&
                   !enfant_a_charge
                 )
               },

--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -131,6 +131,20 @@ function individuBlockFactory(id, chapter?: ChapterName) {
             },
           ]
         : []),
+      ...(demandeur
+        ? [
+            {
+              isActive: (subject, situation) => {
+                const age = IndividuMethods.age(
+                  subject,
+                  datesGenerator(situation.dateDeValeur).today.value
+                )
+                return age <= 31
+              },
+              steps: [r("service_civique")],
+            },
+          ]
+        : []),
       r("handicap"),
       {
         isActive: (subject) => subject.handicap,

--- a/lib/types/individu.d.ts
+++ b/lib/types/individu.d.ts
@@ -10,6 +10,7 @@ export interface Individu {
   salaire_net?: number
   statut_marital?: string
   activite?: string
+  service_civique?: boolean
   scolarite?: string
   _contrat_alternant?: string
   stagiaire?: boolean

--- a/tests/unit/backend/migration-to-v15.spec.ts
+++ b/tests/unit/backend/migration-to-v15.spec.ts
@@ -1,0 +1,91 @@
+import { expect } from "@jest/globals"
+
+import Migration from "@backend/lib/migrations/simulations/to-v15.js"
+
+describe("Migration apply", () => {
+  const createSimulation = (allAnswers, currentAnswers) => ({
+    answers: { all: allAnswers, current: currentAnswers },
+  })
+
+  it("transform both all and current answers correctly when activite is service_civique", () => {
+    const simulation = createSimulation(
+      [
+        { id: "demandeur", fieldName: "activite", value: "service_civique" },
+        { id: "demandeur", fieldName: "handicap", value: false },
+      ],
+      [
+        { id: "demandeur", fieldName: "activite", value: "service_civique" },
+        { id: "demandeur", fieldName: "handicap", value: false },
+      ]
+    )
+
+    const expectedAnswers = {
+      all: [
+        { id: "demandeur", fieldName: "activite", value: "inactif" },
+        {
+          entityName: "individu",
+          fieldName: "service_civique",
+          id: "demandeur",
+          value: true,
+        },
+        { id: "demandeur", fieldName: "handicap", value: false },
+      ],
+      current: [
+        { id: "demandeur", fieldName: "activite", value: "inactif" },
+        {
+          entityName: "individu",
+          fieldName: "service_civique",
+          id: "demandeur",
+          value: true,
+        },
+        { id: "demandeur", fieldName: "handicap", value: false },
+      ],
+    }
+
+    const result = Migration.apply(simulation)
+
+    expect(result.answers.all).toEqual(expectedAnswers.all)
+    expect(result.answers.current).toEqual(expectedAnswers.current)
+  })
+
+  it("do not modify answers if activite is not service_civique", () => {
+    const simulation = createSimulation(
+      [
+        { id: "demandeur", fieldName: "activite", value: "other_activity" },
+        { id: "demandeur", fieldName: "handicap", value: false },
+      ],
+      [
+        { id: "demandeur", fieldName: "activite", value: "other_activity" },
+        { id: "demandeur", fieldName: "handicap", value: false },
+      ]
+    )
+
+    const expectedAnswers = {
+      all: [
+        { id: "demandeur", fieldName: "activite", value: "other_activity" },
+        {
+          entityName: "individu",
+          fieldName: "service_civique",
+          id: "demandeur",
+          value: false,
+        },
+        { id: "demandeur", fieldName: "handicap", value: false },
+      ],
+      current: [
+        { id: "demandeur", fieldName: "activite", value: "other_activity" },
+        {
+          entityName: "individu",
+          fieldName: "service_civique",
+          id: "demandeur",
+          value: false,
+        },
+        { id: "demandeur", fieldName: "handicap", value: false },
+      ],
+    }
+
+    const result = Migration.apply(simulation)
+
+    expect(result.answers.all).toEqual(expectedAnswers.all)
+    expect(result.answers.current).toEqual(expectedAnswers.current)
+  })
+})

--- a/tests/unit/backend/migration-to-v15.spec.ts
+++ b/tests/unit/backend/migration-to-v15.spec.ts
@@ -5,6 +5,7 @@ import Migration from "@backend/lib/migrations/simulations/to-v15.js"
 describe("Migration apply", () => {
   const createSimulation = (allAnswers, currentAnswers) => ({
     answers: { all: allAnswers, current: currentAnswers },
+    dateDeValeur: new Date("2023-01-01"),
   })
 
   it("transform both all and current answers correctly when activite is service_civique", () => {
@@ -48,44 +49,83 @@ describe("Migration apply", () => {
     expect(result.answers.current).toEqual(expectedAnswers.current)
   })
 
-  it("do not modify answers if activite is not service_civique", () => {
-    const simulation = createSimulation(
-      [
-        { id: "demandeur", fieldName: "activite", value: "other_activity" },
-        { id: "demandeur", fieldName: "handicap", value: false },
-      ],
-      [
-        { id: "demandeur", fieldName: "activite", value: "other_activity" },
-        { id: "demandeur", fieldName: "handicap", value: false },
-      ]
-    )
+  describe("when activite is not service_civique", () => {
+    it("do not modify answers when age > 31", () => {
+      const simulation = createSimulation(
+        [
+          { id: "demandeur", fieldName: "age", value: 35 },
+          { id: "demandeur", fieldName: "activite", value: "other_activity" },
+          { id: "demandeur", fieldName: "handicap", value: false },
+        ],
+        [
+          { id: "demandeur", fieldName: "age", value: 35 },
+          { id: "demandeur", fieldName: "activite", value: "other_activity" },
+          { id: "demandeur", fieldName: "handicap", value: false },
+        ]
+      )
 
-    const expectedAnswers = {
-      all: [
-        { id: "demandeur", fieldName: "activite", value: "other_activity" },
-        {
-          entityName: "individu",
-          fieldName: "service_civique",
-          id: "demandeur",
-          value: false,
-        },
-        { id: "demandeur", fieldName: "handicap", value: false },
-      ],
-      current: [
-        { id: "demandeur", fieldName: "activite", value: "other_activity" },
-        {
-          entityName: "individu",
-          fieldName: "service_civique",
-          id: "demandeur",
-          value: false,
-        },
-        { id: "demandeur", fieldName: "handicap", value: false },
-      ],
-    }
+      const expectedAnswers = {
+        all: [
+          { id: "demandeur", fieldName: "age", value: 35 },
+          { id: "demandeur", fieldName: "activite", value: "other_activity" },
+          { id: "demandeur", fieldName: "handicap", value: false },
+        ],
+        current: [
+          { id: "demandeur", fieldName: "age", value: 35 },
+          { id: "demandeur", fieldName: "activite", value: "other_activity" },
+          { id: "demandeur", fieldName: "handicap", value: false },
+        ],
+      }
 
-    const result = Migration.apply(simulation)
+      const result = Migration.apply(simulation)
 
-    expect(result.answers.all).toEqual(expectedAnswers.all)
-    expect(result.answers.current).toEqual(expectedAnswers.current)
+      expect(result.answers.all).toEqual(expectedAnswers.all)
+      expect(result.answers.current).toEqual(expectedAnswers.current)
+    })
+
+    it("add service_civique (false) answer when age < 31", () => {
+      const simulation = createSimulation(
+        [
+          { id: "demandeur", fieldName: "date_naissance", value: "2000-01-01" },
+          { id: "demandeur", fieldName: "activite", value: "other_activity" },
+          { id: "demandeur", fieldName: "handicap", value: false },
+        ],
+        [
+          { id: "demandeur", fieldName: "date_naissance", value: "2000-01-01" },
+          { id: "demandeur", fieldName: "activite", value: "other_activity" },
+          { id: "demandeur", fieldName: "handicap", value: false },
+        ]
+      )
+
+      const expectedAnswers = {
+        all: [
+          { id: "demandeur", fieldName: "date_naissance", value: "2000-01-01" },
+          { id: "demandeur", fieldName: "activite", value: "other_activity" },
+          {
+            entityName: "individu",
+            fieldName: "service_civique",
+            id: "demandeur",
+            value: false,
+          },
+          { id: "demandeur", fieldName: "handicap", value: false },
+        ],
+        current: [
+          { id: "demandeur", fieldName: "date_naissance", value: "2000-01-01" },
+          { id: "demandeur", fieldName: "activite", value: "other_activity" },
+          {
+            entityName: "individu",
+            fieldName: "service_civique",
+            id: "demandeur",
+            value: false,
+          },
+          { id: "demandeur", fieldName: "handicap", value: false },
+        ],
+      }
+
+      const result = Migration.apply(simulation)
+
+      expect(result.answers.all).toEqual(expectedAnswers.all)
+      expect(result.answers.current).toEqual(expectedAnswers.current)
+    })
   })
 })


### PR DESCRIPTION
Ticket: https://trello.com/c/ZG1lCz22/1372-rendre-service-civique-orthogonal-%C3%A0-activit%C3%A9

- [x] Enlever `service_civique` des choix de la question `activite`
- [x] Ajouter une question boolean `service_civique`
- [x] Modifier la connexion à openfisca et au aides javascript pour la notion de `service_civique`
- [x] Fix des tests d'integration
- [x] Migration de la donnée

⚠️ feat: Changement des logiques d'activité 

- Être en service civique n'envoi plus aux moteurs le fait d'être actif, les
autres types d'activité peuvent l'envoyer (Salarié, Indépendant)
- On affiche la question sur l'inaptitude au travail avant le fait d'être en service civique
donc ça n'influe plus sur cette question
- La question sur les heures de travail pour le RSA n'est plus affiché pour les personnes en 
service civique (https://www.service-public.fr/particuliers/vosdroits/F13866#:~:text=de%20service%20civique.-,Service%20civique,la%20fin%20du%20service%20civique)