### PR TITLE
Montre le pass région ARA aux jeunes inscrits en mission locale

### DIFF
--- a/data/benefits/javascript/auvergne-rhone-alpes-pass-region.yml
+++ b/data/benefits/javascript/auvergne-rhone-alpes-pass-region.yml
@@ -6,7 +6,7 @@ description: Le Pass'Région est une carte délivrée par la Région
   culture, le sport, la santé et sous certaines conditions, une aide financière
   pour le permis.
 conditions:
-  - Être dans l'une des situations suivantes ":" lycéen, apprenti inscrit en CFA ou en OFPA,
+  - "Être dans l'une des situations suivantes : lycéen, apprenti inscrit en CFA ou en OFPA,"
     inscrit à la Mission Locale, inscrit dans une école de la deuxième chance, inscrit en formation sanitaire et sociale,
     inscrit en institut médico-éducatif ou inscrit au CNED.
 conditions_generales:

--- a/data/benefits/javascript/auvergne-rhone-alpes-pass-region.yml
+++ b/data/benefits/javascript/auvergne-rhone-alpes-pass-region.yml
@@ -3,8 +3,12 @@ institution: region_auvergne_rhone_alpes
 description: Le Pass'Région est une carte délivrée par la Région
   Auvergne-Rhône-Alpes qui permet d'accéder à de nombreux avantages en lien avec
   la formation (gratuité des manuels scolaires, financement de l'équipement), la
-  culture, le sport, la santé et, sous certaines conditions, une aide financière
+  culture, le sport, la santé et sous certaines conditions, une aide financière
   pour le permis.
+conditions:
+  - Être dans l'une des situations suivantes ":" lycéen, apprenti inscrit en CFA ou en OFPA,
+    inscrit à la Mission Locale, inscrit dans une école de la deuxième chance, inscrit en formation sanitaire et sociale,
+    inscrit en institut médico-éducatif ou inscrit au CNED.
 conditions_generales:
   - type: regions
     values:
@@ -14,7 +18,11 @@ profils:
     conditions: []
   - type: lyceen
     conditions: []
-link: https://jeunes.auvergnerhonealpes.fr/106-pass-region.htm
+  - type: inactif
+    conditions: []
+  - type: salarie
+    conditions: []
+link: https://www.auvergnerhonealpes.fr/passregion
 teleservice: https://auvergnerhonealpes.zecarte.fr/ARA/Forms/InscriptionBeneficiaire/InfosCarte.aspx
 instructions: https://www.auvergnerhonealpes.fr/aides/beneficier-des-avantages-du-passregion
 prefix: le

--- a/data/benefits/javascript/auvergne-rhone-alpes-pass-region.yml
+++ b/data/benefits/javascript/auvergne-rhone-alpes-pass-region.yml
@@ -6,9 +6,7 @@ description: Le Pass'Région est une carte délivrée par la Région
   culture, le sport, la santé et sous certaines conditions, une aide financière
   pour le permis.
 conditions:
-  - "Être dans l'une des situations suivantes : lycéen, apprenti inscrit en CFA ou en OFPA,"
-    inscrit à la Mission Locale, inscrit dans une école de la deuxième chance, inscrit en formation sanitaire et sociale,
-    inscrit en institut médico-éducatif ou inscrit au CNED.
+  - "Être dans l'une des situations suivantes : lycéen, apprenti inscrit en CFA ou en OFPA, inscrit à la Mission Locale, inscrit dans une école de la deuxième chance, inscrit en formation sanitaire et sociale, inscrit en institut médico-éducatif ou inscrit au CNED."
 conditions_generales:
   - type: regions
     values:


### PR DESCRIPTION
montre l'aide aux salariés ou aux inactifs, 
précise le scope dans les conditions
corrige les liens.