### PR TITLE
Ajoute de l'AB testing sur l'envoi de SMS

### DIFF
--- a/src/components/modals/recap-email-and-sms-modal.vue
+++ b/src/components/modals/recap-email-and-sms-modal.vue
@@ -2,12 +2,14 @@
 import RecapEmailAndSmsForm from "@/components/recap-email-and-sms-form.vue"
 import { useStore } from "@/stores/index.js"
 import { computed } from "vue"
+import ABTestingService from "@/plugins/ab-testing-service.js"
 
 const store = useStore()
 const hide = () => store.setModalState(undefined)
 
 const headerTitle = computed(() => {
-  return process.env.VITE_SHOW_SMS_TAB
+  return process.env.VITE_SHOW_SMS_TAB &&
+    ABTestingService.getValues().Followup_SMS === "show"
     ? "Recevoir les résultats par email/SMS"
     : "Recevoir les résultats par email"
 })

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -36,7 +36,9 @@ const inputPhonePattern = computed(() => {
   return `^(((\\+?|00)(${diallingCodes})\\s?|0)[67])([\\s\\.\\-]?\\d{2}){4}`
 })
 
-const showSms = process.env.VITE_SHOW_SMS_TAB
+const showSms =
+  process.env.VITE_SHOW_SMS_TAB &&
+  ABTestingService.getValues().Followup_SMS === "show"
 
 StatisticsMixin.methods.sendEventToMatomo(
   EventCategory.Followup,

--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -33,6 +33,7 @@ import Chapters from "@lib/chapters.js"
 import SendRecapButton from "@/components/buttons/send-recap-button.vue"
 import { useStore } from "@/stores/index.js"
 import { useResultsStore } from "@/stores/results.js"
+import ABTestingService from "@/plugins/ab-testing-service.js"
 
 export default {
   name: "TitreChapitre",
@@ -59,12 +60,14 @@ export default {
       )
     },
     emailButtonTitle() {
-      return process.env.VITE_SHOW_SMS_TAB
+      return process.env.VITE_SHOW_SMS_TAB &&
+        ABTestingService.getValues().Followup_SMS === "show"
         ? "Recevoir les résultats par email/SMS"
         : "Recevoir les résultats par email"
     },
     emailModalTitle() {
-      return process.env.VITE_SHOW_SMS_TAB
+      return process.env.VITE_SHOW_SMS_TAB &&
+        ABTestingService.getValues().Followup_SMS === "show"
         ? "Recevoir un récapitulatif"
         : "Recevoir un récapitulatif par email"
     },

--- a/src/components/titre-chapitre.vue
+++ b/src/components/titre-chapitre.vue
@@ -51,6 +51,12 @@ export default {
     shouldDisplayResults() {
       return this.resultsStore.shouldDisplayResults
     },
+    showSMS() {
+      return (
+        process.env.VITE_SHOW_SMS_TAB &&
+        ABTestingService.getValues().Followup_SMS === "show"
+      )
+    },
     title() {
       return this.getTitleByRoute(this.$route)
     },
@@ -60,14 +66,12 @@ export default {
       )
     },
     emailButtonTitle() {
-      return process.env.VITE_SHOW_SMS_TAB &&
-        ABTestingService.getValues().Followup_SMS === "show"
+      return this.showSMS
         ? "Recevoir les résultats par email/SMS"
         : "Recevoir les résultats par email"
     },
     emailModalTitle() {
-      return process.env.VITE_SHOW_SMS_TAB &&
-        ABTestingService.getValues().Followup_SMS === "show"
+      return this.showSMS
         ? "Recevoir un récapitulatif"
         : "Recevoir un récapitulatif par email"
     },

--- a/src/plugins/ab-testing-service.ts
+++ b/src/plugins/ab-testing-service.ts
@@ -73,6 +73,12 @@ function getEnvironment() {
     ABTestingEnvironment.question_debut_chomage.value ||
     (Math.random() > 0.5 ? "reformulation" : "actuelle")
 
+  ABTestingEnvironment.Followup_SMS = ABTestingEnvironment.Followup_SMS || {}
+  ABTestingEnvironment.Followup_SMS.index = 2
+  ABTestingEnvironment.Followup_SMS.value =
+    ABTestingEnvironment.Followup_SMS.value ||
+    (Math.random() > 0.5 ? "show" : "hide")
+
   storageService.local.setItem("ABTesting", ABTestingEnvironment)
   return ABTestingEnvironment
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -271,6 +271,7 @@ const router = createRouter({
           "aides_bafa_fusionnees_conserve_position"
         )
         ABTestingService.setVariant("question_debut_chomage", "reformulation")
+        ABTestingService.setVariant("Followup_SMS", "show")
         return "/"
       },
     },


### PR DESCRIPTION
La proportion du nombre de personnes qui acceptent d'être recontactée après un envoi de récapitulatif a significativement diminué (ok j'ai pas fait un test d'hypothèse) en même temps qu'on a mis en ligne l'envoi de SMS.

Envoyer des SMS ça fait peur et donc les personnes craignent le spam et indiquent ne pas vouloir être recontactées. À voir avec l'AB test.