### PR TITLE
Rollback - utilisation de https://cors.isomorphic-git.org & d'une version custom de decap-cms

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -1,8 +1,7 @@
 locale: fr
 backend:
-  name: git-gateway-large
+  name: git-gateway
   branch: main
-  repo: https://github.com/betagouv/aides-jeunes.git
   commit_messages:
     create: Crée {{slug}}
     update: Met à jour {{slug}}
@@ -17,7 +16,7 @@ slug:
   encoding: ascii
   clean_accents: true
 
-# local_backend: true
+local_backend: true
 publish_mode: editorial_workflow
 
 root: ../../..

--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -16,7 +16,7 @@ slug:
   encoding: ascii
   clean_accents: true
 
-local_backend: true
+# local_backend: true
 publish_mode: editorial_workflow
 
 root: ../../..

--- a/contribuer/public/admin/index.html
+++ b/contribuer/public/admin/index.html
@@ -27,10 +27,10 @@
   </head>
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->
-    <!-- <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script> -->
+     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
     <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-    <script src="https://betagouv.github.io/decap-cms/decap-cms.js"></script>
+<!--    <script src="https://betagouv.github.io/decap-cms/decap-cms.js"></script>-->
     <script src="main.js" type="text/babel"></script>
     <script src="description.js"></script>
     <script src="institution.js"></script>

--- a/contribuer/public/admin/index.html
+++ b/contribuer/public/admin/index.html
@@ -27,10 +27,10 @@
   </head>
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->
-     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
     <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-<!--    <script src="https://betagouv.github.io/decap-cms/decap-cms.js"></script>-->
+    <!--<script src="https://betagouv.github.io/decap-cms/decap-cms.js"></script>-->
     <script src="main.js" type="text/babel"></script>
     <script src="description.js"></script>
     <script src="institution.js"></script>


### PR DESCRIPTION
Plusieurs jours de blocage de l'outil de contribution. L'URL https://cors.isomorphic-git.org  avec le repo Aides Jeunes ne renvoyait plus des données correctes. Appel en boucle, code d'erreur me font supposer qu'on a atteint une limite comme indiquer sur la page d'accueil de leur service : 
> If you are cloning or pushing large amounts of data your IP address may be banned. Please run your own instance of the software if you need to make heavy use this service.

https://github.com/betagouv/aides-jeunes/issues/4354