### PR TITLE
Gère l'intégration iframe directement sur le simulateur et évite les conflits de configuration dans le sessionStorage

### DIFF
--- a/src/stores/iframe.ts
+++ b/src/stores/iframe.ts
@@ -1,10 +1,19 @@
 import { defineStore } from "pinia"
 import storageService from "@/lib/storage-service.js"
 
+function getMode() {
+  return window.parent !== window ? "basic" : "integrated"
+}
+
 export const useIframeStore = defineStore("iframe", {
   state: () => {
-    const { inIframe, iframeHeaderCollapse } =
-      storageService.session.getItem("iframe") || {}
+    const contexts = storageService.session.getItem("iframe") || {
+      basic: {},
+      integrated: {},
+    }
+    const mode = getMode()
+    const { inIframe, iframeHeaderCollapse } = contexts[mode] || {}
+
     return {
       inIframe,
       iframeHeaderCollapse,
@@ -12,9 +21,15 @@ export const useIframeStore = defineStore("iframe", {
   },
   actions: {
     save() {
+      const full = storageService.session.getItem("iframe")
       storageService.session.setItem("iframe", {
-        inIframe: this.inIframe,
-        iframeHeaderCollapse: this.iframeHeaderCollapse,
+        ...full,
+        ...{
+          [getMode()]: {
+            inIframe: this.inIframe,
+            iframeHeaderCollapse: this.iframeHeaderCollapse,
+          },
+        },
       })
     },
     setInIframe() {

--- a/src/stores/iframe.ts
+++ b/src/stores/iframe.ts
@@ -21,9 +21,9 @@ export const useIframeStore = defineStore("iframe", {
   },
   actions: {
     save() {
-      const full = storageService.session.getItem("iframe")
+      const iframeCurrentState = storageService.session.getItem("iframe")
       storageService.session.setItem("iframe", {
-        ...full,
+        ...iframeCurrentState,
         ...{
           [getMode()]: {
             inIframe: this.inIframe,


### PR DESCRIPTION
Le sessionStorage est partagé entre une page et ses intégrations en iframe dans la même page.

La page https://mes-aides.1jeune1solution.beta.gouv.fr/iframe se comporte bizarrement en l'état.
En rafraichissant la page, on applique la configuration de l'iframe intégrée.
Et en rafraichissant à nouveau, on applique la configuration de l'iframe de base.

Cette PR permet d'éviter la mutualisation du session storage.