### PR TITLE
1492 utiliser exclusivement des donnees matomo

### DIFF
--- a/backend/lib/stats/piwik.ts
+++ b/backend/lib/stats/piwik.ts
@@ -7,6 +7,7 @@ interface PiwikParameters {
   period: string
   date: string
   method?: string
+  flat?: string
 }
 
 const baseParams = {


### PR DESCRIPTION
Ticket: https://trello.com/c/fLgK2DC3/1492-utiliser-exclusivement-des-donn%C3%A9es-matomo-dans-le-premier-tunnel-de-conversion

Avec la [PR sur mes-aides-analytics](https://github.com/betagouv/mes-aides-analytics/pull/151) voici le résultat (Octobre)
<img width="478" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/4059803/bc5e6bdf-f3d1-4dc1-8025-a3142a701c68">
