### PR TITLE
Cache le terme "social" pour les revenus qui ne peuvent pas être renseignés en "revenu net social"

### DIFF
--- a/lib/resources.ts
+++ b/lib/resources.ts
@@ -7,6 +7,8 @@ import { Activite } from "./enums/activite.js"
 import { PatrimoineCategory } from "./enums/patrimoine.js"
 import { Resource, ResourceCategory } from "./types/resources.js"
 
+// When adding new resources, make sure to update showSocialLabelList computed property in src/components/ressource/montants.vue
+
 export const ressourceCategories: ResourceCategory[] = [
   {
     id: "revenusActivite",

--- a/src/components/ressource/montants.vue
+++ b/src/components/ressource/montants.vue
@@ -18,7 +18,8 @@
 
       <div v-if="type.displayMonthly === true">
         <label :for="`${type.meta.id}_monthly`" class="fr-label">
-          Indiquez le montant <b>net social mensuel </b> :
+          Indiquez le montant
+          <b>net <span v-if="showSocialLabel">social </span>mensuel </b> :
         </label>
         <div class="fr-container fr-px-0">
           <div class="fr-grid-row">
@@ -113,6 +114,20 @@ const singleValue = computed({
   get: () => props.type.displayMonthly,
   set: (value) => emit("update", "displayMonthly", props.index, value),
 })
+
+const showSocialLabel = computed(
+  () =>
+    ![
+      "gains_exceptionnels",
+      "revenus_locatifs",
+      "revenus_capital",
+      "rpns_micro_entreprise_CA_bic_vente_imp",
+      "rpns_micro_entreprise_CA_bic_service_imp",
+      "rpns_micro_entreprise_CA_bnc_imp",
+      "rpns_benefice_exploitant_agricole",
+      "rpns_autres_revenus",
+    ].includes(props.type.meta.id)
+)
 
 const onFocus = (monthIndex) => {
   focusedInputIndex.value = monthIndex


### PR DESCRIPTION
Pour l'ensemble des revenus, il est demandé d'ajouter le revenu "net social mensuel". 

Je propose donc de cacher le terme "social" pour les revenus qui ne peuvent pas être renseignés ainsi comme les revenus non salariés, les gains exceptionnels et les revenus du patrimoine. 

Ce n'est peut-être pas exhaustif et ouvert à vos suggestions! 