### PR TITLE
Corrige l'affichage des logos des institutions dans les emails

### DIFF
--- a/backend/lib/mes-aides/emails/simulation-results.ts
+++ b/backend/lib/mes-aides/emails/simulation-results.ts
@@ -49,7 +49,7 @@ export function formatBenefits(benefits, parameters) {
     }
 
     return assign({}, droit, {
-      imgSrc: getBenefitImage(droit),
+      imgSrc: `/${getBenefitImage(droit)}`,
       montant: value,
       ctaLink: ctaLink,
       ctaLabel: ctaLabel,


### PR DESCRIPTION
La modification de [cette PR](https://github.com/betagouv/aides-jeunes/pull/4290) a cassé le chemin pour afficher les logos des institutions dans l'email des résultats.

Je fais le choix de ne pas remodifier `getBenefitImage` car le chemin d'accès aux logos via l'outil de contribution diffère.