### PR TITLE
Ajoute des logs pour mieux comprendre les erreurs

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -7,9 +7,8 @@ import configure from "./configure.js"
 const __dirname = new URL(".", import.meta.url).pathname
 const app: Application = express()
 
-configure(app)
-const port = process.env.PORT
 app.use(morgan("combined"))
+configure(app)
 
 app.use(express.static(path.join(__dirname, "../../dist")))
 app.route("/*").get(function (req, res) {
@@ -22,8 +21,9 @@ const errorMiddleware: ErrorRequestHandler = (err, req, res, next) => {
   res.status(parseInt(err.code) || 500).send(err)
   next()
 }
-app.use(errorMiddleware)
+app.use(errorMiddleware, morgan("combined", { stream: process.stderr }))
 
+const port = process.env.PORT
 app.listen(port, () => {
   console.log(
     `Aides Jeunes server listening on port ${port}, in ${app.get(


### PR DESCRIPTION
Avec la configuration précédente, le logger n'était pas activé en cas d'erreurs dans le traitement des requêtes.
En déplaçant `app.use(morgan("combined"))` avant le `configure` on s'assure du log de toutes les requêtes dans `stdout`.

Pour simplifier les investigations, j'ai aussi ajouté un logger dédié à stderr pour avec des meta données (en particulier l'instant de l'erreur) à côté de l'erreur elle-même logguée.