### PR TITLE
hotfix: `currentPath` n'était plus défini

### DIFF
--- a/src/views/suivi.vue
+++ b/src/views/suivi.vue
@@ -242,7 +242,7 @@ const submit = async () => {
     StatisticsMixin.methods.sendEventToMatomo(
       EventCategory.Accompagnement,
       EventAction.AfficheLienAccompagnement,
-      currentPath.value
+      route.path
     )
   }
 }


### PR DESCRIPTION
<img width="1034" alt="image" src="https://github.com/betagouv/aides-jeunes/assets/4059803/2412d3dc-492b-4c50-8b7d-6121ea266e44">

https://sentry.incubateur.net/organizations/betagouv/issues/70081/?query=is%3Aunresolved+currentPath&referrer=issue-stream&statsPeriod=14d