### PR TITLE
Ajoute l'aide au permis du département des yvelines

### DIFF
--- a/backend/lib/openfisca/mapping/index.ts
+++ b/backend/lib/openfisca/mapping/index.ts
@@ -201,6 +201,12 @@ export function applyHeuristicsAndFix(testCase, sourceSituation) {
 
   const aCharge = demandeur.enfant_a_charge?.[periods.thisYear]
 
+  testCase.foyers_fiscaux._.nb_pac = {
+    [periods.fiscalYear]:
+      testCase.foyers_fiscaux._.declarants.length +
+      testCase.foyers_fiscaux._.personnes_a_charge.length,
+  }
+
   if (aCharge) {
     if (demandeur.bourse_criteres_sociaux_base_ressources_parentale) {
       testCase.foyers_fiscaux._.rbg = {

--- a/data/benefits/openfisca/yvelines_aide_permis.yml
+++ b/data/benefits/openfisca/yvelines_aide_permis.yml
@@ -1,0 +1,17 @@
+label: aide départementale au permis de conduire
+institution: departement_yvelines
+description: Le département des Yvelines aide les jeunes ayant de faibles revenus à obtenir le permis de conduire pour accéder à l’emploi et à la formation. Cette aide est accordée en contrepartie d’une contribution citoyenne.
+link: https://www.78-92.fr/annuaire/aides-et-services/detail/laide-au-financement-du-permis-de-conduire
+conditions:
+  - Être inscrit dans une auto-école.
+  - Être inscrit pour le passage d’un permis de conduire « classique » hors apprentissage anticipé de la conduite.
+voluntary_conditions:
+  - Effectuer entre 20 et 40 heures de contribution citoyenne bénévole au sein des services du Département ou dans une association yvelinoise (liste à retirer auprès du Secteur d’Action sociale de votre domicile).
+teleservice: https://www.78-92.fr/annuaire/aides-et-services/detail/laide-au-financement-du-permis-de-conduire#c1107
+prefix: l’
+type: float
+unit: "€"
+periodicite: ponctuelle
+entity: individus
+openfiscaPeriod: thisMonth
+interestFlag: _interetPermisDeConduire


### PR DESCRIPTION
## Description

Ajoute l'aide au permis des Yvelines.

~~Le revenu brut global étant bien demandé dans le simulateur, ce point soulevé en commentaire par @Allan-CodeWorks dans [la description de la tâche](https://trello.com/c/Qf8uitF6/1469-ajouter-laide-au-permis-de-conduire-du-d%C3%A9partement-des-yvelines) ne pose pas de problème pour ajouter cette aide.~~

## Pré-requis 

- https://github.com/openfisca/openfisca-france-local/pull/192 
     => Fix un problème de chemin d'un fichier xls.
- https://github.com/openfisca/openfisca-france-local/pull/186 
     => Modélisation de l'aide 

## Affichage de l'aide

C'est fonctionnel en local uniquement avec une version Openfisca modifiée prenant en compte les pré-requis listés dans la section précédente (nécessaire pour tester la PR). 

![image](https://github.com/betagouv/aides-jeunes/assets/18016058/7708bab8-ebeb-45d9-8d0c-e426cbb68ddc)
