### PR TITLE
Ajoute le type d'email simulation-results-support  [Bloqué, attentes RGPD]

### DIFF
--- a/backend/controllers/emails.ts
+++ b/backend/controllers/emails.ts
@@ -11,6 +11,8 @@ const renderEmailByType = async (followup, emailType: EmailType) => {
   switch (emailType) {
     case EmailType.SimulationResults:
       return emailRender(EmailType.SimulationResults, followup)
+    case EmailType.SimulationResultsSupport:
+      return emailRender(EmailType.SimulationResultsSupport, followup)
     case EmailType.SimulationUsefulness:
       surveyType = SurveyType.TrackClickOnSimulationUsefulnessEmail
       break

--- a/backend/lib/mes-aides/emails/email-render.ts
+++ b/backend/lib/mes-aides/emails/email-render.ts
@@ -20,6 +20,9 @@ const emailTemplate = readFile("templates/email.mjml")
 const footerTemplate = readFile("templates/footer.mjml")
 const headerTemplate = readFile("templates/header.mjml")
 const simulationResultsTemplate = readFile("templates/simulation-results.mjml")
+const simulationResultsSupportTemplate = readFile(
+  "templates/simulation-results-support.mjml"
+)
 const simulationUsefulnessTemplate = readFile(
   "templates/simulation-usefulness.mjml"
 )
@@ -27,16 +30,22 @@ const emailTemplates = {
   [EmailType.SimulationResults]: simulationResultsTemplate,
   [EmailType.BenefitAction]: benefitActionTemplate,
   [EmailType.SimulationUsefulness]: simulationUsefulnessTemplate,
+  [EmailType.SimulationResultsSupport]: simulationResultsSupportTemplate,
 }
 const simulationResultsTextTemplate = readFile(
   "templates/simulation-results.txt"
+)
+const simulationResultsSupportTextTemplate = readFile(
+  "templates/simulation-results-support.txt"
 )
 const benefitActionTextTemplate = readFile("templates/benefit-action.txt")
 const simulationUsefulnessTextTemplate = readFile(
   "templates/simulation-usefulness.txt"
 )
+
 const textTemplates = {
   [EmailType.SimulationResults]: simulationResultsTextTemplate,
+  [EmailType.SimulationResultsSupport]: simulationResultsSupportTextTemplate,
   [EmailType.BenefitAction]: benefitActionTextTemplate,
   [EmailType.SimulationUsefulness]: simulationUsefulnessTextTemplate,
 }
@@ -88,7 +97,10 @@ export async function emailRender(emailType: EmailType, followup) {
   let formatedBenefits: any = {}
   let benefitTexts: any = {}
 
-  if (emailType === EmailType.SimulationResults) {
+  if (
+    emailType === EmailType.SimulationResults ||
+    emailType === EmailType.SimulationResultsSupport
+  ) {
     const populated = await (followup.populated("simulation")
       ? Promise.resolve(followup)
       : followup.populate("simulation"))
@@ -120,6 +132,13 @@ export async function emailRender(emailType: EmailType, followup) {
     if (emailType === EmailType.SimulationResults) {
       return {
         subject: `Récapitulatif de votre simulation sur 1jeune1solution.gouv.fr [${followup.simulation._id}]`,
+        text: values[0],
+        html: values[1].html,
+        attachments: values[1].attachments,
+      }
+    } else if (emailType === EmailType.SimulationResultsSupport) {
+      return {
+        subject: `Récapitulatif d'une simulation utilisateur sur 1jeune1solution.gouv.fr [${followup.simulation._id}]`,
         text: values[0],
         html: values[1].html,
         attachments: values[1].attachments,

--- a/backend/lib/mes-aides/emails/templates/simulation-results-support.mjml
+++ b/backend/lib/mes-aides/emails/templates/simulation-results-support.mjml
@@ -1,0 +1,95 @@
+<mj-section padding="0px 24px">
+  <mj-column>
+    <mj-text padding="0px">
+      <p>
+        <span
+          >Un utilisateur a récemment réalisé une simulation sur le simulateur
+          de
+          <a href="https://mes-aides.1jeune1solution.beta.gouv.fr/"
+            >1jeune1solution.gouv.fr</a
+          >.
+        </span>
+        <br />
+        <br />
+        <span
+          >Retrouvez les détails de cette simulation
+          <a href="{{&returnURL}}" target="_blank">en cliquant ici</a>.
+        </span>
+        <br />
+        <br />
+        <span
+          >D'après la situation décrite par l'utilisateur, l'éligibilité est
+          possible pour les aides suivantes :</span
+        >
+      </p>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+{{#droits}}
+<mj-wrapper padding="16px 0px 0px 0px">
+  <mj-section padding="0px">
+    <mj-column width="556px" background-color="#FFFFFF" padding="16px">
+      <mj-section padding="0px">
+        <mj-group padding="0px">
+          <mj-column width="20%" vertical-align="middle">
+            <mj-image
+              alt="{{institution.label}}"
+              width="60px"
+              align="left"
+              padding="0px"
+              src="{{&baseURL}}{{&imgSrc}}"
+            />
+          </mj-column>
+          <mj-column vertical-align="middle" width="60%">
+            <mj-text align="left" padding="0px 16px">
+              <strong>{{benefitLabel}}</strong>
+            </mj-text>
+          </mj-column>
+          <mj-column vertical-align="middle" width="20%">
+            <mj-text align="right" padding="0px">
+              <strong>{{montant}}</strong>
+            </mj-text>
+          </mj-column>
+        </mj-group>
+      </mj-section>
+      <mj-section padding="0px">
+        <mj-column width="100%" vertical-align="middle" padding="0px">
+          <mj-divider
+            border-width="1px"
+            border-style="solid"
+            border-color="#E7E7E7"
+            padding="16px 0px"
+          />
+        </mj-column>
+      </mj-section>
+      <mj-section padding="0">
+        <mj-column width="100%">
+          <mj-text padding="0px">{{&description}}</mj-text>
+        </mj-column>
+        <mj-column width="100%" padding="0">
+          <mj-button
+            align="left"
+            background-color="#5770be"
+            color="white"
+            href="{{&ctaLink}}"
+            padding="16px 0px 0px 0px"
+          >
+            {{ctaLabel}}
+          </mj-button>
+        </mj-column>
+      </mj-section>
+    </mj-column>
+  </mj-section>
+</mj-wrapper>
+{{/droits}}
+<mj-section padding="0px 24px">
+  <mj-column width="100%" vertical-align="middle" padding="0px">
+    <mj-divider
+      border-width="1px"
+      border-style="solid"
+      border-color="#E7E7E7"
+      padding="32px 0px"
+    />
+  </mj-column>
+</mj-section>

--- a/backend/lib/mes-aides/emails/templates/simulation-results-support.txt
+++ b/backend/lib/mes-aides/emails/templates/simulation-results-support.txt
@@ -1,0 +1,16 @@
+Bonjour,
+
+Un utilisateur a récemment réalisé une simulation sur le simulateur de 1jeune1solution.gouv.fr.
+
+D'après la situation décrite par l'utilisateur, l'éligibilité est possible pour les aides suivantes :
+
+{{#benefitTexts}}
+- {{&.}}
+{{/benefitTexts}}
+
+Retrouvez les détails de cette simulation au lien suivant : {{&returnURL}}
+
+Nous améliorons ce simulateur en continu, et vous pouvez nous y aider. Vous pouvez nous contacter à l'adresse suivante : aides-jeunes@beta.gouv.fr
+
+Bonne journée,
+L'équipe du simulateur de 1jeune1solution.gouv.fr

--- a/backend/lib/messaging/email/email-service.ts
+++ b/backend/lib/messaging/email/email-service.ts
@@ -10,18 +10,19 @@ import { Followup } from "../../../../lib/types/followup.js"
 import dayjs from "dayjs"
 
 export async function sendSimulationResultsEmail(
-  followup: Followup
+  followup: Followup,
+  emailType: EmailType = EmailType.SimulationResults
 ): Promise<Followup> {
   if (!followup.email) {
     throw new Error("Missing followup email")
   }
-  const render: any = await emailRender(EmailType.SimulationResults, followup)
+  const render: any = await emailRender(emailType, followup)
   const sendEmailSmtpResponse = await sendEmailSmtp({
     to: followup.email,
     subject: render.subject,
     text: render.text,
     html: render.html,
-    tags: [EmailType.SimulationResults],
+    tags: [emailType],
   })
 
   followup.sentAt = dayjs().toDate()
@@ -33,6 +34,13 @@ export async function sendSimulationResultsEmail(
   followup.error = undefined
 
   return await followup.save()
+}
+
+export async function sendSimulationResultsSupportEmail(followup: Followup) {
+  return sendSimulationResultsEmail(
+    followup,
+    EmailType.SimulationResultsSupport
+  )
 }
 
 export async function sendSurveyEmail(

--- a/backend/lib/messaging/sending.ts
+++ b/backend/lib/messaging/sending.ts
@@ -6,6 +6,7 @@ import Followups from "../../models/followup.js"
 import { Followup } from "../../../lib/types/followup.js"
 import {
   sendSimulationResultsEmail,
+  sendSimulationResultsSupportEmail,
   sendSurveyEmail,
 } from "../messaging/email/email-service.js"
 import {
@@ -76,6 +77,9 @@ async function processSingleEmail(emailType: EmailType, followupId: string) {
   switch (emailType) {
     case EmailType.SimulationResults:
       await sendSimulationResultsEmail(followup)
+      break
+    case EmailType.SimulationResultsSupport:
+      await sendSimulationResultsSupportEmail(followup)
       break
     case EmailType.SimulationUsefulness:
       await sendSurveyEmail(

--- a/lib/enums/messaging.ts
+++ b/lib/enums/messaging.ts
@@ -1,5 +1,6 @@
 export enum EmailType {
   SimulationResults = "simulation-results",
+  SimulationResultsSupport = "simulation-results-support",
   BenefitAction = "benefit-action",
   SimulationUsefulness = "simulation-usefulness",
   InitialSurvey = "initial-survey",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "tools:institutions-logo-check": "node --loader ts-node/esm ./tools/institutions-logo-check",
     "tools:serve-mail": "node --loader ts-node/esm ./tools/mjml",
     "tools:send-summary-email": "node --loader ts-node/esm ./tools/email-summary-tool",
+    "tools:send-summary-email-support": "node --loader ts-node/esm ./tools/email-summary-tool --support true",
     "tools:send-survey-email": "node --loader ts-node/esm ./tools/email-sending-tool send simulation-usefulness",
     "tools:send-initial-survey-email": "node --loader ts-node/esm ./tools/email-sending-tool send initial-survey --multiple 1000",
     "tools:send-initial-survey-sms": "node --loader ts-node/esm ./tools/sms-sending-tool send initial-survey --multiple 2",

--- a/tools/mjml.ts
+++ b/tools/mjml.ts
@@ -51,6 +51,8 @@ const followupRendering = async (req: Request) => {
   switch (emailType) {
     case EmailType.SimulationResults:
       return emailRender(EmailType.SimulationResults, followup)
+    case EmailType.SimulationResultsSupport:
+      return emailRender(EmailType.SimulationResultsSupport, followup)
     case EmailType.SimulationUsefulness:
       surveyType = SurveyType.TrackClickOnSimulationUsefulnessEmail
       break

--- a/tools/views/index.html
+++ b/tools/views/index.html
@@ -23,6 +23,9 @@
               <span v-if="typeKey === 'simulation-results'"
                 >Résultats de simulation :
               </span>
+              <span v-if="typeKey === 'simulation-results-support'"
+                >Résultats de simulation (vue du support):
+              </span>
               <span v-else-if="typeKey === 'benefit-action'"
                 >Mail de sondage de la prise d'action suite aux résultats de la
                 simulation (benefit-action) :


### PR DESCRIPTION
Feature en prévision de la PR #4391 

Nouveau type d'email fortement similaire à celui des résultats de simulation pour l'usager, cet email est destiné aux agents de CCAS et leur adressera les résultats de simulation des usagers rattachés à leur centre.