### PR TITLE
Hotfix directive analytic

### DIFF
--- a/src/components/benefit-cta-link.vue
+++ b/src/components/benefit-cta-link.vue
@@ -6,9 +6,12 @@ import { useRouter } from "vue-router"
 import { StandardBenefit } from "@data/types/benefits.d.js"
 import { CTALabel } from "@lib/enums/cta.js"
 import { EventCategory } from "@lib/enums/event"
+import { useBenefits } from "@/composables/use-benefits.js"
 
 const store = useStore()
 const $router = useRouter()
+
+const { benefits } = useBenefits()
 
 const labels = {
   teleservice: {
@@ -77,6 +80,7 @@ const onClick = () => {
       name: analyticsName,
       action: type,
       category: EventCategory.General,
+      benefits: benefits,
     }"
     :aria-label="longLabel"
     :href="getURL(link)"

--- a/src/components/benefit-cta.vue
+++ b/src/components/benefit-cta.vue
@@ -4,10 +4,13 @@ import { CTALabel } from "@lib/enums/cta.js"
 import { EventAction, EventCategory } from "@lib/enums/event.js"
 import { StandardBenefit } from "@data/types/benefits.d.js"
 import { defineProps, computed, PropType } from "vue"
+import { useBenefits } from "@/composables/use-benefits"
 
 const props = defineProps({
   benefit: Object as PropType<StandardBenefit>,
 })
+
+const { benefits } = useBenefits()
 
 const ctaForm = computed(() => {
   return ctas.value.find((cta) => cta?.type === CTALabel.Form)
@@ -103,9 +106,10 @@ const ctas = computed(() => {
       <a
         v-if="benefit.msa"
         v-analytics="{
-          name: benefit.label,
+          name: benefit.id,
           action: EventAction.Msa,
           category: EventCategory.General,
+          benefits: benefits,
         }"
         class="aj-droit-pro-agricole"
         href="https://www.msa.fr/lfy/espace-prive"

--- a/src/composables/use-benefits.ts
+++ b/src/composables/use-benefits.ts
@@ -1,0 +1,15 @@
+import { ref } from "vue"
+import { useStore } from "@/stores/index.js"
+import { StandardBenefit } from "@data/types/benefits"
+
+export function useBenefits() {
+  const store = useStore()
+
+  const benefits = ref<StandardBenefit[]>(
+    store.calculs?.resultats?.droitsEligibles || []
+  )
+
+  return {
+    benefits,
+  }
+}

--- a/src/directives/analytics.ts
+++ b/src/directives/analytics.ts
@@ -12,7 +12,7 @@ const AnalyticsDirective = {
   beforeMount(el, binding) {
     el.myAnalyticsHandler = () => {
       const recorderEvent: RecorderEvent = {
-        benefits: binding?.instance?.droits,
+        benefits: binding.value.benefits || binding?.instance?.droits,
         benefitId: binding.value.name,
         eventAction: binding.value.action,
       }


### PR DESCRIPTION
## Constat : 
- Pour les liens CTA on n'envoi plus de data au recorder
- Cela est dû au fait que la directive analytic n'a pas toujours accès à `binding?.instance?.droits` qui était mis à disposition **implicitement** par le mixin `ResultatsMixin`
- Cela date probablement du passage de certains composant de l'option API à la composition API où le mixin a été enlevé

## Todo court terme : 
- Faire en sort de pouvoir passer explicitement les benefits pour le recorder
- Tester les différents liens CTA 
- Comprendre quels actions ne sont plus disponible dans le code mais affiché quand même dans la page `/behaviour` de MesAidesAnalytic

## Todo long term : 
- voir si on ne peut pas simplifier la logique de la directive analytic et expliciter ce qui est envoyer à l'utilisation de la directive ou bien de `sendEventsToRecorder`
- Trouver un moyen de se rendre compte plus rapidement des soucis
