### PR TITLE
fix: Utilise `id` à la place de `slug`

### DIFF
--- a/src/components/droits-details.vue
+++ b/src/components/droits-details.vue
@@ -185,7 +185,7 @@ export default {
   },
   computed: {
     sharingLinkUrl() {
-      return `${process.env.VITE_BASE_URL}/aides/${this.droit.slug}`
+      return `${process.env.VITE_BASE_URL}/aides/${this.droit.id}`
     },
     sharingLinkByEmailSubject() {
       return `${process.env.VITE_CONTEXT_NAME} - ${this.droit.label} `


### PR DESCRIPTION
Note:
- dans les aides vélo et certaines aides javascript slug n'est pas défini
- quand il est défini il est égal à `id`
- les benefit sont cherché par rapport à leur id (https://github.com/betagouv/aides-jeunes/blob/fd03119d8384d72bf6f6b2ffdda827b77e1596dc/src/lib/benefits.ts#L4)