### PR TITLE
Refactor email sms demo baptiste

### DIFF
--- a/backend/controllers/emails.ts
+++ b/backend/controllers/emails.ts
@@ -1,5 +1,8 @@
 import { EmailCategory } from "../../lib/enums/messaging.js"
-import emailRender from "../../backend/lib/mes-aides/emails/email-render.js"
+import {
+  emailRender,
+  renderSurveyEmail,
+} from "../../backend/lib/mes-aides/emails/email-render.js"
 import { SurveyCategory } from "../../lib/enums/survey.js"
 
 const renderFollowupEmailByType = async (
@@ -21,7 +24,7 @@ const renderFollowupEmailByType = async (
       throw new Error(`Unknown email type: ${emailType}`)
   }
 
-  return followup.renderSurveyEmail(surveyType)
+  return renderSurveyEmail(surveyType, followup)
 }
 
 const getFollowupEmail = async (req, res, next) => {

--- a/backend/lib/mes-aides/emails/email-render.ts
+++ b/backend/lib/mes-aides/emails/email-render.ts
@@ -8,6 +8,8 @@ import openfiscaController from "../../openfisca/parameters.js"
 import { formatBenefits, basicBenefitText } from "./simulation-results.js"
 import { mjml } from "./index.js"
 import { EmailCategory } from "../../../../lib/enums/messaging.js"
+import { SurveyCategory } from "../../../../lib/enums/survey.js"
+import { Followup } from "@lib/types/followup.js"
 
 const __dirname = new URL(".", import.meta.url).pathname
 
@@ -90,7 +92,7 @@ function renderAsHtml(emailType: EmailCategory, dataTemplate) {
     })
 }
 
-export default async function emailRender(emailType: EmailCategory, followup) {
+export async function emailRender(emailType: EmailCategory, followup) {
   let benefits: any = null
   let parameters: any = null
   let formatedBenefits: any = {}
@@ -149,6 +151,32 @@ export default async function emailRender(emailType: EmailCategory, followup) {
         text: values[0],
         html: values[1].html,
       }
+    } else {
+      throw new Error(`Unknown email type: ${emailType}`)
     }
   })
+}
+
+export function renderSurveyEmail(
+  surveyType: SurveyCategory,
+  followup: Followup
+) {
+  switch (surveyType) {
+    case SurveyCategory.TrackClickOnBenefitActionEmail:
+      return emailRender(EmailCategory.BenefitAction, followup)
+    case SurveyCategory.TrackClickOnSimulationUsefulnessEmail:
+      return emailRender(EmailCategory.SimulationUsefulness, followup)
+    case SurveyCategory.TousABordNotification:
+      return emailRender(EmailCategory.TousABordNotification, followup)
+    case SurveyCategory.BenefitAction:
+      return Promise.reject(
+        new Error(
+          `This surveyType "${surveyType}" is not supposed to be sent through an email`
+        )
+      )
+    default:
+      return Promise.reject(
+        new Error(`This surveyType "${surveyType}" has no email template`)
+      )
+  }
 }

--- a/backend/lib/messaging/sending.ts
+++ b/backend/lib/messaging/sending.ts
@@ -4,6 +4,7 @@ import { EmailCategory } from "../../../lib/enums/messaging.js"
 import { SurveyCategory } from "../../../lib/enums/survey.js"
 import Followups from "../../models/followup.js"
 import { Followup } from "../../../lib/types/followup.js"
+import { sendSurvey } from "./email/email-service.js"
 
 const DaysBeforeInitialEmail = 6
 const DaysBeforeTousABordNotificationEmail = 2
