### PR TITLE
Utilise Matomo pour la priorité des liens cassés

### DIFF
--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -8,7 +8,6 @@ import axios from "axios"
 import https from "https"
 import Bluebird from "bluebird"
 import * as Sentry from "@sentry/node"
-import dayjs from "dayjs"
 
 const DEFAULT_BRANCH_REF = "refs/heads/main"
 
@@ -59,23 +58,22 @@ function sleep(ms) {
 }
 
 async function getPriorityStats() {
-  const lastMonth: string = dayjs().subtract(1, "month").format("YYYY-MM-DD")
   const stats = await axios
     .get(
-      `https://aides-jeunes-stats-recorder.osc-fr1.scalingo.io/benefits?startAt=${lastMonth}`
+      "https://stats.data.gouv.fr/index.php?module=API&format=JSON&idSite=165&period=range&date=previous30&method=Events.getName&filter_limit=-1"
     )
     .then((response) => response.data)
 
-  return stats.reduce((priorityMap, benefitStatsEvent) => {
-    const benefitId: string = benefitStatsEvent.id
-    const priority: number = benefitStatsEvent.events.showDetails
+  return stats.reduce((priorityMap, statItem) => {
+    const benefitId: string = statItem.label
+    const priority: number = statItem.nb_visits
 
     if (priority) {
       priorityMap[benefitId] = priority
     }
 
     return priorityMap
-  })
+  }, {})
 }
 
 async function getBenefitData(noPriority: boolean) {


### PR DESCRIPTION
J'ai mis à jour _manuellement_ les priorités actuelles, avec la fonction suivante ajouté temporairement à `tools/check-links-validity.ts`

```ts
async function updatePriorities() {
  if (!process.env.GRIST_DOC_ID) {
    throw new Error("Missing GRIST_DOC_ID")
  }
  if (!process.env.GRIST_API_KEY) {
    throw new Error("Missing GRIST_API_KEY")
  }
  const gristAPI = Grist(process.env.GRIST_DOC_ID, process.env.GRIST_API_KEY)

  const user = await gristAPI.getConnectedUser()
  console.log(`Connected as ${user.name}.`)

  const priorityMap = await getPriorityStats()
  //  console.log(priorityMap)

  const rawExistingWarnings = await gristAPI.get({
    Corrige: [false],
    Aide: benefitIdsFromCLI,
  })
  const updates: GristData[] = []
  rawExistingWarnings.records.forEach((record) => {
    const newPriority = priorityMap[record.fields.Aide] || 0
    if (!newPriority) {
      return
    }
    if (record.fields.Priorite != newPriority) {
      updates.push({
        id: record.id,
        fields: {
          Priorite: newPriority,
        },
      })
    }
  })
  await gristAPI.update(updates)
  console.log("Terminé")
}

```