### PR TITLE
Désactive Chatwoot dans les iframes

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,9 @@
 
     <script>
       ;(function (d, t) {
+        if (window.self !== window.top) {
+          return // Prevents Chatwoot display inside the iframe
+        }
         var BASE_URL = "https://chatwoot.incubateur.net"
         var g = d.createElement(t),
           s = d.getElementsByTagName(t)[0]

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
 
     <script>
       ;(function (d, t) {
-        if (window.self !== window.top) {
+        if (window !== window.top) {
           return // Prevents Chatwoot display inside the iframe
         }
         var BASE_URL = "https://chatwoot.incubateur.net"


### PR DESCRIPTION
Suite à la suggestion de Thomas en [commentaire dans cette PR](https://github.com/betagouv/aides-jeunes/pull/4211#issuecomment-1977023012), il est souhaitable de désactiver Chatwoot dans les intégrations d'iframes pour éviter de recevoir des questions sur des sujets différents du simulateur de 1J1S.

[Tâche Trello](https://trello.com/c/mRgjDrNH/1621-d%C3%A9sactive-chatwoot-dans-les-int%C3%A9grations-en-iframe)