### PR TITLE
Limite le scroll au nécessaire pour voir la question suivante

### DIFF
--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -5,7 +5,7 @@
       class="fr-grid-row"
     >
       <div class="fr-col-12 fr-col-md-6 fr-col-lg-6">
-        <h1 id="aj-title" class="fr-my-0 fr-mx-0">{{ title }}</h1>
+        <h1 class="fr-my-0 fr-mx-0">{{ title }}</h1>
       </div>
       <div class="fr-col-12 fr-col-md-6 fr-col-lg-6">
         <ul
@@ -22,7 +22,7 @@
     </div>
     <div v-else class="fr-grid-row">
       <div class="fr-col-12 fr-col-md-12 fr-col-lg-12">
-        <h1 id="aj-title" class="fr-my-0 fr-mx-0">{{ title }}</h1>
+        <h1 class="fr-my-0 fr-mx-0">{{ title }}</h1>
       </div>
     </div>
   </div>

--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -5,7 +5,7 @@
       class="fr-grid-row"
     >
       <div class="fr-col-12 fr-col-md-6 fr-col-lg-6">
-        <h1 class="fr-my-0 fr-mx-0">{{ title }}</h1>
+        <h1 id="aj-title" class="fr-my-0 fr-mx-0">{{ title }}</h1>
       </div>
       <div class="fr-col-12 fr-col-md-6 fr-col-lg-6">
         <ul
@@ -22,7 +22,7 @@
     </div>
     <div v-else class="fr-grid-row">
       <div class="fr-col-12 fr-col-md-12 fr-col-lg-12">
-        <h1 class="fr-my-0 fr-mx-0">{{ title }}</h1>
+        <h1 id="aj-title" class="fr-my-0 fr-mx-0">{{ title }}</h1>
       </div>
     </div>
   </div>

--- a/src/lib/transition.ts
+++ b/src/lib/transition.ts
@@ -1,13 +1,3 @@
-export function showTitleWithMinimumScrolling() {
-  const header = document.querySelector("h1")
-  console.log(header)
-  header?.scrollIntoView({
-    behavior: "smooth",
-    block: "nearest",
-    inline: "nearest",
-  })
-}
-
 export function getTitleFromRoute(route) {
   let meta
   for (let index = route.matched.length - 1; index >= 0; index -= 1) {

--- a/src/lib/transition.ts
+++ b/src/lib/transition.ts
@@ -1,12 +1,11 @@
 export function showTitleWithMinimumScrolling() {
-  const headers = document.getElementsByTagName("h1")
-  if (headers.length) {
-    headers[0].scrollIntoView({
-      behavior: "smooth",
-      block: "nearest",
-      inline: "nearest",
-    })
-  }
+  const header = document.querySelector("h1")
+  console.log(header)
+  header?.scrollIntoView({
+    behavior: "smooth",
+    block: "nearest",
+    inline: "nearest",
+  })
 }
 
 export function getTitleFromRoute(route) {

--- a/src/lib/transition.ts
+++ b/src/lib/transition.ts
@@ -1,0 +1,24 @@
+export function showTitleWithMinimumScrolling() {
+  const headers = document.getElementsByTagName("h1")
+  if (headers.length) {
+    headers[0].scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "nearest",
+    })
+  }
+}
+
+export function getTitleFromRoute(route) {
+  let meta
+  for (let index = route.matched.length - 1; index >= 0; index -= 1) {
+    meta = route.matched[index].meta
+    if (meta.headTitle) {
+      if (typeof meta.headTitle === "function") {
+        return meta.headTitle(route.params)
+      }
+      return meta.headTitle
+    }
+  }
+  return process.env.VITE_TITLE
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,6 +2,10 @@ import { nextTick } from "vue"
 import { createWebHistory, createRouter } from "vue-router"
 import context from "./context/index.js"
 import Simulations from "@/lib/simulation.js"
+import {
+  getTitleFromRoute,
+  showTitleWithMinimumScrolling,
+} from "@/lib/transition.js"
 import { useStore } from "@/stores/index.js"
 import ABTestingService from "@/plugins/ab-testing-service.js"
 
@@ -324,33 +328,13 @@ router.beforeEach((to, from, next) => {
   next()
 })
 
-function getTitleMeta(route) {
-  let meta
-  for (let index = route.matched.length - 1; index >= 0; index -= 1) {
-    meta = route.matched[index].meta
-    if (meta.headTitle) {
-      if (typeof meta.headTitle === "function") {
-        return meta.headTitle(route.params)
-      }
-      return meta.headTitle
-    }
-  }
-  return process.env.VITE_TITLE
-}
-
 router.afterEach((to) => {
   if (!to.hash) {
-    const headers = document.getElementsByTagName("h1")
-    if (headers.length) {
-      headers[0].scrollIntoView({
-        behavior: "smooth",
-        block: "nearest",
-        inline: "nearest",
-      })
-    }
+    // Managed in scrollBehavior to avoid reimplementing scrollToPosition
+    showTitleWithMinimumScrolling()
   }
   nextTick(function () {
-    document.title = getTitleMeta(to)
+    document.title = getTitleFromRoute(to)
   })
 })
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,10 +2,7 @@ import { nextTick } from "vue"
 import { createWebHistory, createRouter } from "vue-router"
 import context from "./context/index.js"
 import Simulations from "@/lib/simulation.js"
-import {
-  getTitleFromRoute,
-  showTitleWithMinimumScrolling,
-} from "@/lib/transition.js"
+import { getTitleFromRoute } from "@/lib/transition.js"
 import { useStore } from "@/stores/index.js"
 import ABTestingService from "@/plugins/ab-testing-service.js"
 
@@ -277,8 +274,16 @@ const router = createRouter({
         el: to.hash,
         behavior: "smooth",
       }
+    } else {
+      const header = document.querySelector("h1")
+
+      return {
+        el: header,
+        behavior: "smooth",
+        block: "nearest",
+        inline: "nearest",
+      }
     }
-    return false
   },
 })
 
