### PR TITLE
Fix la config pour l'export -> corrige le build Netlify (outil de contribution)

### DIFF
--- a/contribuer/next.config.js
+++ b/contribuer/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "export",
   reactStrictMode: true,
 }
 


### PR DESCRIPTION
Le dossier `out` n'est plus généré suite à la commande `export` devenue obsolète.

Source: https://nextjs.org/docs/app/building-your-application/deploying/static-exports