### PR TITLE
Fix le collapse du header de l'iframe

### DIFF
--- a/iframes/iframe-integration.js
+++ b/iframes/iframe-integration.js
@@ -7,13 +7,7 @@ const src = new URL(`${process.env.BASE_URL}/${page}`)
 src.searchParams.set("iframe", true)
 src.searchParams.set("utm_source", `iframe@${window.location.hostname}`)
 src.searchParams.set("utm_term", window.location.pathname)
-
-if (script.dataset.withLogo !== undefined) {
-  src.searchParams.set("data-with-logo", true)
-}
-if (script.dataset.fromHome !== undefined) {
-  src.searchParams.set("data-from-home", true)
-}
+src.searchParams.set("data-with-logo", script.dataset.withLogo !== undefined)
 if (script.dataset.theme !== undefined) {
   src.searchParams.set("theme", script.dataset.theme)
 }

--- a/src/app.vue
+++ b/src/app.vue
@@ -43,9 +43,8 @@ export default {
       this.iframeStore.setInIframe()
     }
 
-    if (params.has("data-with-logo")) {
-      this.iframeStore.setIframeHeaderCollapse(params.get("data-with-logo"))
-    }
+    const collapseValue = params.get("data-with-logo")
+    this.iframeStore.setIframeHeaderCollapse(collapseValue)
 
     if (params.has("theme")) {
       this.themeStore.set(params.get("theme"))

--- a/src/app.vue
+++ b/src/app.vue
@@ -43,12 +43,16 @@ export default {
       this.iframeStore.setInIframe()
     }
 
-    const collapseValue = params.get("data-with-logo")
-    this.iframeStore.setIframeHeaderCollapse(collapseValue)
+    if (params.has("data-with-logo")) {
+      this.iframeStore.setIframeHeaderCollapse(
+        params.get("data-with-logo") !== "false"
+      )
+    }
 
     if (params.has("theme")) {
       this.themeStore.set(params.get("theme"))
     }
+
     if (
       (window.parent !== window || this.iframeStore.inIframe) &&
       this.themeStore.theme


### PR DESCRIPTION
Corrige l'option sur la page `/iframe` qui ne désactivait plus les logos institutionnels une fois sa checkbox décochée