### PR TITLE
Ajoute un loading pour améliorer l'affichage des résultats

### DIFF
--- a/src/lib/simulation.ts
+++ b/src/lib/simulation.ts
@@ -15,9 +15,10 @@ const getLatestId = (): string | undefined => {
 }
 
 const restoreLatestSimulation = async (resultsComputing = true) => {
-  const lastestSimulationId = Simulation.getLatestId()
-  const store = useStore()
   const router = useRouter()
+  const store = useStore()
+  store.calculs.updating = true
+  const lastestSimulationId = Simulation.getLatestId()
   if (!lastestSimulationId) {
     StatisticsMixin.methods.sendEventToMatomo(
       EventCategory.General,
@@ -39,8 +40,9 @@ const restoreLatestSimulation = async (resultsComputing = true) => {
   if (store.simulationAnonymized) {
     await store.retrieveResultsAlreadyComputed()
   } else if (resultsComputing) {
-    store.computeResults()
+    await store.computeResults()
   }
+  store.calculs.updating = false
 }
 
 const restoreLatestSimulationWithoutResultsComputing = async () =>

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -470,13 +470,13 @@ export const useStore = defineStore("store", {
       this.calculs.error = true
       this.calculs.exception = (error.response && error.response.data) || error
     },
-    computeResults() {
+    async computeResults() {
       this.startComputation()
       const token = this.getSimulationToken
       const headers = {
         ...(token && { Authorization: `Bearer ${token}` }),
       }
-      return axios
+      return await axios
         .get(`/api/simulation/${this.simulationId}/results`, {
           headers,
         })

--- a/src/stores/results.ts
+++ b/src/stores/results.ts
@@ -5,12 +5,9 @@ import { hasBafaInterestFlag } from "@/lib/benefits.js"
 import ABTestingService from "@/plugins/ab-testing-service.js"
 
 export const useResultsStore = defineStore("results", {
-  state: () => ({
-    loading: true,
-  }),
   actions: {
-    setLoading(loading: boolean) {
-      this.loading = loading
+    setUpdating(updating: boolean) {
+      useStore().calculs.updating = updating
     },
   },
   getters: {
@@ -81,10 +78,7 @@ export const useResultsStore = defineStore("results", {
       return useStore().saveSituationError
     },
     shouldDisplayResults() {
-      return (
-        !(this.updating || this.hasWarning || this.error || this.loading) &&
-        this.benefits
-      )
+      return !(this.updating || this.hasWarning || this.error) && this.benefits
     },
     simulationAnonymized() {
       return useStore().simulationAnonymized

--- a/src/stores/results.ts
+++ b/src/stores/results.ts
@@ -5,6 +5,14 @@ import { hasBafaInterestFlag } from "@/lib/benefits.js"
 import ABTestingService from "@/plugins/ab-testing-service.js"
 
 export const useResultsStore = defineStore("results", {
+  state: () => ({
+    loading: true,
+  }),
+  actions: {
+    setLoading(loading: boolean) {
+      this.loading = loading
+    },
+  },
   getters: {
     benefits(): StandardBenefit[] {
       return this.resultats?.droitsEligibles || []
@@ -73,7 +81,10 @@ export const useResultsStore = defineStore("results", {
       return useStore().saveSituationError
     },
     shouldDisplayResults() {
-      return !(this.updating || this.hasWarning || this.error) && this.benefits
+      return (
+        !(this.updating || this.hasWarning || this.error || this.loading) &&
+        this.benefits
+      )
     },
     simulationAnonymized() {
       return useStore().simulationAnonymized

--- a/src/views/simulation/resultats/resultats-wrapper.vue
+++ b/src/views/simulation/resultats/resultats-wrapper.vue
@@ -49,6 +49,7 @@ onMounted(async () => {
       store.computeResults()
     }
   }
+  resultsStore.setLoading(false)
 })
 
 onBeforeUnmount(() => {

--- a/src/views/simulation/resultats/resultats-wrapper.vue
+++ b/src/views/simulation/resultats/resultats-wrapper.vue
@@ -32,7 +32,6 @@ const goBack = () => {
 }
 
 onMounted(async () => {
-  setUpdating(true)
   initializeStore()
   handleLegacySituationId()
   if (MockResults.mockResultsNeeded()) {
@@ -48,7 +47,7 @@ onMounted(async () => {
     if (store.simulation.teleservice) {
       await redirectToTeleservice()
     } else {
-      store.computeResults()
+      await store.computeResults()
     }
   }
 })
@@ -135,11 +134,12 @@ const handleSimulationIdQuery = async () => {
 }
 const saveSimulation = async () => {
   try {
+    setUpdating(true)
     store.setSaveSituationError("")
     await store.save()
 
     if (!store.access.forbidden) {
-      store.computeResults()
+      await store.computeResults()
     }
   } catch (error: any) {
     store.setSaveSituationError(error.response?.data || error)
@@ -148,6 +148,8 @@ const saveSimulation = async () => {
       EventAction.ErreurSauvegardeSimulation,
       route.path
     )
+  } finally {
+    setUpdating(false)
   }
 }
 const redirectToTeleservice = async () => {

--- a/src/views/simulation/resultats/resultats-wrapper.vue
+++ b/src/views/simulation/resultats/resultats-wrapper.vue
@@ -18,6 +18,7 @@ const route = useRoute()
 const benefits = computed(() => resultsStore.benefits)
 const fetching = computed(() => resultsStore.fetching)
 const updating = computed(() => resultsStore.updating)
+const setUpdating = (value: boolean) => resultsStore.setUpdating(value)
 const stopSubscription = ref<(() => void) | null>(null)
 const showBackButton = computed(() => {
   return (
@@ -31,6 +32,7 @@ const goBack = () => {
 }
 
 onMounted(async () => {
+  setUpdating(true)
   initializeStore()
   handleLegacySituationId()
   if (MockResults.mockResultsNeeded()) {
@@ -49,7 +51,6 @@ onMounted(async () => {
       store.computeResults()
     }
   }
-  resultsStore.setLoading(false)
 })
 
 onBeforeUnmount(() => {
@@ -127,7 +128,7 @@ const handleSimulationIdQuery = async () => {
     sendAccessToAnonymizedResults()
     await store.retrieveResultsAlreadyComputed()
   } else {
-    store.computeResults()
+    await store.computeResults()
   }
 
   router.replace({ ...router.currentRoute.value, simulationId: null } as any)


### PR DESCRIPTION
Suggestion d'un fix rapide pour fix le bug identifié dans[ cette tâche](https://trello.com/c/0iDz2Uuz/1624-corriger-laffichage-pas-de-r%C3%A9sultats-pr%C3%A9sent-avant-le-calcul-des-r%C3%A9sultats)

~~Preneur d'avis externe. Cette solution ne me satisfait pas complètement et je pense qu'on pourrait aller plus loin en faisant un refacto des logiques updating et fetching du store "index".~~ => réutilisation de la propriété `updating` dans le store `index`