### PR TITLE
Cache l'aide VAE de la Bretagne. 

### DIFF
--- a/data/benefits/javascript/region-bretagne-aide-qualif-vae.yml
+++ b/data/benefits/javascript/region-bretagne-aide-qualif-vae.yml
@@ -23,3 +23,4 @@ unit: €
 periodicite: autre
 legend: maximum
 montant: 700
+private: true


### PR DESCRIPTION
Cette aide n'existe plus mais sera peut-être renouvellée plus tard.