### PR TITLE
Ajoute le pré-remplissage DS sur l'aide du FSL énergie du Var

### DIFF
--- a/backend/lib/teleservices/demarches-simplifiees.ts
+++ b/backend/lib/teleservices/demarches-simplifiees.ts
@@ -50,7 +50,6 @@ const sources = {
     const en_couple =
       getAnswer(simulation.answers.current, "famille", "en_couple") === true
 
-    console.log("en couple: ", en_couple)
     if (en_couple) {
       const statut_marital = getAnswer(
         simulation.answers.current,
@@ -58,7 +57,7 @@ const sources = {
         "statut_marital",
         "conjoint"
       )
-      console.log("statut_marital: ", statut_marital)
+
       // - Answer "en_couple" value "Union libre" is "celibataire" and needs to be restored as "Union libre" for the prefill
       // - Missing not available answers in the simulator : Veuf(ve), Séparé(e), Divorcé(e)
       const situations_couple = {
@@ -66,10 +65,7 @@ const sources = {
         pacse: "Pacsé(e)",
         celibataire: "Union libre",
       }
-      console.log(
-        "situations_couple[statut_marital]: ",
-        situations_couple[statut_marital]
-      )
+
       return situations_couple[statut_marital]
     }
     return "Célibataire"
@@ -85,7 +81,6 @@ const fsl_var_sources = {
       "activite",
       "demandeur"
     )
-    console.log("activite", activite)
     return activite
   },
   loyer_avec_charges: (simulation) => {
@@ -198,7 +193,6 @@ DemarchesSimplifiees.prototype.toInternal = async function () {
     a[v.id] = v.label
     return a
   }, {})
-  console.log("fieldLabelMap", fieldLabelMap)
 
   const keys = Object.keys(data)
   return keys.map((fieldId) => {

--- a/backend/lib/teleservices/demarches-simplifiees.ts
+++ b/backend/lib/teleservices/demarches-simplifiees.ts
@@ -1,7 +1,7 @@
 import axios from "axios"
 import dayjs from "dayjs"
 import { getAnswer } from "../../../lib/answers.js"
-import { getActiviteLabelFromString } from "../../../lib/enums/activite.js"
+import { getActiviteLabel } from "../../../lib/enums/activite.js"
 import Scolarite from "../../../lib/scolarite.js"
 
 const sources = {
@@ -83,7 +83,7 @@ const fsl_var_sources = {
       "activite",
       "demandeur"
     )
-    return getActiviteLabelFromString(activite)
+    return getActiviteLabel(activite)
   },
   loyer_avec_charges: (simulation) => {
     const { loyer, charges_locatives } = getAnswer(
@@ -132,7 +132,7 @@ const fsl_var_sources = {
 
     conjoint["champ_Q2hhbXAtMjU1NDk1MQ"] = date_naissance.slice(0, 10)
     conjoint["champ_Q2hhbXAtMjU1NDk1NA"] = "Conjoint(e)"
-    conjoint["champ_Q2hhbXAtMjU1NDk1NQ"] = getActiviteLabelFromString(activite)
+    conjoint["champ_Q2hhbXAtMjU1NDk1NQ"] = getActiviteLabel(activite)
     return conjoint
   },
   buildChild(simulation, id) {

--- a/backend/lib/teleservices/demarches-simplifiees.ts
+++ b/backend/lib/teleservices/demarches-simplifiees.ts
@@ -50,25 +50,25 @@ const sources = {
     const en_couple =
       getAnswer(simulation.answers.current, "famille", "en_couple") === true
 
-    if (en_couple) {
-      const statut_marital = getAnswer(
-        simulation.answers.current,
-        "individu",
-        "statut_marital",
-        "conjoint"
-      )
-
-      // - Answer "en_couple" value "Union libre" is "celibataire" and needs to be restored as "Union libre" for the prefill
-      // - Missing not available answers in the simulator : Veuf(ve), Séparé(e), Divorcé(e)
-      const situations_couple = {
-        marie: "Marié(e)",
-        pacse: "Pacsé(e)",
-        celibataire: "Union libre",
-      }
-
-      return situations_couple[statut_marital]
+    if (!en_couple) {
+      return "Célibataire"
     }
-    return "Célibataire"
+    const statut_marital = getAnswer(
+      simulation.answers.current,
+      "individu",
+      "statut_marital",
+      "conjoint"
+    )
+
+    // - Answer "en_couple" value "Union libre" is "celibataire" and needs to be restored as "Union libre" for the prefill
+    // - Missing not available answers in the simulator : Veuf(ve), Séparé(e), Divorcé(e)
+    const situations_couple = {
+      marie: "Marié(e)",
+      pacse: "Pacsé(e)",
+      celibataire: "Union libre",
+    }
+
+    return situations_couple[statut_marital]
   },
   telephone: () => "0612345678",
 }

--- a/backend/lib/teleservices/demarches-simplifiees.ts
+++ b/backend/lib/teleservices/demarches-simplifiees.ts
@@ -115,8 +115,6 @@ const fsl_var_sources = {
     ) {
       return null
     }
-
-    const conjoint = {}
     const date_naissance = getAnswer(
       simulation.answers.current,
       "individu",
@@ -129,14 +127,13 @@ const fsl_var_sources = {
       "activite",
       "conjoint"
     )
-
-    conjoint["champ_Q2hhbXAtMjU1NDk1MQ"] = date_naissance.slice(0, 10)
-    conjoint["champ_Q2hhbXAtMjU1NDk1NA"] = "Conjoint(e)"
-    conjoint["champ_Q2hhbXAtMjU1NDk1NQ"] = getActiviteLabel(activite)
-    return conjoint
+    return {
+      champ_Q2hhbXAtMjU1NDk1MQ: date_naissance.slice(0, 10),
+      champ_Q2hhbXAtMjU1NDk1NA: "Conjoint(e)",
+      champ_Q2hhbXAtMjU1NDk1NQ: getActiviteLabel(activite),
+    }
   },
   buildChild(simulation, id) {
-    const child = {}
     const date_naissance = getAnswer(
       simulation.answers.current,
       "individu",
@@ -158,12 +155,11 @@ const fsl_var_sources = {
     const scolariteLabel = Scolarite.types.find(
       (t) => t.value === scolarite
     )?.label
-    child["champ_Q2hhbXAtMjU1NDk1MQ"] = date_naissance.slice(0, 10)
-    child["champ_Q2hhbXAtMjU1NDk0OQ"] = prenom
-    if (scolariteLabel) {
-      child["champ_Q2hhbXAtMjU1NDk1NQ"] = scolariteLabel
+    return {
+      champ_Q2hhbXAtMjU1NDk1MQ: date_naissance.slice(0, 10),
+      champ_Q2hhbXAtMjU1NDk0OQ: prenom,
+      champ_Q2hhbXAtMjU1NDk1NQ: scolariteLabel,
     }
-    return child
   },
   autres_personnes_du_foyer: (simulation) => {
     const results: any[] = []

--- a/data/benefits/javascript/departement-var-fonds-de-solidarite-energie.yml
+++ b/data/benefits/javascript/departement-var-fonds-de-solidarite-energie.yml
@@ -13,8 +13,8 @@ conditions_generales:
       - "248300543"
 profils: []
 link: https://www.var.fr/social/insertion/fonds-de-solidarite-logement
-form: https://www.var.fr/documents/d/departement-du-var/energie-a4-2
 instructions: https://www.var.fr/documents/d/departement-du-var/notice-d_accompagnement-a-l_application-du-reglement-interieur-2023-1
+teleservicePrefill: ds?procedure=departement-83-demande-fonds-solidarite-energie
 prefix: le
 type: bool
 periodicite: autre

--- a/lib/enums/activite.ts
+++ b/lib/enums/activite.ts
@@ -12,3 +12,27 @@ export enum Activite {
   SituationHandicap = "situation_handicap",
   Stagiaire = "stagiaire",
 }
+
+export enum ActiviteLabel {
+  Apprenti = "En contrat d’apprentissage",
+  Autre = "Autre",
+  BeneficiaireRsa = "Bénéficiaire rsa",
+  Chomeur = "En recherche d’emploi",
+  Etudiant = "En études",
+  Inactif = "En situation d’inactivité",
+  Independant = "Indépendant(e)",
+  Professionnalisation = "Contrat de professionnalisation en alternance",
+  Retraite = "Retraité(e)",
+  Salarie = "Salarié(e)",
+  ServiceCivique = "En service civique",
+  SituationHandicap = "En situation de handicap",
+  Stagiaire = "Stagiaire",
+}
+
+export function getActiviteLabelFromString(activite: string): any {
+  const activiteLabelKey = Object.keys(Activite).find(
+    (key) => Activite[key] === activite
+  )
+  if (!activiteLabelKey) throw new Error(`Activite ${activite} not found`)
+  return ActiviteLabel[activiteLabelKey]
+}

--- a/lib/enums/activite.ts
+++ b/lib/enums/activite.ts
@@ -13,26 +13,27 @@ export enum Activite {
   Stagiaire = "stagiaire",
 }
 
-export enum ActiviteLabel {
-  Apprenti = "En contrat d’apprentissage",
-  Autre = "Autre",
-  BeneficiaireRsa = "Bénéficiaire rsa",
-  Chomeur = "En recherche d’emploi",
-  Etudiant = "En études",
-  Inactif = "En situation d’inactivité",
-  Independant = "Indépendant(e)",
-  Professionnalisation = "Contrat de professionnalisation en alternance",
-  Retraite = "Retraité(e)",
-  Salarie = "Salarié(e)",
-  ServiceCivique = "En service civique",
-  SituationHandicap = "En situation de handicap",
-  Stagiaire = "Stagiaire",
+// Used for prefill "FSL énergie du Var"
+const ActiviteLabelMapping: Record<Activite, string> = {
+  [Activite.Apprenti]: "En contrat d’apprentissage",
+  [Activite.Autre]: "Autre",
+  [Activite.BeneficiaireRsa]: "Bénéficiaire rsa",
+  [Activite.Chomeur]: "En recherche d’emploi",
+  [Activite.Etudiant]: "En études",
+  [Activite.Inactif]: "En situation d’inactivité",
+  [Activite.Independant]: "Indépendant(e)",
+  [Activite.Professionnalisation]:
+    "Contrat de professionnalisation en alternance",
+  [Activite.Retraite]: "Retraité(e)",
+  [Activite.Salarie]: "Salarié(e)",
+  [Activite.SituationHandicap]: "En situation de handicap",
+  [Activite.Stagiaire]: "Stagiaire",
 }
 
-export function getActiviteLabelFromString(activite: string): any {
-  const activiteLabelKey = Object.keys(Activite).find(
-    (key) => Activite[key] === activite
-  )
-  if (!activiteLabelKey) throw new Error(`Activite ${activite} not found`)
-  return ActiviteLabel[activiteLabelKey]
+export function getActiviteLabel(activite: Activite): string {
+  const activiteLabel = ActiviteLabelMapping[activite]
+  if (!activiteLabel) {
+    throw new Error(`Activite ${activite} not found`)
+  }
+  return activiteLabel
 }


### PR DESCRIPTION
# Description

Pré-remplissage des champs activité, loyer+charges, nom de la commune et la date de naissance.

J'ai ajouté l'objet `fsl_var_sources` pour le calcul des valeur via les réponses du simulateur. Ce serait peut être bien de découper ces données dans d'autres fichiers si c'est voué à grossir.

# Note

Le code postal a été inclus  par anticipation au pré-remplissage mais il n'est malheureusement pas encore disponible pour cette aide.

[Source : encart "code postal"](https://www.demarches-simplifiees.fr/preremplir/departement-83-demande-fonds-solidarite-energie
)
![image](https://github.com/betagouv/aides-jeunes/assets/18016058/cd265db7-0845-4354-acd0-a2415cf329ad)