### PR TITLE
Désactive l'ab-testing sur l'email d'envoi du sondage

### DIFF
--- a/backend/lib/messaging/sending.ts
+++ b/backend/lib/messaging/sending.ts
@@ -50,13 +50,11 @@ async function sendMultipleInitialEmails(limit: number) {
 
   const results: { ok?: any; ko?: any }[] = await Promise.all(
     followups.map(async (followup: Followup) => {
-      const surveyType =
-        Math.random() > 0.5
-          ? SurveyType.TrackClickOnBenefitActionEmail
-          : SurveyType.TrackClickOnSimulationUsefulnessEmail
-
       try {
-        const survey = await sendSurveyEmail(followup, surveyType)
+        const survey = await sendSurveyEmail(
+          followup,
+          SurveyType.TrackClickOnSimulationUsefulnessEmail
+        )
         return { survey_id: survey._id }
       } catch (error) {
         return { ko: error }
@@ -117,9 +115,6 @@ async function processSingleEmail(emailType: EmailType, followupId: string) {
   switch (emailType) {
     case EmailType.SimulationResults:
       await sendSimulationResultsEmail(followup)
-      break
-    case EmailType.BenefitAction:
-      await sendSurveyEmail(followup, SurveyType.TrackClickOnBenefitActionEmail)
       break
     case EmailType.SimulationUsefulness:
       await sendSurveyEmail(

--- a/tools/email-sending-tool.ts
+++ b/tools/email-sending-tool.ts
@@ -26,7 +26,6 @@ const send_types = send.add_subparsers({
 // Single emails types parsers
 const singleEmailTypes = [
   EmailType.SimulationResults,
-  EmailType.BenefitAction,
   EmailType.SimulationUsefulness,
 ]
 singleEmailTypes.forEach((emailType) => {


### PR DESCRIPTION
### Pré-requis

https://github.com/betagouv/aides-jeunes/pull/4066 (refacto des services email/sms)

### Description 

L'AB testing sur l'envoi des emails de sondage est désactivé. 

Les reliquats du template supprimé (benefit-action) sont conservés pour le moment car les liens contenus dans les emails envoyés avant cette modification doivent pouvoir continuer à fonctionner.