### PR TITLE
Met à jour le PACE de la région Grand Est.

### DIFF
--- a/data/benefits/javascript/grand-est-parcours-acquisition-des-competences-en-entreprises.yml
+++ b/data/benefits/javascript/grand-est-parcours-acquisition-des-competences-en-entreprises.yml
@@ -3,7 +3,9 @@ institution: grand_est
 description:
   Ce dispositif permet aux jeunes de 18 à 29 ans, titulaires d'un diplôme ou non,
   d’acquérir des compétences et une première expérience professionnelle tutorée
-  d’une durée de six mois, au sein d’une entreprise.
+  d’une durée de six mois, au sein d’une entreprise. En intégrant le dispositif PACE,
+  vous percevrez une remunération de stagiaire de la formation professionnelle, dont le
+  montant est régit par le Code du Travail.
 conditions_generales:
   - type: age
     operator: ">="
@@ -22,4 +24,4 @@ prefix: le
 type: float
 unit: €
 periodicite: mensuelle
-montant: 500
+montant: 528


### PR DESCRIPTION
suite à une demande de Claire.DUPUIT@grandest.fr 
email du 13 octobre 2023

"Bonjour,
 
Je tenais à vous informer que le dispositif PACE de la Région GRAND EST a évolué depuis le 1er octobre, le montant estimé n’est plus de 500 euros/mois, il est désormais de 528 euros/mois et évolutif suivant le statut de la personne.
Merci de bien vouloir modifier cette donnée.
 
Bien cordialement"