### PR TITLE
Skip le smtp-tester en local

### DIFF
--- a/cypress/utils/results.js
+++ b/cypress/utils/results.js
@@ -12,7 +12,7 @@ const back = () => cy.get('[data-testid="back-button"]').click()
 const IdentifyBenefit = (id, name) => {
   cy.get(
     `[itemtype="http://schema.org/GovernmentService"][data-testid="${id}"]`,
-    { timeout: 10000 }
+    { timeout: 10000 },
   ).as(`${id}-summary`)
   cy.checkA11y()
   getBenefitSummary(id)
@@ -30,7 +30,7 @@ const hasBafaGroupPreviewBenefit = (mustBeDisplay) => {
   } else {
     cy.get(
       `[itemtype="http://schema.org/GovernmentService"][data-testid="${bafaGroupPreviewId}"]`,
-      { timeout: 10000 }
+      { timeout: 10000 },
     ).should("not.exist")
   }
 }
@@ -71,11 +71,11 @@ const hasPrimeActiviteNearbyPlaces = () => {
   cy.get('[data-testid="nearby-places"]').should("be.visible")
   cy.get('[data-testid="lieu-title"]').should(
     "contain",
-    "Caisse d'allocations familiales"
+    "Caisse d'allocations familiales",
   )
   cy.get('[data-testid="lieu-informations-link"]').should(
     "contain",
-    "Voir les informations"
+    "Voir les informations",
   )
 }
 
@@ -206,7 +206,7 @@ const hasVeloGroupPreviewBenefit = (mustBeDisplay) => {
   } else {
     cy.get(
       `[itemtype="http://schema.org/GovernmentService"][data-testid="${veloGroupPreviewId}"]`,
-      { timeout: 10000 }
+      { timeout: 10000 },
     ).should("not.exist")
   }
 }
@@ -249,9 +249,18 @@ const receiveResultsEmail = () => {
   cy.get('[data-testid="simulation-id"')
     .invoke("text")
     .then((simulationId) => {
-      cy.task("getLastEmail", email)
-        .its("headers.subject")
-        .should("includes", simulationId)
+      cy.url().then((url) => {
+        if (url.includes("localhost")) {
+          // skip this test on localhost
+          // todo : implement a solution for testing this feature locally
+          return
+        } else {
+          // Works on CI only
+          cy.task("getLastEmail", email)
+            .its("headers.subject")
+            .should("includes", simulationId)
+        }
+      })
     })
 }
 
@@ -268,7 +277,7 @@ const receiveResultsSms = () => {
         surveyOptin: true,
         phone: "0600000000",
       },
-    }
+    },
   ).as("post-receive-results-sms")
 
   cy.get("[data-testid='send-email-and-sms-button']", {
@@ -292,7 +301,7 @@ const checkResultsRequests = () => {
   cy.wait("@post-simulation").then(({ request, response }) => {
     cy.writeFile(
       `cypress/payloads/${Cypress.spec.fileName}-simulation.json`,
-      response.body
+      response.body,
     )
     expect(request.method).to.equal("POST")
     expect(response.statusCode).to.equal(200)


### PR DESCRIPTION
Le test du smtp sur la CI fonctionne mais échoue avec la config en local via ethreal. Il pourrait être intéressant d'investiguer plus sur la façon de pouvoir le configurer pour qu'il fonctionne aussi en local. 

Je n'ai pas réussi à trouver la bonne configuration pour le moment et mais cela ne me semble pas être une priorité donc, je ne préfère pas investir trop de temps dessus et je laisse donc un commentaire dans le code afin de garder une trace dans l'objectif d'implémenter une solution à l'avenir.

Ressource liée (implémentation actuelle similaire mais non fonctionnelle en l'état : https://www.cypress.io/blog/2021/05/11/testing-html-emails-using-cypress )