### PR TITLE
Prévient le scrollIntoView sur la page d'accueil

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -324,10 +324,10 @@ router.beforeEach((to, from, next) => {
   next()
 })
 
-router.afterEach((to) => {
+router.afterEach((to, from) => {
   nextTick(function () {
     // scroll with a hash is managed in scrollBehavior
-    if (!to.hash) {
+    if (!to.hash && from.name !== undefined) {
       const header = document.querySelector("h1")
       header?.scrollIntoView({
         behavior: "smooth",


### PR DESCRIPTION
Problème découvert par le test d'intégration de l'iframe réalisée sur https://www.etudiant.gouv.fr/fr/vos-aides-financieres-1896 où le scroll s'effectue à l'ouverture de la page et pose un problème d'UI car tout le contenu précédant l'iframe est évité dû à ce scroll.

La solution que j'ai trouvée pour éviter cela est d'empêcher ce scroll sur la page d'accueil.