### PR TITLE
Log error: Suppression de faux positifs

### DIFF
--- a/backend/controllers/webhook.ts
+++ b/backend/controllers/webhook.ts
@@ -35,7 +35,7 @@ export const verifyAuthentication = (
   next()
 }
 
-const isValidBody = (body: RequestBody): boolean => {
+const shouldProcessEvent = (body: RequestBody): boolean => {
   return !!(
     body &&
     body.meta &&
@@ -63,9 +63,8 @@ export const validateRequestPayload = (
   next: NextFunction
 ): void => {
   req.body = JSON.parse(req.body.toString())
-  if (!isValidBody(req.body)) {
-    console.error("Invalid payload structure", req.body)
-    res.status(400).json({ error: "Invalid payload structure" })
+  if (!shouldProcessEvent(req.body)) {
+    res.status(400).json({ error: "Event not supported" })
     return
   }
 

--- a/tests/unit/backend/webhook.spec.ts
+++ b/tests/unit/backend/webhook.spec.ts
@@ -104,10 +104,9 @@ describe("validateRequestPayload", () => {
 
     validateRequestPayload(req, res, next)
 
-    expect(consoleSpy).toHaveBeenCalledWith("Invalid payload structure", {})
     expect(res.status).toHaveBeenCalledWith(400)
     expect(res.json).toHaveBeenCalledWith({
-      error: "Invalid payload structure",
+      error: "Event not supported",
     })
     expect(next).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
C'est pour ne pas considérer en erreur les events qui ne sont tout simplement pas pris en compte
Ça générait des trace d'erreur énorme pour les updates de rendez-vous en prod