### PR TITLE
Refacto datesGenerator

### DIFF
--- a/backend/lib/openfisca/mapping/common.ts
+++ b/backend/lib/openfisca/mapping/common.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs"
 
 import benefits from "../../../../data/all.js"
-import { generator } from "../../../../lib/dates.js"
+import { datesGenerator } from "../../../../lib/dates.js"
 import { CONDITION_STRATEGY } from "../../../../lib/benefits/compute-javascript.js"
 
 import {
@@ -21,7 +21,7 @@ function isIndividuValid(individu: Individu, situation: Situation) {
 }
 
 function getPeriods(dateDeValeur: Date): OpenfiscaPeriods {
-  const dateMap = generator(dateDeValeur)
+  const dateMap = datesGenerator(dateDeValeur)
   const keys = Object.keys(dateMap)
   return keys.reduce((result, key) => {
     // Manage single item and maps

--- a/lib/benefits/compute-aides-velo.ts
+++ b/lib/benefits/compute-aides-velo.ts
@@ -1,5 +1,5 @@
 import aidesVelo from "aides-velo"
-import { generator } from "../dates.js"
+import { datesGenerator } from "../dates.js"
 import { Velo } from "../enums/velo.js"
 
 const veloTypes = {
@@ -28,7 +28,7 @@ export function computeAidesVeloBenefits(
   if (!canComputeAidesVeloBenefits(situation)) {
     return
   }
-  const periods = generator(situation.dateDeValeur)
+  const periods = datesGenerator(situation.dateDeValeur)
 
   const eligibleBenefitsMap = {}
   for (const type of situation.demandeur._interetsAidesVelo) {

--- a/lib/benefits/compute-javascript.ts
+++ b/lib/benefits/compute-javascript.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs"
-import { generator } from "../dates.js"
+import { datesGenerator } from "../dates.js"
 import { filterByInterestFlag } from "./filter-interest-flag.js"
 import ScolariteCategories from "../scolarite.js"
 
@@ -310,7 +310,7 @@ export function computeJavascriptBenefits(
     situation.demandeur?.date_naissance,
     "year"
   )
-  const periods = generator(situation.dateDeValeur)
+  const periods = datesGenerator(situation.dateDeValeur)
   const data = { situation, openfiscaResponse, periods, age }
 
   benefits.all

--- a/lib/benefits/compute.ts
+++ b/lib/benefits/compute.ts
@@ -6,9 +6,7 @@ import { computeAidesVeloBenefits } from "./compute-aides-velo.js"
 import { Situation } from "../../lib/types/situations.d.js"
 import { BenefitCatalog } from "../../data/types/generator.d.js"
 import { Resultats } from "@lib/types/store.js"
-
-import { generator } from "../dates.js"
-export const datesGenerator = generator
+import { datesGenerator } from "../dates.js"
 
 /**
  * OpenFisca test cases separate ressources between two entities: individuals and families.
@@ -65,7 +63,7 @@ export function computeAides(
   openfiscaResponse,
   showPrivate?: boolean
 ) {
-  const periods = generator(situation.dateDeValeur)
+  const periods = datesGenerator(situation.dateDeValeur)
 
   computeJavascriptBenefits(this, situation, openfiscaResponse)
 

--- a/lib/dates.ts
+++ b/lib/dates.ts
@@ -18,7 +18,7 @@ function generateYear(dt: Dayjs): DateItem {
   }
 }
 
-export const generator = function datesGenerator(
+export const datesGenerator = function (
   dateDeValeur: Date | number | string
 ): DatesRange {
   const ref = dayjs(dateDeValeur)

--- a/lib/resources.ts
+++ b/lib/resources.ts
@@ -1,5 +1,5 @@
 import IndividuMethods from "./individu.js"
-import { generator } from "./dates.js"
+import { datesGenerator } from "./dates.js"
 
 import { Situation } from "../lib/types/situations.js"
 import { Individu } from "../lib/types/individu.js"
@@ -140,7 +140,7 @@ export const ressourceTypes: Resource[] = [
         55 <=
         IndividuMethods.age(
           individu,
-          generator(situation.dateDeValeur).today.value
+          datesGenerator(situation.dateDeValeur).today.value
         )
       )
     },
@@ -191,7 +191,7 @@ export const ressourceTypes: Resource[] = [
     isRelevant: (situation: Situation, individu: Individu) => {
       const age = IndividuMethods.age(
         individu,
-        generator(situation.dateDeValeur).today.value
+        datesGenerator(situation.dateDeValeur).today.value
       )
       return Boolean(
         16 <= age && (age <= 25 || (individu.handicap && age < 30))

--- a/lib/situations.ts
+++ b/lib/situations.ts
@@ -1,6 +1,6 @@
 import Ressource from "./ressource.js"
 import { ressourceTypes } from "./resources.js"
-import { generator as datesGenerator } from "./dates.js"
+import { datesGenerator } from "./dates.js"
 import ScolariteCategories from "./scolarite.js"
 import { Individu } from "./types/individu.js"
 import { Situation } from "./types/situations.js"

--- a/lib/state/blocks.ts
+++ b/lib/state/blocks.ts
@@ -1,7 +1,7 @@
 import IndividuMethods from "../individu.js"
 import { ACTIVITES_ACTIF } from "../activite.js"
 import Ressource from "../ressource.js"
-import { generator as datesGenerator } from "../dates.js"
+import { datesGenerator } from "../dates.js"
 import { StepGenerator, ComplexStepGenerator } from "./steps.js"
 import ScolariteCategories from "../scolarite.js"
 import { childStepsComplete } from "../enfants.js"

--- a/src/components/ressource/montants.vue
+++ b/src/components/ressource/montants.vue
@@ -84,10 +84,11 @@ import YesNoQuestion from "@/components/yes-no-question.vue"
 import IndividuMethods from "@lib/individu.js"
 import InputNumber from "@/components/input-number.vue"
 import { ResourceType } from "@lib/types/resources.d.js"
+import { DatesRange } from "@lib/types/dates.d.js"
 
 const props = defineProps({
   type: { type: Object as PropType<ResourceType>, required: true },
-  dates: { type: Object as PropType<any>, required: true },
+  dates: { type: Object as PropType<DatesRange>, required: true },
   index: Number,
 })
 

--- a/src/components/ressource/montants.vue
+++ b/src/components/ressource/montants.vue
@@ -5,7 +5,7 @@
         {{ type.meta.label }}
       </span>
     </legend>
-    <div v-if="dates" class="fr-fieldset__content">
+    <div class="fr-fieldset__content">
       <YesNoQuestion
         :id="`${type.meta.id}_question`"
         v-model="singleValue"

--- a/src/components/ressource/montants.vue
+++ b/src/components/ressource/montants.vue
@@ -5,16 +5,14 @@
         {{ type.meta.label }}
       </span>
     </legend>
-    <div class="fr-fieldset__content">
+    <div v-if="dates" class="fr-fieldset__content">
       <YesNoQuestion
         :id="`${type.meta.id}_question`"
         v-model="singleValue"
         html-heading="h2"
       >
         <span
-          v-html="
-            getQuestionLabel(type.meta, store.dates.twelveMonthsAgo.label)
-          "
+          v-html="getQuestionLabel(type.meta, dates.twelveMonthsAgo.label)"
         />
       </YesNoQuestion>
 
@@ -28,7 +26,7 @@
               <InputNumber
                 :id="`${type.meta.id}_monthly`"
                 :min="0"
-                :value="type.amounts[store.dates.thisMonth.id]"
+                :value="type.amounts[dates.thisMonth.id]?.toString()"
                 @update:model-value="
                   $emit('update', 'singleValue', index, $event)
                 "
@@ -85,16 +83,15 @@ import MonthLabel from "@/components/month-label.vue"
 import YesNoQuestion from "@/components/yes-no-question.vue"
 import IndividuMethods from "@lib/individu.js"
 import InputNumber from "@/components/input-number.vue"
-import { useStore } from "@/stores/index.js"
 import { ResourceType } from "@lib/types/resources.d.js"
 
 const props = defineProps({
   type: { type: Object as PropType<ResourceType>, required: true },
+  dates: { type: Object as PropType<any>, required: true },
   index: Number,
 })
 
 const emit = defineEmits(["update"])
-const store = useStore()
 
 const singleValue = computed({
   get: () => props.type.displayMonthly,

--- a/src/components/ressource/montants.vue
+++ b/src/components/ressource/montants.vue
@@ -26,7 +26,7 @@
               <InputNumber
                 :id="`${type.meta.id}_monthly`"
                 :min="0"
-                :value="type.amounts[dates.thisMonth.id]?.toString()"
+                :value="type.amounts[dates.thisMonth.id]"
                 @update:model-value="
                   $emit('update', 'singleValue', index, $event)
                 "

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia"
 import dayjs from "dayjs"
 import { version } from "@lib/simulation.js"
-import { generator as datesGenerator } from "@lib/dates.js"
+import { datesGenerator } from "@lib/dates.js"
 import { generateAllSteps } from "@lib/state/generator.js"
 import { getAnswer, isStepAnswered, storeAnswer } from "@lib/answers.js"
 import { categoriesRnc, patrimoineTypes } from "@lib/resources.js"

--- a/src/views/simulation/Ressources/montants.vue
+++ b/src/views/simulation/Ressources/montants.vue
@@ -153,6 +153,7 @@ export default {
               })
             }
           }
+
           const months = Ressource.getPeriodsForCurrentYear(
             this.store.dates,
             type

--- a/src/views/simulation/Ressources/montants.vue
+++ b/src/views/simulation/Ressources/montants.vue
@@ -12,7 +12,7 @@
         v-if="isSimple(type.meta.id)"
         :index="index"
         :type="type"
-        :dates="dates"
+        :dates="store.dates"
         @update="process"
       />
       <RessourceMicroEntreprise
@@ -55,8 +55,6 @@ import { getAnswer } from "@lib/answers.js"
 import { useStore } from "@/stores/index.js"
 import { Individu } from "@lib/types/individu.d.js"
 import { ResourceType } from "@lib/types/resources.d.js"
-import { datesGenerator } from "@lib/dates.js"
-import dayjs from "dayjs"
 
 export default {
   name: "RessourcesMontants",
@@ -69,8 +67,7 @@ export default {
   },
   mixins: [RessourceProcessor],
   setup() {
-    const dates = datesGenerator(dayjs().format())
-    return { store: useStore(), dates }
+    return { store: useStore() }
   },
   data() {
     const individu = this.getIndividu()
@@ -156,7 +153,10 @@ export default {
               })
             }
           }
-          const months = Ressource.getPeriodsForCurrentYear(this.dates, type)
+          const months = Ressource.getPeriodsForCurrentYear(
+            this.store.dates,
+            type
+          )
 
           resourceTypes.push({
             amounts,

--- a/src/views/simulation/Ressources/montants.vue
+++ b/src/views/simulation/Ressources/montants.vue
@@ -12,6 +12,7 @@
         v-if="isSimple(type.meta.id)"
         :index="index"
         :type="type"
+        :dates="dates"
         @update="process"
       />
       <RessourceMicroEntreprise
@@ -54,6 +55,8 @@ import { getAnswer } from "@lib/answers.js"
 import { useStore } from "@/stores/index.js"
 import { Individu } from "@lib/types/individu.d.js"
 import { ResourceType } from "@lib/types/resources.d.js"
+import { datesGenerator } from "@lib/dates.js"
+import dayjs from "dayjs"
 
 export default {
   name: "RessourcesMontants",
@@ -66,7 +69,8 @@ export default {
   },
   mixins: [RessourceProcessor],
   setup() {
-    return { store: useStore() }
+    const dates = datesGenerator(dayjs().format())
+    return { store: useStore(), dates }
   },
   data() {
     const individu = this.getIndividu()
@@ -152,11 +156,7 @@ export default {
               })
             }
           }
-
-          const months = Ressource.getPeriodsForCurrentYear(
-            this.store.dates,
-            type
-          )
+          const months = Ressource.getPeriodsForCurrentYear(this.dates, type)
 
           resourceTypes.push({
             amounts,


### PR DESCRIPTION
Grâce à ce refacto, le composant `montants.vue` n'a plus besoin du store pour accéder aux données liées aux dates. 

J'en ai profité pour faire une passe sur les imports `generator as datesGenerator` qui pouvaient être simplifiés.