### PR TITLE
Variation du label des teleservices sur rdv-aide-numerique.fr

### DIFF
--- a/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
+++ b/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
@@ -15,3 +15,4 @@ conditions:
 type: bool
 periodicite: autre
 teleservice: https://www.rdv-aide-numerique.fr/?address=1&departement=AJ
+link: https://www.rdv-aide-numerique.fr/?address=1&departement=AJ

--- a/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
+++ b/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
@@ -1,0 +1,16 @@
+label: Accompagnement personnalisé
+institution: ville_aubervilliers
+description: Vous avez besoin d’aide pour comprendre vos aides et effectuer vos démarches ?
+  Prenez un rendez-vous pour vous faire accompagner. La prise de rendez-vous se fait
+  en quelques minutes et vous permet de bénéficier d’un accompagnement téléphonique
+  d’une vingtaine de minutes par un membre de notre équipe.
+prefix: l'
+conditions_generales:
+  - type: communes
+    values:
+      - "93001"
+conditions:
+  - Résider à Aubervilliers
+type: bool
+periodicite: autre
+teleservice: https://www.rdv-aide-numerique.fr/?address=1&departement=AJ

--- a/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
+++ b/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
@@ -1,6 +1,7 @@
 label: Accompagnement personnalisé
 institution: ville_aubervilliers
-description: Vous avez besoin d’aide pour comprendre vos aides et effectuer vos démarches ?
+description:
+  Vous avez besoin d’aide pour comprendre vos aides et effectuer vos démarches ?
   Prenez un rendez-vous pour vous faire accompagner. La prise de rendez-vous se fait
   en quelques minutes et vous permet de bénéficier d’un accompagnement téléphonique
   d’une vingtaine de minutes par un membre de notre équipe.

--- a/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
+++ b/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
@@ -5,7 +5,7 @@ description:
   Prenez un rendez-vous pour vous faire accompagner. La prise de rendez-vous se fait
   en quelques minutes et vous permet de bénéficier d’un accompagnement téléphonique
   d’une vingtaine de minutes par un membre de notre équipe.
-prefix: l'
+prefix: l’
 conditions_generales:
   - type: communes
     values:

--- a/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
+++ b/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
@@ -11,7 +11,7 @@ conditions_generales:
     values:
       - "93001"
 conditions:
-  - Résider à Aubervilliers
+  - Résider à Aubervilliers.
 type: bool
 periodicite: autre
 teleservice: https://www.rdv-aide-numerique.fr/?address=1&departement=AJ

--- a/data/institutions/ville_aubervilliers.yml
+++ b/data/institutions/ville_aubervilliers.yml
@@ -1,4 +1,4 @@
-name: Ville de Aubervilliers
+name: Ville d'Aubervilliers
 imgSrc: img/institutions/logo_ville_aubervilliers.png
 prefix: de la
 type: commune

--- a/src/components/benefit-cta-link.vue
+++ b/src/components/benefit-cta-link.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useStore } from "@/stores/index.js"
 import storageService from "@/lib/storage-service.js"
-import { PropType, computed, defineProps } from "vue"
+import { PropType, computed, defineProps, onMounted, ref } from "vue"
 import { useRouter } from "vue-router"
 import { StandardBenefit } from "@data/types/benefits.d.js"
 import { CTALabel } from "@lib/enums/cta.js"
@@ -13,7 +13,7 @@ const $router = useRouter()
 
 const { benefits } = useBenefits()
 
-const labels = {
+const labels = ref({
   teleservice: {
     short: "Faire une demande en ligne",
     long: "Faire une demande en ligne pour",
@@ -34,7 +34,7 @@ const labels = {
     short: "Plus d'informations",
     long: "Plus d'informations pour",
   },
-}
+})
 
 const props = defineProps({
   analyticsName: String,
@@ -43,14 +43,23 @@ const props = defineProps({
   link: String,
 })
 
-const label = computed(() => (props.type ? labels[props.type].short : null))
+onMounted(() => {
+  if (props.link && props.link.includes("rdv-aide-numerique")) {
+    labels.value.teleservice.short = "Prendre un rendez-vous téléphonique"
+    labels.value.teleservice.long = "Prendre un rendez-vous téléphonique pour"
+  }
+})
+
+const label = computed(() =>
+  props.type ? labels.value[props.type].short : null
+)
 
 const longLabel = computed(() => {
   if (props.type) {
     const prefix = props.benefit.prefix || ""
     const label = props.benefit.label || ""
     const endsWithQuote = prefix.endsWith("’")
-    return `${labels[props.type].long} ${prefix}${
+    return `${labels.value[props.type].long} ${prefix}${
       endsWithQuote ? "" : " "
     }${label} - Nouvelle fenêtre`
   }


### PR DESCRIPTION
Suit la PR https://github.com/betagouv/aides-jeunes/pull/4177 où une modification du label du bouton de teleservice est souhaitable pour remplacer `Faire une demande en ligne` par `Prendre un rendez-vous téléphonique`.
