### PR TITLE
Corrige la period associée au RNI pour accorder avec l'année fiscale

### DIFF
--- a/backend/lib/openfisca/mapping/index.ts
+++ b/backend/lib/openfisca/mapping/index.ts
@@ -213,7 +213,7 @@ export function applyHeuristicsAndFix(testCase, sourceSituation) {
         [periods.fiscalYear]: parents.rfr,
       }
       testCase.foyers_fiscaux._.rni = {
-        [periods.lastYear]: parents.rfr,
+        [periods.fiscalYear]: parents.rfr,
       }
     }
     if (parents.nbptr) {

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -2,5 +2,5 @@ gunicorn>=21.2.0
 pytest==7.2.2
 Openfisca-France==155.0.6
 Openfisca-Core[web-api]==41.3.0
-OpenFisca-France-Local[excel-reader]==6.11.2
+OpenFisca-France-Local[excel-reader]==6.11.3
 Openfisca-Paris==5.4.0


### PR DESCRIPTION
# Description

Le RNI qu'on envoit a openfisca (il me semble exclusivement pour le CEJ), n'est pas associée à la bonne periode.