### PR TITLE
Simplification Store

### DIFF
--- a/lib/answers.ts
+++ b/lib/answers.ts
@@ -43,38 +43,18 @@ export function nullifyUndefinedValue(value) {
   return value === undefined ? null : value
 }
 
-export function storeAnswer(answers, newAnswer, enfants?) {
+export function storeAnswer(answers: Answer[], newAnswer: Answer): Answer[] {
   const existingAnswerIndex = answers.findIndex(
     (answer) =>
       answer.id === newAnswer.id &&
       answer.entityName === newAnswer.entityName &&
       answer.fieldName === newAnswer.fieldName
   )
-  let results
-  if (existingAnswerIndex === -1) {
-    results = [...answers, newAnswer]
-  } else {
-    const answer = answers[existingAnswerIndex]
-    answer.value = newAnswer.value
-    if (enfants) {
-      // Keep all answers related to children because they are not on the same path
-      const allowedAnswered = enfants
-        ? enfants
-            .map((enfant) => `enfant_${enfant}`)
-            .filter((id) => id !== newAnswer.id)
-        : []
-      results = answers.slice(0, existingAnswerIndex + 1)
-      results = results.concat(
-        answers.filter(
-          (answer) =>
-            allowedAnswered.includes(answer.id) &&
-            results.find((result) => result.id !== answer.id)
-        )
-      )
-    } else {
-      results = [...answers]
-    }
-  }
 
-  return results
+  if (existingAnswerIndex === -1) {
+    return [...answers, newAnswer]
+  } else {
+    answers[existingAnswerIndex].value = newAnswer.value
+    return [...answers]
+  }
 }

--- a/lib/answers.ts
+++ b/lib/answers.ts
@@ -17,27 +17,6 @@ export const getAnswer = (answers: Answer[], entity, variable?, id?) => {
   return answer ? answer.value : undefined
 }
 
-export const getAnswerIndex = (
-  answers: Answer[],
-  entityName,
-  id,
-  fieldName
-) => {
-  return answers.findIndex((answer) => {
-    if (entityName && id && fieldName) {
-      return (
-        answer.entityName === entityName &&
-        answer.id === id &&
-        answer.fieldName === fieldName
-      )
-    } else if (entityName && id) {
-      return answer.entityName === entityName && answer.id === id
-    } else if (entityName) {
-      return answer.entityName === entityName
-    }
-  })
-}
-
 // Nécessaire si la question est optionnelle
 export function nullifyUndefinedValue(value) {
   return value === undefined ? null : value

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -264,11 +264,6 @@ export const useStore = defineStore("store", {
       this.simulation.answers = {
         ...this.simulation.answers,
         all: storeAnswer(this.simulation.answers.all, answer),
-        current: storeAnswer(
-          this.simulation.answers.current,
-          answer,
-          this.simulation.enfants
-        ),
       }
     },
     updateCurrentAnswers(newPath: string | undefined) {
@@ -347,22 +342,12 @@ export const useStore = defineStore("store", {
         path: `/simulation/individu/enfant_${enfantId}/_firstName`,
       }
 
-      // When you add a children you need to remove all current answer after the child validation
-      const currentLastIndex = this.simulation.answers.current.findIndex(
-        (answer) => answer.entityName === "enfants"
-      )
-
-      const currentAnswers =
-        currentLastIndex === -1
-          ? this.simulation.answers.current
-          : this.simulation.answers.current.splice(0, currentLastIndex)
-
       this.simulation = {
         ...this.simulation,
         enfants,
         answers: {
+          ...this.simulation.answers,
           all: storeAnswer(this.simulation.answers.all, answer),
-          current: storeAnswer(currentAnswers, answer, this.simulation.enfants),
         },
       }
       this.setDirty()

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -266,28 +266,28 @@ export const useStore = defineStore("store", {
         all: storeAnswer(this.simulation.answers.all, answer),
       }
     },
-    updateCurrentAnswers(newPath: string | undefined) {
+    updateCurrentAnswers(newPath: string) {
       const steps = this.getAllSteps
-      const currentAnswers: any = []
-      let i = 0
-      let currentStep = steps[0]
-      while (currentStep && currentStep.path !== newPath) {
-        if (currentStep.isActive && currentStep.path !== "/") {
-          const currentAnswer = this.simulation.answers.all.find((answer) => {
-            return (
-              answer.id === currentStep.id &&
-              answer.entityName === currentStep.entity &&
-              answer.fieldName === currentStep.variable
-            )
-          })
+      const currentAnswers: Answer[] = []
 
+      for (const step of steps) {
+        if (step.path === newPath) {
+          break
+        }
+
+        if (step.isActive && step.path !== "/") {
+          const currentAnswer: Answer = this.simulation.answers.all.find(
+            (answer: Answer) =>
+              answer.id === step.id &&
+              answer.entityName === step.entity &&
+              answer.fieldName === step.variable
+          )
           if (currentAnswer) {
             currentAnswers.push(currentAnswer)
           }
         }
-        i = i + 1
-        currentStep = steps[i]
       }
+
       this.simulation.answers.current = currentAnswers
     },
     ressourcesFiscales(ressourcesFiscales: any) {

--- a/tests/unit/answer.spec.ts
+++ b/tests/unit/answer.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from "@jest/globals"
 import { createPinia, setActivePinia } from "pinia"
 import { useStore } from "@root/src/stores/index.js"
-import { getAnswerIndex } from "@lib/answers.js"
 import { Answer } from "@lib/types/store.d.js"
 import { SimulationStatus } from "@lib/enums/simulation.js"
 import { Activite } from "@lib/enums/activite.js"
@@ -118,39 +117,5 @@ describe("Answers tests", () => {
     } as unknown as Answer
     store.answer(newAnswer)
     expect(store.calculs.dirty).toEqual(true)
-  })
-
-  // Answer tests
-  it("Get answer index", () => {
-    const store = initStore()
-    const answer = store.simulation.answers.all[2]
-
-    const answerIndex = getAnswerIndex(
-      store.simulation.answers.all,
-      answer.entityName,
-      answer.id,
-      answer.fieldName
-    )
-    expect(answerIndex).toStrictEqual(2)
-
-    const firstAnswer = store.simulation.answers.all[0]
-    const firstAnswerIndex = getAnswerIndex(
-      store.simulation.answers.all,
-      firstAnswer.entityName,
-      firstAnswer.id,
-      firstAnswer.fieldName
-    )
-    expect(firstAnswerIndex).toEqual(0)
-  })
-  it("Wrong answer should give an not found index (-1)", () => {
-    const store = initStore()
-    const answer = store.simulation.answers.all[1]
-    const answerIndex = getAnswerIndex(
-      store.simulation.answers.all,
-      "wrong entity name",
-      answer.id,
-      answer.fieldName
-    )
-    expect(answerIndex).toEqual(-1)
   })
 })


### PR DESCRIPTION
# Contexte : 
Dans chaque composant de question on fait appel à 
- `store.answer` pour stocker la question (ex [ici](https://github.com/betagouv/aides-jeunes/blob/7960061400269fde4c136b01d62b17519097add8/src/views/simulation/mutualized-step.vue#L180))
- `$push` pour passer au composant suivant (ex [ici](https://github.com/betagouv/aides-jeunes/blob/7960061400269fde4c136b01d62b17519097add8/src/views/simulation/mutualized-step.vue#L187))

Dans `store.answer` on append ou modifie la question de `simulation.answer.all` et dans `simulation.answer.current` (avec un peu plus de logique pour current, lié à la variable `enfants`) ([ici](https://github.com/betagouv/aides-jeunes/blob/f2f0e815587990a5b9ed074ad59fe5a1830c9a6f/src/stores/index.ts#L266-L271))

Cependant dans le `$push` du state-service on fait appel à `store.updateCurrentAnswers` ([ici](https://github.com/betagouv/aides-jeunes/blob/a4c099f2a30cfdf390ad7c531bc581e5e4af13cb/src/plugins/state-service.ts#L18)) qui reconstruit current (en l'overidant) à partir des steps actuelles et surtout sans se baser sur current. ([ici](https://github.com/betagouv/aides-jeunes/blob/f2f0e815587990a5b9ed074ad59fe5a1830c9a6f/src/stores/index.ts#L296))

⚠️ Afin de calculer les steps, on a besoin de la situation, **mais le point d'attention à avoir** c'est que le calcul de la situation à cet endroit ci se base sur `answers.all` et non sur `answers.current` (cf [ici](https://github.com/betagouv/aides-jeunes/blob/2af9dcd4790f1faad1f31d165347a0b45ff9f1ce/src/stores/index.ts#L230))

# Constat
➜ le fait de remplir current dans `store.answer` ne sert plus a rien car overridé directement : on peut supprimer cette logique et la logique compliquée liés à `enfant` (dans la fonction `storeAnswer`)


# Next steps 
dans une prochaines PR : 
- TBD