### PR TITLE
Met à jour l'incitation au covoiturage de Lyon

### DIFF
--- a/data/benefits/javascript/metropole-lyon-aide-covoiturage.yml
+++ b/data/benefits/javascript/metropole-lyon-aide-covoiturage.yml
@@ -1,6 +1,6 @@
 label: incitation au covoiturage
 institution: intercommunalite_metropole_lyon
-description: "Pour encourager le covoiturage, la Métropole de Lyon subventionne tous vos trajets réservés depuis son application web et mobile En Covoit’Grand Lyon. Gain pour le conducteur : entre 1 et 8 euros par passager, en fonction de la longueur du trajet. Coût pour le passager : gratuité pour les détenteur d’une carte d’abonnement aux transports et 0,50€ + 0,10€/km au-delà de 30km pour les autres."
+description: "La Métropole de Lyon subventionne tous vos trajets réservés depuis l'application En Covoit’Grand Lyon. Vous êtes conductrice ou conducteur ? Vous êtes indemnisé entre 1€ et 8€ par trajet et par passager, selon la distance parcourue. Vous êtes passagère ou passager ? Bénéficiez de la gratuité pour les détenteurs d’une carte d’abonnement aux transports, ou de trajets à 50 centimes jusqu'au trentième kilomètre puis 10 centimes par kilomètre supplémentaire pour les autres."
 prefix: l’
 conditions_generales:
   - type: epcis
@@ -14,6 +14,7 @@ conditions:
   - Télécharger l’application mobile En Covoit’Grand Lyon, opérée par Karos.
   - Effectuer un trajet dont la distance est comprise entre 5 et 80 kilomètres.
   - Partir ou arriver dans l’une des 59 communes de la métropole de Lyon.
+  - Effectuer un maximum de 6 trajets par jour si vous êtes conducteur et un maximum de 2 trajets par jour si vous êtes passager.
 type: bool
 periodicite: autre
 link: https://met.grandlyon.com/trajets-quotidien-covoiturage/

--- a/data/benefits/javascript/metropole-lyon-aide-covoiturage.yml
+++ b/data/benefits/javascript/metropole-lyon-aide-covoiturage.yml
@@ -1,6 +1,6 @@
 label: incitation au covoiturage
 institution: intercommunalite_metropole_lyon
-description: "La Métropole de Lyon subventionne tous vos trajets réservés depuis l'application En Covoit’Grand Lyon. Vous êtes conductrice ou conducteur ? Vous êtes indemnisé entre 1€ et 8€ par trajet et par passager, selon la distance parcourue. Vous êtes passagère ou passager ? Bénéficiez de la gratuité pour les détenteurs d’une carte d’abonnement aux transports, ou de trajets à 50 centimes jusqu'au trentième kilomètre puis 10 centimes par kilomètre supplémentaire pour les autres."
+description: "La Métropole de Lyon subventionne vos covoiturages réservés depuis l'application En Covoit’Grand Lyon. Vous êtes conductrice ou conducteur ? Vous êtes indemnisé entre 1€ et 8€ par passager, selon la distance parcourue. Vous êtes passagère ou passager ? Vos trajets sont gratuits si vous avez la carte d’abonnement aux transports et vous coûtent sinon 0,50€ puis 0,10€ par kilomètre au-delà de 30 kilomètres."
 prefix: l’
 conditions_generales:
   - type: epcis

--- a/data/benefits/javascript/metropole-lyon-aide-covoiturage.yml
+++ b/data/benefits/javascript/metropole-lyon-aide-covoiturage.yml
@@ -1,6 +1,6 @@
 label: incitation au covoiturage
 institution: intercommunalite_metropole_lyon
-description: "La Métropole de Lyon subventionne tous vos trajets réservés depuis l'application En Covoit’Grand Lyon. Vous êtes conductrice ou conducteur ? Vous êtes indemnisé entre 1€ et 8€ par trajet et par passager, selon la distance parcourue. Vous êtes passagère ou passager ? Bénéficiez de la gratuité pour les détenteur d’une carte d’abonnement aux transports, ou de trajets à 50 centimes jusqu'au trentième kilomètre puis 10 centimes par kilomètre supplémentaire pour les autres."
+description: "Pour encourager le covoiturage, la Métropole de Lyon subventionne tous vos trajets réservés depuis son application web et mobile En Covoit’Grand Lyon. Gain pour le conducteur : entre 1 et 8 euros par passager, en fonction de la longueur du trajet. Coût pour le passager : gratuité pour les détenteur d’une carte d’abonnement aux transports et 0,50€ + 0,10€/km au-delà de 30km pour les autres."
 prefix: l’
 conditions_generales:
   - type: epcis
