### PR TITLE
Ajoute une github action pour modifier milestone des PR fermées non mergées

### DIFF
--- a/.github/workflows/associate-cancel-milestone.yml
+++ b/.github/workflows/associate-cancel-milestone.yml
@@ -1,0 +1,25 @@
+name: Associate cancel milestone to closed and unmerged PRs
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  update-milestone:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Update milestone on PR closure
+        run: |
+          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          pr_state=$(gh pr view "$pr_number" --json state | jq -r '.state')
+
+          if [ "$pr_state" == "CLOSED" ]; then
+            gh pr edit "$pr_number" --milestone "Annulé"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Preneur d'avis en attendant que la tâche soit officielle.

A priori, lorsqu'une une PR est fermée elle a son "state" qui vaut "MERGED" si elle est mergée et "CLOSED" si elle n'est pas mergée 