### PR TITLE
Supprime les réponses associées à un enfant quand il est supprimé dans le store

### DIFF
--- a/cypress/e2e/family.cy.js
+++ b/cypress/e2e/family.cy.js
@@ -20,7 +20,9 @@ context("Full simulation", () => {
     profil.defaultIndivu()
 
     foyer.kindergartenChildren()
-    foyer.children(2)
+    foyer.deleteChilden(0)
+    foyer.kindergartenChildren()
+    foyer.children(1, 2)
     foyer.fill_en_couple(true)
     profil.defaultConjoint()
 

--- a/cypress/e2e/family.cy.js
+++ b/cypress/e2e/family.cy.js
@@ -20,7 +20,7 @@ context("Full simulation", () => {
     profil.defaultIndivu()
 
     foyer.kindergartenChildren()
-    foyer.deleteChilden(0)
+    foyer.deleteChildren(0)
     foyer.kindergartenChildren()
     foyer.children(1, 2)
     foyer.fill_en_couple(true)

--- a/cypress/utils/foyer.js
+++ b/cypress/utils/foyer.js
@@ -22,7 +22,7 @@ const kindergartenChildren = () => {
   urlInclude("enfants")
 }
 
-const deleteChilden = (index) => {
+const deleteChildren = (index) => {
   cy.get(`[data-testid="row-enfant_${index}"]`).should("be.visible")
   cy.get(`[data-testid="delete-enfant_${index}"]`).click()
   cy.get(`[data-testid="row-enfant_${index}"]`).should("not.exist")
@@ -74,7 +74,7 @@ const fill_rsa_isolement_recent = (isolement) => {
 export default {
   children,
   kindergartenChildren,
-  deleteChilden,
+  deleteChildren,
   checkChildrenNumber,
   fill_en_couple,
   fill__situation,

--- a/cypress/utils/foyer.js
+++ b/cypress/utils/foyer.js
@@ -2,13 +2,14 @@ import { fillRadio, submit } from "./form.js"
 import profil from "./profil.js"
 import { urlInclude } from "./controllers.js"
 
-const children = (numberOfChildren) => {
+const children = (numberOfChildren, totalToCheck = numberOfChildren) => {
   for (let i = 0; i < numberOfChildren; i++) {
     urlInclude("enfants")
     cy.checkA11y()
     cy.get('[data-testid="add-pac"]').click()
     profil.defaultChildren()
   }
+  checkChildrenNumber(totalToCheck)
   urlInclude("enfants")
   submit()
 }
@@ -19,6 +20,18 @@ const kindergartenChildren = () => {
   cy.get('[data-testid="add-pac"]').click()
   profil.kindergartenChildren()
   urlInclude("enfants")
+}
+
+const deleteChilden = (index) => {
+  cy.get(`[data-testid="row-enfant_${index}"]`).should("be.visible")
+  cy.get(`[data-testid="delete-enfant_${index}"]`).click()
+  cy.get(`[data-testid="row-enfant_${index}"]`).should("not.exist")
+}
+
+const checkChildrenNumber = (numberOfChildren) => {
+  for (let i = 0; i < numberOfChildren; i++) {
+    cy.get(`[data-testid="row-enfant_${i}"]`).should("be.visible")
+  }
 }
 
 const fill_en_couple = (enCouple) => {
@@ -61,6 +74,8 @@ const fill_rsa_isolement_recent = (isolement) => {
 export default {
   children,
   kindergartenChildren,
+  deleteChilden,
+  checkChildrenNumber,
   fill_en_couple,
   fill__situation,
   fill_bourse_criteres_sociaux_nombre_enfants_a_charge,

--- a/src/router.ts
+++ b/src/router.ts
@@ -353,6 +353,23 @@ router.beforeEach((to, from, next) => {
     store.decrementMessageRemainingViewTime()
   }
 
+  // When a child has been removed from the /enfants step, the previous child questions should be skipped
+  const { current } = window.history.state
+  const enfantPath = "/individu/enfant_"
+
+  if (current.includes(enfantPath)) {
+    const id_enfant = current.split(enfantPath)[1].split("/")[0]
+    const hasStoreChild = store.situation.enfants.find(
+      (enfant) => enfant.id === `enfant_${id_enfant}`
+    )
+
+    if (!hasStoreChild) {
+      // go(-2) used to skip the "/enfants" step on the removed child first step "_firstName"
+      const stepsToGoBack = current.includes("_firstName") ? -2 : -1
+      return router.go(stepsToGoBack)
+    }
+  }
+
   next()
 })
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -378,6 +378,12 @@ export const useStore = defineStore("store", {
       this.simulation = {
         ...this.simulation,
         enfants: this.simulation.enfants?.filter((i) => i !== enfantIndex),
+        answers: {
+          all: this.simulation.answers.all.filter((answer) => answer.id !== id),
+          current: this.simulation.answers.current.filter(
+            (answer) => answer.id !== id
+          ),
+        },
       }
       this.setDirty()
     },

--- a/src/views/simulation/enfants.vue
+++ b/src/views/simulation/enfants.vue
@@ -10,7 +10,12 @@
         >
       </legend>
       <div class="fr-fieldset__content">
-        <div v-for="enfant in enfants" :key="enfant.id" class="fr-mb-4w">
+        <div
+          v-for="enfant in enfants"
+          :key="enfant.id"
+          class="fr-mb-4w"
+          :data-testid="`row-${enfant.id}`"
+        >
           <div v-if="enfant.date_naissance">
             <div class="fr-container fr-px-0">
               <div class="fr-grid-row fr-grid-row--middle">
@@ -29,6 +34,7 @@
                     <li
                       ><button
                         class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-mb-0"
+                        :data-testid="`delete-${enfant.id}`"
                         @click="removePAC(enfant.id)"
                         >supprimer</button
                       ></li


### PR DESCRIPTION
- [x] Améliore la suppression d'un enfant sur la page `/enfants` (logique historique incomplète)
- [x] Ajoute une logique de redirection pour éviter les questions associées à un enfant préalablement supprimé
- [x] Ajoute des tests e2e pour valider la suppression et la bonne redirection d'un enfant supprimé