@@ -14,7 +14,6 @@ conditions:
   - Télécharger l’application mobile En Covoit’Grand Lyon, opérée par Karos.
   - Effectuer un trajet dont la distance est comprise entre 5 et 80 kilomètres.
   - Partir ou arriver dans l’une des 59 communes de la métropole de Lyon.
-  - Effectuer un maximum de 6 trajets par jour si vous êtes conducteur et un maximum de 2 trajets par jour si vous êtes passager.
 type: bool
 periodicite: autre
 link: https://met.grandlyon.com/trajets-quotidien-covoiturage/

--- a/data/benefits/javascript/metropole-lyon-aide-covoiturage.yml
+++ b/data/benefits/javascript/metropole-lyon-aide-covoiturage.yml
@@ -1,6 +1,6 @@
 label: incitation au covoiturage
 institution: intercommunalite_metropole_lyon
-description: "Pour encourager le covoiturage, la Métropole de Lyon subventionne tous vos trajets réservés depuis son application web et mobile En Covoit’Grand Lyon. Gain pour le conducteur : entre 1 et 8 euros par passager, en fonction de la longueur du trajet. Coût pour le passager : gratuité pour les détenteur d’une carte d’abonnement aux transports et 0,50€ + 0,10€/km au-delà de 30km pour les autres."
+description: "La Métropole de Lyon subventionne tous vos trajets réservés depuis l'application En Covoit’Grand Lyon. Vous êtes conductrice ou conducteur ? Vous êtes indemnisé entre 1€ et 8€ par trajet et par passager, selon la distance parcourue. Vous êtes passagère ou passager ? Bénéficiez de la gratuité pour les détenteur d’une carte d’abonnement aux transports, ou de trajets à 50 centimes jusqu'au trentième kilomètre puis 10 centimes par kilomètre supplémentaire pour les autres."
 prefix: l’
 conditions_generales:
   - type: epcis
@@ -14,6 +14,7 @@ conditions:
   - Télécharger l’application mobile En Covoit’Grand Lyon, opérée par Karos.
   - Effectuer un trajet dont la distance est comprise entre 5 et 80 kilomètres.
   - Partir ou arriver dans l’une des 59 communes de la métropole de Lyon.
+  - Effectuer un maximum de 6 trajets par jour si vous êtes conducteur et un maximum de 2 trajets par jour si vous êtes passager.
 type: bool
 periodicite: autre
 link: https://met.grandlyon.com/trajets-quotidien-covoiturage/

--- a/data/benefits/javascript/metropole-lyon-aide-covoiturage.yml
+++ b/data/benefits/javascript/metropole-lyon-aide-covoiturage.yml
@@ -1,6 +1,6 @@
 label: incitation au covoiturage
 institution: intercommunalite_metropole_lyon
-description: "La Métropole de Lyon subventionne vos covoiturages réservés depuis l'application En Covoit’Grand Lyon. Vous êtes conductrice ou conducteur ? Vous êtes indemnisé entre 1€ et 8€ par passager, selon la distance parcourue. Vous êtes passagère ou passager ? Vos trajets sont gratuits si vous avez la carte d’abonnement aux transports et vous coûtent sinon 0,50€ puis 0,10€ par kilomètre au-delà de 30 kilomètres."
+description: "La Métropole de Lyon subventionne vos covoiturages réservés depuis l’application En Covoit’Grand Lyon. Vous êtes conductrice ou conducteur ? Vous êtes indemnisé entre 1€ et 8€ par passager, selon la distance parcourue. Vous êtes passagère ou passager ? Vos trajets sont gratuits si vous avez la carte d’abonnement aux transports et vous coûtent sinon 0,50€ puis 0,10€ par kilomètre au-delà de 30 kilomètres."
 prefix: l’
 conditions_generales:
   - type: epcis


### PR DESCRIPTION
1) Harmonise la formulation de la description 
2) Précise le nombre maximal de trajets subventionnés