### PR TITLE
Ajoute anonymisation du numéro de téléphone dans le script d'anonymisation des followups

### DIFF
--- a/lib/cleaner-functions.ts
+++ b/lib/cleaner-functions.ts
@@ -90,7 +90,7 @@ export function anonymizeSimulation(simulation) {
 
 export function anonymizeFollowup(followup) {
   followup.email = undefined
+  followup.phone = undefined
   followup.error = undefined
-
   return followup
 }

--- a/tools/cleaner.ts
+++ b/tools/cleaner.ts
@@ -17,7 +17,7 @@ async function main() {
   let followup_count = 0
   const followupsCursor = await Followups.find({
     createdAt: { $lt: aMonthAgo },
-    email: { $exists: true },
+    $or: [{ email: { $exists: true } }, { phone: { $exists: true } }],
   })
     .sort({ _id: -1 })
     .cursor()


### PR DESCRIPTION
Cette PR ajoute l'anonymisation du numéro de téléphone dans le script d'anonymisation des followups.

[Tâche associée](https://trello.com/c/UbgB1w4e/1487-int%C3%A9grer-le-num%C3%A9ro-de-t%C3%A9l%C3%A9phone-au-script-danonymisation-des-followups)