### PR TITLE
fix: Ajoute la fonction `next` pour passer à la fonction suivante

### DIFF
--- a/tools/mjml.ts
+++ b/tools/mjml.ts
@@ -75,6 +75,7 @@ app.route("/mjml/:id/:type").get(
         }
 
         req.followup = followup
+        next()
       })
   },
   function (req, res) {


### PR DESCRIPTION
Bug depuis cette PR https://github.com/betagouv/aides-jeunes/pull/3929