### PR TITLE
Fix le glitch d'affichage sur la page de résultats

### DIFF
--- a/src/stores/results.ts
+++ b/src/stores/results.ts
@@ -78,7 +78,10 @@ export const useResultsStore = defineStore("results", {
       return useStore().saveSituationError
     },
     shouldDisplayResults() {
-      return !(this.updating || this.hasWarning || this.error) && this.resultats
+      return (
+        !(this.updating || this.hasWarning || this.error) &&
+        this.resultats?.droitsEligibles
+      )
     },
     simulationAnonymized() {
       return useStore().simulationAnonymized

--- a/src/stores/results.ts
+++ b/src/stores/results.ts
@@ -78,7 +78,7 @@ export const useResultsStore = defineStore("results", {
       return useStore().saveSituationError
     },
     shouldDisplayResults() {
-      return !(this.updating || this.hasWarning || this.error) && this.benefits
+      return !(this.updating || this.hasWarning || this.error) && this.resultats
     },
     simulationAnonymized() {
       return useStore().simulationAnonymized


### PR DESCRIPTION
Superseeds #4246

La logique historique se basait sur `this.benefits` mais avec #4125 on a forçait  `this.benefits` à toujours renvoyer une liste, même vide.