### PR TITLE
Investigation sur le problème d'envoi d'emails de sondage

### DIFF
--- a/backend/lib/messaging/email/email-service.ts
+++ b/backend/lib/messaging/email/email-service.ts
@@ -40,7 +40,9 @@ export async function sendSurveyEmail(
   surveyType: SurveyType
 ): Promise<Survey> {
   if (!followup.email) {
-    throw new Error("Missing followup email")
+    throw new Error(
+      `${dayjs().toISOString()} - Missing followup email: ${followup}`
+    )
   }
   const survey = await followup.addSurveyIfMissing(surveyType)
   const render: any = await emailRenderBySurveyType(surveyType, followup)

--- a/backend/lib/messaging/email/email-service.ts
+++ b/backend/lib/messaging/email/email-service.ts
@@ -40,8 +40,9 @@ export async function sendSurveyEmail(
   surveyType: SurveyType
 ): Promise<Survey> {
   if (!followup.email) {
+    const date = dayjs().toString()
     throw new Error(
-      `${dayjs().toISOString()} - Missing followup email: ${followup}`
+      `${date} - Missing followup email (id : ${followup.get("_id")})`
     )
   }
   const survey = await followup.addSurveyIfMissing(surveyType)

--- a/backend/lib/messaging/sending.ts
+++ b/backend/lib/messaging/sending.ts
@@ -29,6 +29,9 @@ async function sendMultipleEmails(emailType: EmailType, limit: number) {
 
 async function sendMultipleInitialEmails(limit: number) {
   const followups: any[] = await Followups.find({
+    email: {
+      $exists: true,
+    },
     surveys: {
       $not: {
         $elemMatch: {
@@ -43,6 +46,7 @@ async function sendMultipleInitialEmails(limit: number) {
     },
     sentAt: {
       $lt: dayjs().subtract(DaysBeforeInitialSurvey, "day").toDate(),
+      $gt: dayjs("2024-01-01").toDate(),
     },
     surveyOptin: true,
   })
@@ -148,6 +152,7 @@ function initialSurveySmsMongooseCriteria(): any {
     },
     smsSentAt: {
       $lt: getDaysBeforeInitialSurveyDate(),
+      $gt: dayjs("2024-01-01").toDate(),
     },
     surveyOptin: true,
   }


### PR DESCRIPTION
## Constat du problème 
Depuis le 6 juillet, aucun email de sondage n'a été envoyé suite au merge d'un refacto sur les types de sondages le 5 juillet ( #4416 ).

## Solution envisagée et debug

J'ai ajouté des infos pour debug, et affiné les conditions d'envoi. J'ai l'impression que suite au refaco, les followups sélectionnés pour l'envoi multiple (via le cron de l'ops) sont très anciens et ne contiennent pas d'email (anonymisés ?), d'où l'ajout de condition sur leur date d'envoi et sur leur champ `email`. 

Au passage, j'en ai profité pour ajouter cette même condition sur l'envoi des sondages par SMS.
