### PR TITLE
fix: Répare la fonction pour trouver la dernière migration

### DIFF
--- a/backend/lib/migrations/index.ts
+++ b/backend/lib/migrations/index.ts
@@ -31,7 +31,7 @@ function getSortedMigrations(modelName) {
     a: any,
     b: any
   ) {
-    return a.version - b.version
+    return a.default.version - b.default.version
   })
 }
 


### PR DESCRIPTION
LE truc c'est que les valeur de `migrationFilesByModelName` sont des import de fichier de migration. Mais les valeurs exporté dans les migration sont exportées dans leur `default`. D'ailleurs on le prend en compte ici : 
https://github.com/betagouv/aides-jeunes/blob/c769a8091a5729a4d7ab7bd0a155b7337dbddf34/backend/lib/migrations/index.ts#L54

Avant ce fix, la dernière migration était choisi au hasard (comparaison de `undefined` avec `undefined`), enfin en réalité c'était le dernier fichier importé donc `"v9"`, var en comparaison de chaine de caractères `"v9"` > `"v15"`