### PR TITLE
Expérimente l'utilisation de MCP et d'un git gateway 'autohébergé' chez Scalingo

### DIFF
--- a/backend/routes-loader/index.ts
+++ b/backend/routes-loader/index.ts
@@ -3,9 +3,11 @@ import { Application } from "express"
 import api from "./api.js"
 import followupRedirectRoute from "../routes/followup-redirect.js"
 import short from "../routes/short.js"
+import netlify from "../routes/netlify.js"
 
 export function loadRoutes(app: Application): void {
   app.use("/api", api)
   app.use("/followups", followupRedirectRoute)
   app.use("/s", short)
+  app.use("/.netlify/identity", netlify)
 }

--- a/backend/routes/moncomptepro.ts
+++ b/backend/routes/moncomptepro.ts
@@ -1,12 +1,14 @@
 import cookieParser from "cookie-parser"
 import moncompteproController from "../controllers/moncomptepro.js"
 import { Express } from "express"
+import jwt from "jsonwebtoken"
 
 const moncompteproRoutes = function (api: Express) {
   api.get("/login", moncompteproController.login)
   api.get(
     "/auth/redirect",
     cookieParser(),
+    moncompteproController.checkNetlify,
     moncompteproController.access,
     moncompteproController.loginCallbackRedirect
   )

--- a/backend/routes/netlify.js
+++ b/backend/routes/netlify.js
@@ -1,0 +1,52 @@
+import cors from "cors"
+import express from "express"
+import jwt from "jsonwebtoken"
+
+import moncompteproController from "../controllers/moncomptepro.js"
+const api = express()
+
+api.use(cors("*"))
+api.get("/settings", (req, res) => {
+  return res.json({
+    external: {
+      bitbucket: false,
+      github: false,
+      gitlab: false,
+      google: false,
+      mcp: false,
+      email: false,
+      // Astuce, on fait passer MCP pour du SAML
+      // En fait, Netlify permet de faire de l'OpenId Connect (auth via redirections) via la config SAML
+      // Pour allez plus loin, il faudrait prendre le temps de permet la gestion d'autres external providers oauth
+      // cf.
+      // https://github.com/netlify/netlify-identity-widget/blob/master/src/components/app.js#L167-L173
+      saml: true,
+    },
+    disable_signup: true,
+    autoconfirm: false,
+  })
+})
+
+api.get(
+  "/authorize",
+  (req, res, next) => {
+    req.state = "netlify"
+    next()
+  },
+  moncompteproController.login,
+)
+
+api.get("/user", (req, res) => {
+  const sessionSecret = process.env.GIT_GATEWAY_SHARED_SECRET
+  const userInfo = jwt.verify(
+    req.headers.authorization?.slice("Bearer ".length),
+    sessionSecret,
+  )
+  return res.json(userInfo.user_metadata)
+})
+
+api.get("/logout", (req, res) => {
+  return res.json({ message: "TODO" })
+})
+
+export default api

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -3,6 +3,14 @@ backend:
   name: git-gateway-large
   branch: main
   repo: https://github.com/betagouv/aides-jeunes.git
+  gateway_url: https://git-gateway.osc-fr1.scalingo.io
+  # identity_url pas encore fonctionnel, comportement en local trop différent ?!
+  # cf.
+  # https://github.com/search?q=repo%3Anetlify%2Fnetlify-identity-widget%20isLocal&type=code
+  identity_url: /api/.test
+  # De plus pour la réalisation des tests
+  # l'ajout automatique du 'netlifySiteURL' via les dernières lignes de contribuer/public/admin/main.js
+  # a été désactivé
   commit_messages:
     create: Crée {{slug}}
     update: Met à jour {{slug}}

--- a/contribuer/public/admin/main.js
+++ b/contribuer/public/admin/main.js
@@ -132,11 +132,3 @@ class DroitPreviewTemplate extends React.Component {
 
 CMS.registerPreviewTemplate("benefits_openfisca", DroitPreviewTemplate)
 CMS.registerPreviewTemplate("benefits_javascript", DroitPreviewTemplate)
-
-if (document.location.host == "localhost:3000") {
-  const productionURL = "https://contribuer-aides-jeunes.netlify.app/"
-  if (localStorage.getItem("netlifySiteURL") !== productionURL) {
-    window.localStorage.setItem("netlifySiteURL", productionURL)
-    document.location.reload()
-  }
-}


### PR DESCRIPTION
:exploding_head: 

ça marche...

Il faut héberger https://github.com/netlify/git-gateway, l'environnement suivant fonctionne (rien ne semble être mis dans la base de donnée)
```env
DATABASE_URL=gorm.db
GITGATEWAY_DB_DRIVER=sqlite3
GITGATEWAY_GITHUB_ACCESS_TOKEN=xxx
GITGATEWAY_GITHUB_REPO=betagouv/aides-jeunes
GITGATEWAY_JWT_SECRET=zzz
```

Côté serveur Aides Jeunes, il faut aussi un GIT_GATEWAY_SHARED_SECRET qui doit absolument correspondre avec `GITGATEWAY_JWT_SECRET`.

J'ai mis des commentaires en vrac mais la PR reste petite +112 / - 10.

Ça me semble être une bonne itération pour l'interne et des partenaires proches.

Une itération suivante pourrait être la modification de https://github.com/netlify/netlify-identity-widget pour que la charte MonComptePro soit utilisée notamment pour rassurer les partenaires.