### PR TITLE
Fix sélection de l'input au clic

### DIFF
--- a/src/views/simulation/mutualized-step.vue
+++ b/src/views/simulation/mutualized-step.vue
@@ -63,11 +63,11 @@
                   v-else-if="questionType === 'text'"
                   :id="fieldName"
                   v-model="value"
+                  v-select-on-click
                   aria-labelledby="step-question"
                   :data-testid="fieldName"
                   type="text"
                   class="fr-input"
-                  @click="selectText"
                 />
                 <YesNoQuestion v-else v-model="value"></YesNoQuestion>
               </div>
@@ -171,12 +171,6 @@ export default {
     },
   },
   methods: {
-    selectText() {
-      const inputElement = document.getElementById(this.fieldName)
-      if (inputElement instanceof HTMLInputElement) {
-        inputElement.select()
-      }
-    },
     onInputError(hasError) {
       this.inputError = hasError
     },

--- a/src/views/simulation/mutualized-step.vue
+++ b/src/views/simulation/mutualized-step.vue
@@ -67,6 +67,7 @@
                   :data-testid="fieldName"
                   type="text"
                   class="fr-input"
+                  @click="selectText"
                 />
                 <YesNoQuestion v-else v-model="value"></YesNoQuestion>
               </div>
@@ -170,6 +171,12 @@ export default {
     },
   },
   methods: {
+    selectText() {
+      const inputElement = document.getElementById(this.fieldName)
+      if (inputElement instanceof HTMLInputElement) {
+        inputElement.select()
+      }
+    },
     onInputError(hasError) {
       this.inputError = hasError
     },


### PR DESCRIPTION
Pour entrer le nom/prénom, c'est plus user friendly si une sélection est appliquée au clic dans l'input.

Réutilisation d'une directive custom.