### PR TITLE
chore: remove unused code block

### DIFF
--- a/src/components/ressource/montants.vue
+++ b/src/components/ressource/montants.vue
@@ -78,8 +78,8 @@
   </fieldset>
 </template>
 
-<script lang="ts">
-import { PropType } from "vue"
+<script setup lang="ts">
+import { computed, PropType } from "vue"
 
 import MonthLabel from "@/components/month-label.vue"
 import YesNoQuestion from "@/components/yes-no-question.vue"
@@ -88,19 +88,32 @@ import InputNumber from "@/components/input-number.vue"
 import { useStore } from "@/stores/index.js"
 import { ResourceType } from "@lib/types/resources.d.js"
 
+const props = defineProps({
+  type: { type: Object as PropType<ResourceType>, required: true },
+  index: Number,
+})
+
+const emit = defineEmits(["update"])
+const store = useStore()
+
+const singleValue = computed({
+  get: () => props.type.displayMonthly,
+  set: (value) => emit("update", "displayMonthly", props.index, value),
+})
+
 function getQuestionLabel(ressource, debutAnneeGlissante) {
-  let verbForms = {
+  const verbForms = {
     pensions_alimentaires_versees_individu: "versé",
     default: "reçu",
   }
 
-  let verb = verbForms[ressource.id] || verbForms.default
+  const verb = verbForms[ressource.id] || verbForms.default
   return `${[
     "Le montant",
     verb,
     "est-il le même <b>tous les mois</b> depuis",
     debutAnneeGlissante,
-  ].join(" ")} ?`
+  ].join(" ")} ?`
 }
 
 function getLongLabel(individu, ressource) {
@@ -118,39 +131,6 @@ function getLongLabel(individu, ressource) {
   }
   const verb = verbs[ressource.id] || verbs.default
 
-  return `${[subject, aux, verb, "en"].join(" ")} :`
-}
-
-export default {
-  name: "RessourceMontants",
-  components: {
-    InputNumber,
-    MonthLabel,
-    YesNoQuestion,
-  },
-  props: {
-    type: { type: Object as PropType<ResourceType>, required: true },
-    index: Number,
-  },
-  emits: ["update"],
-  setup() {
-    return {
-      store: useStore(),
-    }
-  },
-  computed: {
-    singleValue: {
-      get() {
-        return this.type.displayMonthly
-      },
-      set(value) {
-        this.$emit("update", "displayMonthly", this.index, value)
-      },
-    },
-  },
-  methods: {
-    getQuestionLabel,
-    getLongLabel,
-  },
+  return `${[subject, aux, verb, "en"].join(" ")} :`
 }
 </script>

--- a/src/mixins/ressource-processor.ts
+++ b/src/mixins/ressource-processor.ts
@@ -62,48 +62,5 @@ export default {
         }
       }
     },
-    save(types, single) {
-      if (!types.length) {
-        return
-      } else if (single) {
-        const updatedRessources = {}
-        this.types.forEach((t) => {
-          updatedRessources[t.meta.id] = Object.assign(
-            {},
-            t.individu[t.meta.id]
-          )
-          t.months.forEach((m) => {
-            updatedRessources[t.meta.id][m.id] =
-              t.amounts[m.id] || t.amounts[m.id] === 0
-                ? t.amounts[m.id]
-                : t.amounts[this.store.dates.thisMonth.id] || 0
-          })
-
-          const extras = t.meta.extra || []
-          extras.forEach((e) => {
-            updatedRessources[e.id] = t.extra[e.id]
-          })
-        })
-      } else {
-        this.types.forEach((t) => {
-          const updatedRessources = {}
-          updatedRessources[t.meta.id] = Object.assign(
-            {},
-            t.individu[t.meta.id]
-          )
-          t.months.forEach((m) => {
-            updatedRessources[t.meta.id][m.id] =
-              t.amounts[m.id] || t.amounts[m.id] === 0
-                ? t.amounts[m.id]
-                : t.amounts[this.store.dates.thisMonth.id] || 0
-          })
-
-          const extras = t.meta.extra || []
-          extras.forEach((e) => {
-            updatedRessources[e.id] = t.extra[e.id]
-          })
-        })
-      }
-    },
   },
 }


### PR DESCRIPTION
En fouillant j'ai trouvé aucun endroit où c'était utilisé, chaud pour un deuxième check quand même. Pas d'impact sur le parcours en local.

Mon enquête :
- Le mixin est utilisé que [ici](https://github.com/betagouv/aides-jeunes/blob/9fed19b2be0652925368c6b5ef4a1b1bb04d34d3/src/views/simulation/Ressources/montants.vue#L50)
- Seule les méthodes [process](https://github.com/betagouv/aides-jeunes/blob/9fed19b2be0652925368c6b5ef4a1b1bb04d34d3/src/views/simulation/Ressources/montants.vue#L16) et [getDisplayMonthly](https://github.com/betagouv/aides-jeunes/blob/9fed19b2be0652925368c6b5ef4a1b1bb04d34d3/src/views/simulation/Ressources/montants.vue#L165) sont utilisées

Plus: passage en composition api
