### PR TITLE
Ajoute la vidéo tutoriel d'ajout d'une aide sur page accueil des liens de l'outil de contribution

### DIFF
--- a/contribuer/pages/index.js
+++ b/contribuer/pages/index.js
@@ -33,6 +33,17 @@ function Home() {
             Guides de contribution (nouvelle fenêtre)
           </a>
         </h3>
+        <br />
+        <h4>
+          Tutoriel vidéo pour ajouter une aide dans l’outil de contribution ⬇️
+        </h4>
+        <video width="600" controls preload="auto">
+          <source
+            src="https://betagouv.github.io/aides-jeunes-files/public/demo-outil-contribution.mp4"
+            type="video/mp4"
+          />
+          Your browser does not support the video tag.
+        </video>
       </main>
     </>
   )

--- a/contribuer/pages/index.js
+++ b/contribuer/pages/index.js
@@ -24,26 +24,31 @@ function Home() {
         <h3>
           <a href="/admin/index.html">Outil de contribution</a>
         </h3>
-        <h3>
-          <a
-            target="_blank"
-            rel="noreferrer"
-            href="https://drive.google.com/drive/folders/1dSsjM6LmLkaPPTe6aNLODtKcfeIruMlG"
-          >
-            Guides de contribution (nouvelle fenêtre)
-          </a>
-        </h3>
-        <br />
-        <h4>
-          Tutoriel vidéo pour ajouter une aide dans l’outil de contribution ⬇️
-        </h4>
-        <video width="600" controls preload="auto">
-          <source
-            src="https://betagouv.github.io/aides-jeunes-files/public/demo-outil-contribution.mp4"
-            type="video/mp4"
-          />
-          Your browser does not support the video tag.
-        </video>
+        <h3>Guides de contribution</h3>
+        <ul>
+          <li>
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href="https://drive.google.com/drive/folders/1dSsjM6LmLkaPPTe6aNLODtKcfeIruMlG"
+            >
+              Documentation textuelle (nouvelle fenêtre)
+            </a>
+          </li>
+          <br />
+          <li>
+            Tutoriel vidéo pour ajouter une aide dans l’outil de contribution ⬇️
+            <br />
+            <br />
+            <video width="600" controls preload="auto">
+              <source
+                src="https://betagouv.github.io/aides-jeunes-files/public/demo-outil-contribution.mp4"
+                type="video/mp4"
+              />
+              Your browser does not support the video tag.
+            </video>
+          </li>
+        </ul>
       </main>
     </>
   )


### PR DESCRIPTION
La vidéo est hébergée page la github page de ce nouveau répo: https://github.com/betagouv/aides-jeunes-files