### PR TITLE
Modifie la période envoyée pour le RNI

### DIFF
--- a/backend/lib/openfisca/mapping/index.ts
+++ b/backend/lib/openfisca/mapping/index.ts
@@ -213,7 +213,7 @@ export function applyHeuristicsAndFix(testCase, sourceSituation) {
         [periods.fiscalYear]: parents.rfr,
       }
       testCase.foyers_fiscaux._.rni = {
-        [periods.lastYear]: parents.rfr,
+        [periods.fiscalYear]: parents.rfr,
       }
     }
     if (parents.nbptr) {


### PR DESCRIPTION
# Description

J'avais mis cette période pour que ça marche avec l'aide à la garde d'enfants des hauts de france que j'ai faite en même temps mais ce n'est pas la bonne période pour ce genre de valeures et donc ça ne marche pas avec, au moins, le CEJ