### PR TITLE
Corrige la prise en compte du statut d'occupation du logement sur l'aide domiciliation

### DIFF
--- a/data/benefits/javascript/etat-domiciliation-pour-les-personnes-sans-domicile-stable.yml
+++ b/data/benefits/javascript/etat-domiciliation-pour-les-personnes-sans-domicile-stable.yml
@@ -9,7 +9,7 @@ description:
 prefix: la
 conditions_generales:
   - type: statut_occupation_logement
-    value:
+    includes:
       - sans_domicile
 profils: []
 conditions:


### PR DESCRIPTION
Il faut utiliser le terme `includes` à la place de `value` pour les chaînes de caractères