### PR TITLE
Investigation historique window.history

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -11,6 +11,7 @@ import BandeauDemo from "@/components/bandeau-demo.vue"
 import context from "@/context/index.js"
 import { useIframeStore } from "@/stores/iframe.js"
 import { useThemeStore } from "@/stores/theme.js"
+import { useHistoryStore } from "@/stores/history.js"
 
 const { Layout } = context
 
@@ -24,9 +25,11 @@ export default {
   setup() {
     const iframeStore = useIframeStore()
     const themeStore = useThemeStore()
+    const historyStore = useHistoryStore()
     return {
       iframeStore,
       themeStore,
+      historyStore,
     }
   },
   computed: {

--- a/src/stores/history.ts
+++ b/src/stores/history.ts
@@ -1,0 +1,25 @@
+import { defineStore } from "pinia"
+import storageService from "@/lib/storage-service.js"
+
+export const useHistoryStore = defineStore("history", {
+  state: () => {
+    return {
+      historyStateEnfants: storageService.session.getItem(
+        "historyStateEnfants"
+      ),
+    }
+  },
+  actions: {
+    setHistoryStateEnfants(historyStateEnfants) {
+      if (historyStateEnfants) {
+        storageService.session.setItem(
+          "historyStateEnfants",
+          historyStateEnfants
+        )
+      }
+      this.historyStateEnfants = storageService.session.getItem(
+        "historyStateEnfants"
+      )
+    },
+  },
+})

--- a/src/views/simulation/enfants.vue
+++ b/src/views/simulation/enfants.vue
@@ -76,6 +76,7 @@ import Nationality from "@/lib/nationality.js"
 import EnSavoirPlus from "@/components/en-savoir-plus.vue"
 import ScolariteCategories from "@lib/scolarite"
 import { useStore } from "@/stores/index.js"
+import { useHistoryStore } from "@/stores/history.js"
 
 export default {
   name: "SimulationEnfants",
@@ -86,12 +87,19 @@ export default {
   setup() {
     return {
       store: useStore(),
+      historyStore: useHistoryStore(),
     }
   },
   computed: {
     enfants() {
       return this.store.situation.enfants || []
     },
+  },
+  created() {
+    const historyState = window.history.state
+    if (historyState.back === "/simulation/individu/demandeur/enceinte") {
+      this.historyStore.setHistoryStateEnfants(historyState)
+    }
   },
 
   methods: {
@@ -106,6 +114,14 @@ export default {
     },
     removePAC(id) {
       this.store.removeEnfant(id)
+      const currentState = window.history.state
+      if (currentState.back.includes("enfant_a_charge")) {
+        const actualPosition = currentState.position
+        const previousPosition = this.historyStore.historyStateEnfants.position
+        const positionDiff = actualPosition - previousPosition
+        window.history.go(-positionDiff)
+        this.historyStore.setHistoryStateEnfants(window.history.state)
+      }
     },
     editPAC(id) {
       this.store.editEnfant()


### PR DESCRIPTION
Travaux d'investigation sur la sauvegarde l'état de la page des enfants dans le store. On revient à l'historique précédent si un enfant est supprimé mais cela engendre des bugs complexe dans diverses situations (ex: ajout de 2 enfants + suppression d'un des enfants => skip la page de récap des enfants). 

Le plus simple étant dans laisser gérer l'historique du navigateur...