### PR TITLE
CI:Vérification de lien - Analyse des aides devenues privées en se basant sur les alertes …

### DIFF
--- a/lib/benefits/link-validity.ts
+++ b/lib/benefits/link-validity.ts
@@ -2,7 +2,6 @@ import {
   BenefitLinkProperties,
   GristOperation,
 } from "../types/link-validity.js"
-import { StandardBenefit } from "@data/types/benefits"
 
 function buildPullRequestProcessor(pullRequestURL) {
   function processPullRequest(

--- a/lib/benefits/link-validity.ts
+++ b/lib/benefits/link-validity.ts
@@ -98,3 +98,37 @@ export function determineOperationsOnBenefitLinkError(
 
   return operations
 }
+
+export function determineExistingWarningsFixByPrivateBenefits(
+  existingWarnings,
+  privateBenefits,
+  benefitOperationsList,
+  pullRequestURL?: string
+) {
+  for (const warningBenefitId in existingWarnings) {
+    const privateBenefit = privateBenefits?.filter(
+      (benefit) => benefit.id === warningBenefitId
+    )
+    if (privateBenefit?.length) {
+      for (const type in existingWarnings[warningBenefitId]) {
+        const fixPullRequestUrl =
+          pullRequestURL &&
+          existingWarnings[warningBenefitId][type].fields.PR !== pullRequestURL
+            ? pullRequestURL
+            : existingWarnings[warningBenefitId][type].fields.PR
+        benefitOperationsList.push([
+          {
+            type: "update",
+            data: {
+              id: existingWarnings[warningBenefitId][type].id,
+              fields: {
+                Corrige: true,
+                PR: fixPullRequestUrl,
+              },
+            },
+          },
+        ])
+      }
+    }
+  }
+}

--- a/lib/benefits/link-validity.ts
+++ b/lib/benefits/link-validity.ts
@@ -85,8 +85,7 @@ function processCron(
 export function determineOperationsOnBenefitLinkError(
   existingWarnings,
   benefitLinksCheckResult: BenefitLinkProperties,
-  pullRequestURL?: string,
-  privateBenefits?: StandardBenefit[]
+  pullRequestURL?: string
 ) {
   const processor = pullRequestURL
     ? buildPullRequestProcessor(pullRequestURL)
@@ -97,33 +96,6 @@ export function determineOperationsOnBenefitLinkError(
     const existingWarning = existingWarnings?.[benefitId]?.[link.type]
     processor(benefitLinksCheckResult, link, existingWarning, operations)
   })
-
-  // Analyse des aides devenues privés et donc corrigé dans la list existingWarnings
-  for (const warningBenefitId in existingWarnings) {
-    const privateBenefit = privateBenefits?.filter(
-      (benefit) => benefit.id === warningBenefitId
-    )
-
-    if (privateBenefit?.length) {
-      for (const type in existingWarnings[warningBenefitId]) {
-        const fixPullRequestUrl =
-          pullRequestURL &&
-          existingWarnings[warningBenefitId][type].fields.PR !== pullRequestURL
-            ? pullRequestURL
-            : existingWarnings[warningBenefitId][type].fields.PR
-        operations.push({
-          type: "update",
-          data: {
-            id: existingWarnings[warningBenefitId][type].id,
-            fields: {
-              Corrige: true,
-              PR: fixPullRequestUrl,
-            },
-          },
-        })
-      }
-    }
-  }
 
   return operations
 }

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -80,6 +80,10 @@ function filterPublicBenefits(benefits) {
   return benefits.filter((benefit) => !benefit.private)
 }
 
+export function filterPrivateBenefits(benefits) {
+  return benefits.filter((benefit) => benefit.private)
+}
+
 async function getBenefitData(noPriority: boolean) {
   let priorityMap = {}
   try {
@@ -179,6 +183,7 @@ async function main() {
   const rawExistingWarnings = await gristAPI.get({
     Corrige: [false],
     Aide: benefitIdsFromCLI,
+    Traite: [false],
   })
   const benefitData = await getBenefitData(noPriority)
   const benefitsToAnalyze = filterBenefitDataToProcess(
@@ -204,14 +209,17 @@ async function main() {
     }
   )
 
+  const privateBenefits = filterPrivateBenefits(Benefits.all)
   const benefitOperationsList = benefitLinksCheckResults.map(
     (benefitLinksCheckResult) =>
       determineOperationsOnBenefitLinkError(
         existingWarnings,
         benefitLinksCheckResult,
-        pullRequestURL
+        pullRequestURL,
+        privateBenefits
       )
   )
+
   type RecordsByOperationTypesType = { [operationType: string]: GristData[] }
   const recordsByOperationTypes: RecordsByOperationTypesType = {
     add: [],


### PR DESCRIPTION
https://trello.com/c/Dqfv8fQC/1675-r%C3%A9parer-la-veille-sur-les-liens-cass%C3%A9s

Analyse des liens/institutions cassés et mise à jour de la ligne vers le statut Corriger (true) si l'aide est devenue privée