### PR TITLE
Ajoute une Github Action pour associer le milestone BC actuel aux PR ouvertes

### DIFF
--- a/.github/workflows/associate-actual-milestone.yml
+++ b/.github/workflows/associate-actual-milestone.yml
@@ -1,0 +1,26 @@
+name: Associate actual milestone
+
+on:
+  schedule:
+    - cron: "0 10 * * *" # Every day at 10:00 UTC
+
+jobs:
+  associate-milestone:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up GitHub CLI
+        uses: actions/setup-gh@v2
+
+      - name: Update milestone on open PRs
+        run: |
+          open_prs=$(gh pr list --base "master" --state open --json number -q ".[].number" 2>/dev/null || echo null)
+
+          if [ "$open_prs" != "null" ]; then
+            for pr_number in $open_prs; do
+              gh pr edit "$pr_number" --milestone "BC actuel"
+            done
+          fi

--- a/.github/workflows/associate-actual-milestone.yml
+++ b/.github/workflows/associate-actual-milestone.yml
@@ -1,8 +1,9 @@
 name: Associate actual milestone
 
 on:
-  schedule:
-    - cron: "0 10 * * *" # Every day at 10:00 UTC
+  pull_request:
+    types:
+      - opened
 
 jobs:
   associate-milestone:
@@ -15,12 +16,7 @@ jobs:
       - name: Set up GitHub CLI
         uses: actions/setup-gh@v2
 
-      - name: Update milestone on open PRs
+      - name: Update milestone on a PR opening
         run: |
-          open_prs=$(gh pr list --base "master" --state open --json number -q ".[].number" 2>/dev/null || echo null)
-
-          if [ "$open_prs" != "null" ]; then
-            for pr_number in $open_prs; do
-              gh pr edit "$pr_number" --milestone "BC actuel"
-            done
-          fi
+          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          gh pr edit "$pr_number" --milestone "BC actuel"

--- a/.github/workflows/associate-actual-milestone.yml
+++ b/.github/workflows/associate-actual-milestone.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Update milestone on a PR opening
         run: |
           pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")

--- a/.github/workflows/associate-actual-milestone.yml
+++ b/.github/workflows/associate-actual-milestone.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Update milestone on a PR opening
         run: |
           pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")

--- a/.github/workflows/associate-actual-milestone.yml
+++ b/.github/workflows/associate-actual-milestone.yml
@@ -13,10 +13,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up GitHub CLI
-        uses: actions/setup-gh@v2
-
       - name: Update milestone on a PR opening
         run: |
           pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           gh pr edit "$pr_number" --milestone "BC actuel"
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://trello.com/c/egiZTujW/1549-ajouter-une-github-action-pour-associer-automatiquement-les-pr-ouvertes-au-milestone-qui-a-actuel-dans-son-nom