### PR TITLE
Ajoute la sauvegarde de la position du scroll pour le retour à la page précédente

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -278,16 +278,12 @@ const router = createRouter({
   ],
   // https://router.vuejs.org/guide/advanced/scroll-behavior.html
   scrollBehavior(to, _from, savedPosition) {
-    const defaultScrollOptions: ScrollOptions = { behavior: "smooth" }
     if (savedPosition) {
-      return {
-        ...savedPosition,
-        ...defaultScrollOptions,
-      }
+      return savedPosition
     } else if (to.hash) {
       return {
         el: to.hash,
-        ...defaultScrollOptions,
+        behavior: "smooth",
       }
     }
   },

--- a/src/router.ts
+++ b/src/router.ts
@@ -276,12 +276,18 @@ const router = createRouter({
       },
     },
   ],
-  scrollBehavior(to /*, from, savedPosition*/) {
-    if (to.hash) {
-      // https://router.vuejs.org/guide/advanced/scroll-behavior.html
+  // https://router.vuejs.org/guide/advanced/scroll-behavior.html
+  scrollBehavior(to, _from, savedPosition) {
+    const defaultScrollOptions: ScrollOptions = { behavior: "smooth" }
+    if (savedPosition) {
+      return {
+        ...savedPosition,
+        ...defaultScrollOptions,
+      }
+    } else if (to.hash) {
       return {
         el: to.hash,
-        behavior: "smooth",
+        ...defaultScrollOptions,
       }
     }
   },


### PR DESCRIPTION
https://trello.com/c/cnq3cFaS/1571-revenir-sur-la-position-du-scroll-de-la-page-de-r%C3%A9sultats-au-retour-des-d%C3%A9tails-dune-aide

Suite à la réflexion amenée dans [cette proposition](https://github.com/betagouv/aides-jeunes/pull/4205), on privilégiera pour le moment l'utilisation plus simple de l'historique du navigateur. On passe par le paramétrage du router avec la méthode `scrollBehavor`(déjà utilisée dans le répo) fournie par la dépendance `vue-router`.

À noter : "cette fonctionnalité ne fonctionne que si le navigateur prend en charge history.pushState." 

Source : https://router.vuejs.org/guide/advanced/scroll-behavior.html





