### PR TITLE
Corrige le double spin lors de la récupération des données d'une aide

### DIFF
--- a/src/views/simulation/resultats-detail.vue
+++ b/src/views/simulation/resultats-detail.vue
@@ -1,20 +1,7 @@
 <template>
   <div>
     <LoadingModal v-if="fetching || updating">
-      <p v-show="fetching">
-        <span
-          class="fr-icon--ml fr-icon-refresh-line fr-icon-spin"
-          aria-hidden="true"
-        ></span
-        ><span class="fr-ml-2w">Récupération en cours…</span>
-      </p>
-      <p v-show="updating">
-        <span
-          class="fr-icon--ml fr-icon-refresh-line fr-icon-spin"
-          aria-hidden="true"
-        ></span
-        ><span class="fr-ml-2w">Récupération de vos droits…</span>
-      </p>
+      <p>Récupération en cours… </p>
     </LoadingModal>
 
     <BackButton


### PR DESCRIPTION
Quand on ouvre les détails d'une aide dans un nouvel onglet, on peut constater un double spin dans la modale de chargement. 

Correctif de l'issue https://github.com/betagouv/aides-jeunes/issues/4136