### PR TITLE
Corrige la légende du LEP

### DIFF
--- a/data/benefits/additional-attributes/index.ts
+++ b/data/benefits/additional-attributes/index.ts
@@ -3,7 +3,6 @@
 import dayjs from "dayjs"
 
 import { Benefit } from "../../types/benefits.js"
-import { OpenfiscaParameters } from "../../../lib/types/parameters.js"
 import { Situation } from "../../../lib/types/situations.js"
 import { Activite } from "../../../lib/enums/activite.js"
 import { StatutOccupationLogement } from "../../../lib/enums/logement.js"
@@ -98,10 +97,6 @@ export const additionalBenefitAttributes = {
     labelFunction: function (b) {
       return `${b.label} avec un taux de ${b.montant}% / an ${b.legend}`
     },
-    legend: (parameters: OpenfiscaParameters) =>
-      `au lieu de ${
-        parameters["taxation_capital.epargne.livret_a.taux"] * 100
-      }%`,
   },
   occitanie_carte_transport_scolaire_lio,
 }


### PR DESCRIPTION
Uniformise l'affichage du LEP par email avec le rendu dans la page des résultats du simulateur.

[Tâche Trello](https://trello.com/c/ojYweJTI/1615-dans-lemail-r%C3%A9cap-cest-%C3%A9crit-6-au-lieu-de-5-pour-le-lep-je-pense-quil-faudrait-juste-%C3%A9crire-5-par-an-comme-sur-la-page-de-r%C3%A9sult)