### PR TITLE
Réduit la longueur du message du sondage par SMS

### DIFF
--- a/backend/lib/messaging/sms/sms-service.ts
+++ b/backend/lib/messaging/sms/sms-service.ts
@@ -52,7 +52,7 @@ function buildSmsUrl({ accessToken, phone, username, password, smsType }) {
       break
     case SmsType.InitialSurvey:
       surveyLink = `${baseURL}/api/r/${accessToken}`
-      text = `Bonjour\nVotre simulation sur 1jeune1solution.gouv.fr vous a-t-elle été utile?\nVoici un court sondage : ${surveyLink}\n1jeune1solution`
+      text = `Votre simulation sur 1jeune1solution.gouv.fr vous a-t-elle été utile ? Dites-le nous : ${surveyLink}`
       break
     default:
       throw new Error(`Unknown SMS type: ${smsType}`)


### PR DESCRIPTION
Le message avec le lien du sondage envoyé par SMS est trop long (+160 caractères). Cette correction (ouverte aux suggestions) permet de réduire sa taille