### PR TITLE
Ajoute l'enregistrement du JSON de la simulation de base en CI dans les artefacts GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,13 +289,13 @@ jobs:
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: cypress-${{matrix.test}}
+          name: cypress-video-${{matrix.test}}
           path: cypress/videos
           retention-days: 10
       - name: Upload cypress payloads
         uses: actions/upload-artifact@v4
         with:
-          name: cypress-${{matrix.test}}
+          name: cypress-json-${{matrix.test}}
           path: cypress/payloads
   check-for-openfisca-requirements-changes:
     name: Check openfisca requirement changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,11 @@ jobs:
           name: cypress-${{matrix.test}}
           path: cypress/videos
           retention-days: 10
+      - name: Upload cypress payloads
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-${{matrix.test}}
+          path: cypress/payloads
   check-for-openfisca-requirements-changes:
     name: Check openfisca requirement changes
     runs-on: ubuntu-20.04

--- a/cypress/utils/results.js
+++ b/cypress/utils/results.js
@@ -274,7 +274,11 @@ const receiveResultsSms = () => {
 }
 
 const checkResultsRequests = () => {
-  cy.wait("@post-simulation").should(({ request, response }) => {
+  cy.wait("@post-simulation").then(({ request, response }) => {
+    cy.writeFile(
+      `cypress/payloads/payload_${Cypress.spec.fileName}.json`,
+      response.body
+    )
     expect(request.method).to.equal("POST")
     expect(response.statusCode).to.equal(200)
   })


### PR DESCRIPTION
L'objectif de cette PR est d'avoir une simulation fonctionnelle à jour à utiliser sur le site d'expérimentation https://aides-jeunes-experimentations.netlify.app/