### PR TITLE
Correction CI - mise à jour des liens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,10 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
       - id: has-changes
-        run: if "${GITHUB_WORKSPACE}/.github/has-file-changes.sh data/benefits" ; then echo "{status}={success}" >> $GITHUB_OUTPUT ; fi
+        run: |
+          if "${GITHUB_WORKSPACE}/.github/has-file-changes.sh" "${GITHUB_WORKSPACE}/data/benefits" ; then
+            echo "status=success" >> $GITHUB_OUTPUT
+          fi
   check_benefit_link_improvements:
     name: Check benefit link improvements and update link table if necessary
     needs: [test_benefit_file_changes]
@@ -381,6 +384,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.18.2"
       - name: Restore node modules
         uses: actions/cache@v3
         id: restore-dependencies

--- a/data/benefits/dynamic/fsl.ts
+++ b/data/benefits/dynamic/fsl.ts
@@ -256,7 +256,7 @@ export const FSL_BY_INSTITUTION_SLUG = {
   },
   departement_du_haut_rhin: {
     label: "du département du Haut-Rhin",
-    link: "https://www.haut-rhin.fr/content/des-aides-pour-votre-logement",
+    link: "https://www.alsace.eu/aides-et-services/habitat/vous-rencontrez-difficultes-avec-votre-logement/",
   },
   departement_rhone: {
     label: "du département du Rhône",


### PR DESCRIPTION
Résolution du problème de [cette tâche](https://trello.com/c/yAXhicTe/1582-%F0%9F%AA%9B-r%C3%A9parer-le-fichier-grist-des-liens-cass%C3%A9s-les-colonnes-dans-une-pr-et-corrig%C3%A9-doivent-se-checker-automatiquement-la-ligne-est)

Suite à une [mise à jour des github actions](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), un correctif avait été réalisé sur la CI pour mettre à jour le statut des aides du Grist. Cependant cela n'était pas fonctionnel : 

### Solution proposée 

1. `echo "{status}={success}" >> $GITHUB_OUTPUT` devient `echo "status=success" >> $GITHUB_OUTPUT`

2. Le script des liens ne s'exécutait pas => j'ai fixé la version de node en reprenant la même version que celle de la github action `check-links-validity.yaml`

3. Correction du lien de l'aide FSL du Haut-Rhin pour les tests