### PR TITLE
Corrige les conditions d'affichage de la question du RBG

### DIFF
--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -603,7 +603,6 @@ export function generateBlocks(situation): Block[] {
               demandeur &&
               demandeur.activite === Activite.Etudiant &&
               !demandeur.alternant &&
-              !(situation.enfants && situation.enfants.length) &&
               BCSAgeCondition(situation)
             return demandeur_ok
           },

--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -11,6 +11,7 @@ import { Scolarite, Etudiant } from "../enums/scolarite.js"
 import { LogementCategory } from "../enums/logement.js"
 import { ChapterName } from "../enums/chapter.js"
 import { Block } from "../types/blocks.js"
+import { BCSAgeCondition } from "./step-conditions.js"
 
 function individuBlockFactory(id, chapter?: ChapterName) {
   const r = (variable, chapter?: ChapterName) => {
@@ -602,7 +603,8 @@ export function generateBlocks(situation): Block[] {
               demandeur &&
               demandeur.activite === Activite.Etudiant &&
               !demandeur.alternant &&
-              !(situation.enfants && situation.enfants.length)
+              !(situation.enfants && situation.enfants.length) &&
+              BCSAgeCondition(situation)
             return demandeur_ok
           },
           steps: [

--- a/lib/state/step-conditions.ts
+++ b/lib/state/step-conditions.ts
@@ -1,0 +1,17 @@
+import IndividuMethods from "../individu.js"
+import { Situation } from "../types/situations.d.js"
+
+/* Condition BCS :
+    "Vous devez avoir moins de 28 ans lors de votre 1re demande de bourse (au 1er septembre de l'année des études).
+    À partir de 28 ans, vous devez poursuivre vos études pour continuer à toucher la bourse.
+    Cette limite d'âge peut être reportée si vous êtes dans l'une des conditions suivantes :
+    - Étudiant parent d'enfant :
+    La limite d'âge est reculée d'1 an par enfant élevé."
+    https://www.service-public.fr/particuliers/vosdroits/F12214
+    */
+export function BCSAgeCondition(situation: Situation): boolean {
+  const { demandeur, enfants, dateDeValeur } = situation
+  const childrenRaisedNumber = enfants?.length || 0
+  const individuAge = IndividuMethods.age(demandeur, dateDeValeur.toString())
+  return individuAge <= 28 + childrenRaisedNumber
+}


### PR DESCRIPTION
## Description

Fixbug issu de [la tâche suivante](https://trello.com/c/aOHNj0NL/1413-bug-certaines-questions-pos%C3%A9es-%C3%A0-lutilisateur-sont-toujours-pr%C3%A9sentes-m%C3%AAme-apr%C3%A8s-avoir-modifi%C3%A9-la-simulation) (plus d'informations sur l'investigation en commentaires de la tâche sur Trello)

## Questionnements

Suite à ces investigations, je me pose aussi la question de la condition d'affichage historique `8 < age && age <= 25` de la question présente ici et suis preneur d'éclaircissement à propos de ce choix car l'âge d'un enfant à charge est normalement de 0 à 21 ans selon [service-public.fr](https://www.service-public.fr/particuliers/vosdroits/F16947#:~:text=L'enfant%20est%20consid%C3%A9r%C3%A9%20%C3%A0,exc%C3%A8de%20pas%20un%20certain%20montant.) :

> Un enfant est considéré à charge :
> 
> Dès la grossesse pour la [prime à la naissance](https://www.service-public.fr/particuliers/vosdroits/F2550) ou le [revenu de solidarité active](https://www.service-public.fr/particuliers/vosdroits/N19775)
> Jusqu'à ses 3 ans
> 
> De 3 ans à 15 ans s'il remplit l'[obligation scolaire](https://www.service-public.fr/particuliers/vosdroits/N23493)
> 
> L'enfant est considéré à charge jusqu'à ses 20 ans (21 ans pour l'attribution du [complément familial](https://www.service-public.fr/particuliers/vosdroits/F13214) et des [allocations logement](https://www.service-public.fr/particuliers/vosdroits/N20360)) si sa rémunération mensuelle nette n'excède pas un certain montant."

Piste de concernant l'ajout de cette condition : https://github.com/betagouv/aides-jeunes/pull/1501 => pas d'info sur les spécifications de ce choix. On peut supposer que c'était les conditions de l'époque

## DoD

- [x] Refactoriser les conditions d'âge
- [x] Abaisser l'âge d'un enfant à charge à 21 ans
- [x] Ajouter la condition d'enfant à charge à la question du RBG
- [x] Adapter l'âge des tests e2e pour les profils"enfant à charge"