### PR TITLE
Cache l'aide au permis de la région hauts-de-france 

### DIFF
--- a/data/benefits/openfisca/hauts_de_france_aide_permis.yml
+++ b/data/benefits/openfisca/hauts_de_france_aide_permis.yml
@@ -15,3 +15,4 @@ entity: individus
 openfiscaPeriod: thisMonth
 legend: "maximum"
 periodicite: ponctuelle
+private: true


### PR DESCRIPTION
car l'enveloppe 2023 a été consommée. 
Pas d'information sur la reconduction de l'aide pour septembre 2024.
Veille sur les private:true à faire en juin et en septembre