@@ -52,7 +53,7 @@ async function sendMultipleInitialEmails(limit: number) {
           : SurveyCategory.TrackClickOnSimulationUsefulnessEmail
 
       try {
-        const result = await followup.sendSurvey(surveyType)
+        const result = await sendSurvey(surveyType, followup)
         return { ok: result._id }
       } catch (error) {
         return { ko: error }
@@ -91,8 +92,9 @@ async function sendMultipleTousABordNotificationEmails(limit: number) {
   const results = await Promise.all(
     followups.map(async (followup: Followup) => {
       try {
-        const result = await followup.sendSurvey(
-          SurveyCategory.TousABordNotification
+        const result = await sendSurvey(
+          SurveyCategory.TousABordNotification,
+          followup
         )
         return { ok: result._id }
       } catch (error) {
@@ -119,13 +121,15 @@ async function processSingleEmail(
       emailPromise = followup.sendSimulationResultsEmail()
       break
     case EmailCategory.BenefitAction:
-      emailPromise = followup.sendSurvey(
-        SurveyCategory.TrackClickOnBenefitActionEmail
+      emailPromise = sendSurvey(
+        SurveyCategory.TrackClickOnBenefitActionEmail,
+        followup
       )
       break
     case EmailCategory.SimulationUsefulness:
-      emailPromise = followup.sendSurvey(
-        SurveyCategory.TrackClickOnSimulationUsefulnessEmail
+      emailPromise = sendSurvey(
+        SurveyCategory.TrackClickOnSimulationUsefulnessEmail,
+        followup
       )
       break
     default:

--- a/lib/types/followup.d.ts
+++ b/lib/types/followup.d.ts
@@ -26,13 +26,10 @@ interface FollowupAttributes {
 
 interface FollowupMethods {
   postSimulationResultsSms(messageId: string): void
-  renderSimulationResultsEmail(): any
   renderSimulationResultsSms(): any
   sendSimulationResultsEmail(): Promise<void>
   sendSimulationResultsSms(): Promise<void>
-  renderSurveyEmail(surveyType: SurveyCategory): any
   addSurveyIfMissing(surveyType: SurveyCategory): Promise<any>
-  sendSurvey(surveyType: SurveyCategory): Promise<any>
   updateSurvey(action: SurveyCategory, data?: any)
 }
 

--- a/tools/mjml.ts
+++ b/tools/mjml.ts
@@ -8,7 +8,10 @@ import express from "express"
 import Followups from "../backend/models/followup.js"
 // To load the simulation model in mongoose
 import "../backend/models/simulation.js"
-import emailRender from "../backend/lib/mes-aides/emails/email-render.js"
+import {
+  emailRender,
+  renderSurveyEmail,
+} from "../backend/lib/mes-aides/emails/email-render.js"
 import { SurveyCategory } from "../lib/enums/survey.js"
 import { __express } from "ejs"
 import "../backend/lib/mongo-connector.js"
@@ -62,7 +65,7 @@ const followupRendering = async (req: Request) => {
 
   await followup.addSurveyIfMissing(surveyType)
   await followup.save()
-  return followup.renderSurveyEmail(surveyType)
+  return renderSurveyEmail(surveyType, followup)
 }
 
 app.route("/mjml/:id/:type").get(


### PR DESCRIPTION

C'est pour inspiration, et j'ai pas encore tout check, il reste du travail (dis moi si besoin de le faire) : 
Les points principaux : 
Mettre au même niveau d'abstraction l'envoi de resultat et de survey : Tout se passe dans `email-service` : 
C'est le service qui envoi les email et non plus le followup (qui faisait appel au service).

⚠️ je t'avais dit de ne pas faire une method de followup qui appelle un service qui appel une méthode de followup. Désormais comme le point d'entrée est le service.on peut utiliser des méthode de followup dedans (genre `addSurveyIfMissing`)

Tout la logique de render est dans `email-render maintenant`

⚠️ Je n'ai rien touché pour les SMS

Ça va p.e. trop loin dis moi. Mon plus gros soucis avec le code en prod actuel c'est (comme ça tu as des insight en plus :-) )
- On a créé trop de méthode pour envoyer un email, elles sont imbriqué a plusieurs niveau différents, et ce sont des méthodes du model followup (qui ne devrait pas savoir comment s'envoyer par email). 
- Si on veut créé plein de méthode pour découper le code, on peut c'est même recommander, mais il faut dans la mesure du possible qu'elles soient isolée et "privée", le seule but est la lecture facilité et pas la mise a disposition de feature sur le model followup