### PR TITLE
Ajoute un filtre sur les aides avec le statut private lors de la détection des liens cassés (Grist)

### DIFF
--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -76,6 +76,10 @@ async function getPriorityStats() {
   }, {})
 }
 
+function filterPublicBenefits(benefits) {
+  return benefits.filter((benefit) => !benefit.private)
+}
+
 async function getBenefitData(noPriority: boolean) {
   let priorityMap = {}
   try {
@@ -85,8 +89,8 @@ async function getBenefitData(noPriority: boolean) {
     Sentry.captureException(error)
     console.warn("Unable to get priority stats, priorityMap is empty")
   }
-
-  const data = Benefits.all.map((benefit) => {
+  const publicBenefits = filterPublicBenefits(Benefits.all)
+  const data = publicBenefits.map((benefit) => {
     const linkMap = ["link", "instructions", "form", "teleservice"]
       .filter(
         (linkType) => benefit[linkType] && typeof benefit[linkType] === "string"


### PR DESCRIPTION
[Tâche Trello](https://trello.com/c/IJfLBKK0/1606-ne-pas-prendre-en-compte-les-aides-avec-private-%C3%A0-true-dans-la-d%C3%A9tection-des-liens-cass%C3%A9s-du-grist)