### PR TITLE
Force l'accompagnement à Aubervilliers à être en haut de la liste

### DIFF
--- a/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
+++ b/data/benefits/javascript/ville-aubervilliers-accompagnement.yml
@@ -15,4 +15,4 @@ type: bool
 periodicite: autre
 teleservice: https://www.rdv-aide-numerique.fr/?address=1&departement=AJ
 link: https://www.rdv-aide-numerique.fr/?address=1&departement=AJ
-top: 0
+top: -1


### PR DESCRIPTION
La recommandation initiale de mettre 0 (zéro) était une mauvaise idée.
En effet, 0 (zéro) est [considéré comme une absence de valeur](https://github.com/betagouv/aides-jeunes/blob/main/data/index.ts#L56) et donc 0 (zéro) est remplacé par la valeur par défaut d'une aide de commune. Et hop l'aide redescend dans la liste.