### PR TITLE
Fixbug du calcul du loyer avec charges - FSL énergie Var (démarches simplifiées)

### DIFF
--- a/backend/lib/teleservices/demarches-simplifiees.ts
+++ b/backend/lib/teleservices/demarches-simplifiees.ts
@@ -86,7 +86,7 @@ const fsl_var_sources = {
     return getActiviteLabel(activite)
   },
   loyer_avec_charges: (simulation) => {
-    const { loyer, charges_locatives } = getAnswer(
+    const { loyer, charges_locatives = 0 } = getAnswer(
       simulation.answers.current,
       "menage",
       "loyer"


### PR DESCRIPTION
https://trello.com/c/tGJ5rgye/1551-fix-question-loyer-charges-pr%C3%A9-remplissage-dans-laide-fsl-%C3%A9nergie-var

Le montant des charges est demandé sous plusieurs formes de questions : 
- Un champ pour le loyer + charges
- Deux champs séparés)

Cela mène à avoir parfois le champ "charges_locatives" de valeur `undefined`. Ce correctif prend en compte ce cas et évite l'addition d'un nombre avec `undefined`