### PR TITLE
Aide à la garde d'enfant des Hauts de France - Convertit l'aide JS en Openfisca

### DIFF
--- a/data/benefits/openfisca/hauts_de_france_aide_garde_enfant.yml
+++ b/data/benefits/openfisca/hauts_de_france_aide_garde_enfant.yml
@@ -1,4 +1,4 @@
-label: aide à la garde d'enfants
+label: Aide à la garde d'enfants
 institution: hauts_de_france
 description: Cette aide permet de faciliter l'accès aux services de garde
   d'enfants pour le(s) parent(s) aux revenus modestes.
@@ -7,19 +7,12 @@ conditions:
     Hauts-de-France.
   - Recourir à un mode de garde déclaré.
   - Recourir à une garde d'au moins 20 heures par semaine.
-conditions_generales:
-  - type: regions
-    values:
-      - "32"
-profils:
-  - type: salarie
-    conditions: []
 link: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=636
 teleservice: https://aides.hautsdefrance.fr/sub/tiers/aides/details/?sigle=AGE%2009%2F21
 instructions: https://guide-aides.hautsdefrance.fr/spip.php?page=dispositif&id_dispositif=636
 prefix: l’
 type: float
 unit: €
+openfiscaPeriod: thisMonth
 periodicite: mensuelle
-legend: maximum
-montant: 30
+entity: familles


### PR DESCRIPTION
# Description

Lors de l’introduction initiale de cette aide dans le simulateur, un crash a eu lieu et la [PR d’ajout](https://github.com/betagouv/aides-jeunes/pull/3820) à été revert dans [cette PR](https://github.com/betagouv/aides-jeunes/pull/3824) .

L’aide a été corrigée sur openfisca dans la [PR 171](https://github.com/openfisca/openfisca-france-local/pull/171)

Cette PR supprime le fichier JS et le remplace un fichier openfisca