### PR TITLE
Fixbug Sentry - liste des aides bafa/bafd

### DIFF
--- a/src/views/simulation/resultats/benefits-bafa-list.vue
+++ b/src/views/simulation/resultats/benefits-bafa-list.vue
@@ -17,7 +17,7 @@ const groupBenefits = computed(() => {
   const bafaBafdGroup = resultsStore.benefitTree.find(
     (b) => b.id === "bafa-bafd-group"
   ) as BenefitGroup
-  return bafaBafdGroup.benefits
+  return bafaBafdGroup?.benefits
 })
 
 onMounted(async () => {

--- a/src/views/simulation/resultats/benefits-bafa-list.vue
+++ b/src/views/simulation/resultats/benefits-bafa-list.vue
@@ -40,6 +40,10 @@ onMounted(async () => {
       @click="router.push({ name: 'resultats' })"
       >Retour aux résultats
     </BackButton>
-    <BenefitsList :benefits-and-benefit-groups="groupBenefits" />
+    <BenefitsList
+      v-if="groupBenefits"
+      :benefits-and-benefit-groups="groupBenefits"
+    />
+    <p v-else> Aucune aide BAFA ou BAFD n'a été trouvée. </p>
   </div>
 </template>


### PR DESCRIPTION
Correction du bug sentry : https://sentry.incubateur.net/organizations/betagouv/issues/84743/?query=is%3Aunresolved&referrer=issue-stream

Bug assez improbable mais reproductible ainsi: 
- Lancer une simulation en répondant `Oui` pour les aides BAFA et accéder au résultats
- Modifier la simulation en répondant `Non` à la réponse des aides BAFA
- Accéder directement à l'URL http://localhost:8080/simulation/resultats/groupe/bafa-bafd

=> Vue blanche sans possibilité d'interaction

La modification permet de corriger le calcul du computed `groupBenefits` et d'afficher le bouton de retour à la page des résultats