@@ -330,10 +335,6 @@ router.beforeEach((to, from, next) => {
 
 router.afterEach((to) => {
   nextTick(function () {
-    if (!to.hash) {
-      // Managed in scrollBehavior to avoid reimplementing scrollToPosition
-      showTitleWithMinimumScrolling()
-    }
     document.title = getTitleFromRoute(to)
   })
 })

--- a/src/router.ts
+++ b/src/router.ts
@@ -274,7 +274,7 @@ const router = createRouter({
         behavior: "smooth",
       }
     }
-    return { left: 0, top: 0 }
+    return false
   },
 })
 
@@ -339,6 +339,16 @@ function getTitleMeta(route) {
 }
 
 router.afterEach((to) => {
+  if (!to.hash) {
+    const el = document.getElementById("aj-title")
+    if (el) {
+      el.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+        inline: "nearest",
+      })
+    }
+  }
   nextTick(function () {
     document.title = getTitleMeta(to)
   })

--- a/src/router.ts
+++ b/src/router.ts
@@ -340,9 +340,9 @@ function getTitleMeta(route) {
 
 router.afterEach((to) => {
   if (!to.hash) {
-    const el = document.getElementById("aj-title")
-    if (el) {
-      el.scrollIntoView({
+    const headers = document.getElementsByTagName("h1")
+    if (headers.length) {
+      headers[0].scrollIntoView({
         behavior: "smooth",
         block: "nearest",
         inline: "nearest",

--- a/src/router.ts
+++ b/src/router.ts
@@ -329,11 +329,11 @@ router.beforeEach((to, from, next) => {
 })
 
 router.afterEach((to) => {
-  if (!to.hash) {
-    // Managed in scrollBehavior to avoid reimplementing scrollToPosition
-    showTitleWithMinimumScrolling()
-  }
   nextTick(function () {
+    if (!to.hash) {
+      // Managed in scrollBehavior to avoid reimplementing scrollToPosition
+      showTitleWithMinimumScrolling()
+    }
     document.title = getTitleFromRoute(to)
   })
 })


### PR DESCRIPTION
J'ai préféré afficher le titre du chapitre plutôt qu'uniquement la question mais ça peut être la question via par exemple, `#step-question`.

J'ai aussi préféré d'avoir deux endroits pour gérer les scrolls pour éviter de réimplémenter [`scrollToPosition`](https://github.com/vuejs/router/blob/main/packages/router/src/router.ts#L1177) qui n'est pas exporté de la dépendance (selon ma tentative).