### PR TITLE
fix: min height

### DIFF
--- a/src/styles/aides-jeunes.css
+++ b/src/styles/aides-jeunes.css
@@ -265,6 +265,7 @@ textarea {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 40em;
 }
 
 .aj-column-container {


### PR DESCRIPTION
J'ai enlevé le min height qui provoquait un soucis avec le resize de l'iframe. Mais il faut en rajouter un pour ne pas avoir le site ratatiné verticalement.
La diff c'est qu'on donne une taille absolu et non en fonction du viewport (historiquement `100vh` qui créait un infinite loop avec le resize de l'iframe)