### PR TITLE
feat: set `strictQuery` to false to prepare mongoose 7

### DIFF
--- a/backend/config/mongoose.ts
+++ b/backend/config/mongoose.ts
@@ -3,6 +3,7 @@ import { Configuration } from "../types/config.js"
 
 export default function (mongoose: any, config: Configuration) {
   mongoose.Promise = bluebird
+  mongoose.set("strictQuery", false)
 
   if (!config.mongodb_url) {
     throw new Error("Please provide a `MONGODB_URL` environment variable")


### PR DESCRIPTION
Cette PR est surtout pour voir si les tests d'integration passe. L'objectif étant de supprimer un warning en préparant pour l'avenir la migration mongoose 7

Warning in production :
[MONGOOSE] DeprecationWarning: Mongoose: the `strictQuery` option will be switched back to `false` by default in Mongoose 7. Use `mongoose.set('strictQuery', false);` if you want to prepare for this change. Or use `mongoose.set('strictQuery', true);` to suppress this warning.