### PR TITLE
Unit test : gestion du mode offline d'openfisca pour la récupération des paramètres.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,21 @@ jobs:
           key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Run schema-validation-config.spec.ts
         run: npm run test -- tests/integration/schema-validation-config.spec.ts
+  unit_tests:
+    name: Unit tests
+    needs: [install, check_data_file_consistency]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Restore node modules
+        uses: actions/cache@v3
+        id: restore-dependencies
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
+      - name: Jest
+        run: npm run test
   build:
     name: Build
     needs: [install]
@@ -177,21 +192,6 @@ jobs:
         run: |
           source .venv/bin/activate
           npm run test tests/unit/openfisca/test.spec.ts
-  unit_tests:
-    name: Unit tests
-    needs: [install, check_data_file_consistency]
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Restore node modules
-        uses: actions/cache@v3
-        id: restore-dependencies
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
-      - name: Jest
-        run: npm run test
   iframe_build_control:
     name: Iframe build control
     needs: [install]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,21 +96,6 @@ jobs:
           key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
       - name: Run schema-validation-config.spec.ts
         run: npm run test -- tests/integration/schema-validation-config.spec.ts
-  unit_tests:
-    name: Unit tests
-    needs: [install, check_data_file_consistency]
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Restore node modules
-        uses: actions/cache@v3
-        id: restore-dependencies
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
-      - name: Jest
-        run: npm run test
   build:
     name: Build
     needs: [install]
@@ -192,6 +177,21 @@ jobs:
         run: |
           source .venv/bin/activate
           npm run test tests/unit/openfisca/test.spec.ts
+  unit_tests:
+    name: Unit tests
+    needs: [install, check_data_file_consistency]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Restore node modules
+        uses: actions/cache@v3
+        id: restore-dependencies
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
+      - name: Jest
+        run: npm run test
   iframe_build_control:
     name: Iframe build control
     needs: [install]

--- a/lib/benefits/compute.ts
+++ b/lib/benefits/compute.ts
@@ -8,7 +8,10 @@ import { BenefitCatalog } from "../../data/types/generator.d.js"
 import { Resultats } from "@lib/types/store.js"
 import { datesGenerator } from "../dates.js"
 import { getBenefitLegend } from "./details.js"
-import { getParameters } from "../../backend/lib/openfisca/parameters.js"
+import {
+  getParameters,
+  parametersList,
+} from "../../backend/lib/openfisca/parameters.js"
 
 /**
  * OpenFisca test cases separate ressources between two entities: individuals and families.
@@ -63,7 +66,8 @@ export function computeAides(
   situation: Situation,
   id: string,
   openfiscaResponse,
-  showPrivate?: boolean
+  showPrivate?: boolean,
+  openfiscaDefaultParameters: boolean = false
 ) {
   const periods = datesGenerator(situation.dateDeValeur)
 
@@ -133,7 +137,9 @@ export function computeAides(
           }
         : benefit.institution
 
-      const openfiscaParameters = getParameters(situation.dateDeValeur)
+      const openfiscaParameters = openfiscaDefaultParameters
+        ? parametersList
+        : getParameters(situation.dateDeValeur)
 
       result.droitsEligibles!.push(
         // @ts-ignore

--- a/tests/unit/compute-aides.spec.ts
+++ b/tests/unit/compute-aides.spec.ts
@@ -80,7 +80,7 @@ describe("computeAides", function () {
     let ids
 
     beforeEach(function () {
-      droits = compute(situation, "id", openfiscaResult)
+      droits = compute(situation, "id", openfiscaResult, false, true)
       ids = droits.droitsInjectes.map((d) => d.id)
     })
 
@@ -101,7 +101,7 @@ describe("computeAides", function () {
 
   describe("computeAides of numeric value", function () {
     beforeEach(function () {
-      droits = compute(situation, "id", openfiscaResult)
+      droits = compute(situation, "id", openfiscaResult, false, true)
     })
 
     it("should extract droits from openfisca result", function () {
@@ -126,7 +126,7 @@ describe("computeAides", function () {
       openfiscaResult.individus.demandeur.logement_social_eligible = {
         "2014-11": true,
       }
-      droits = compute(situation, "id", openfiscaResult, true)
+      droits = compute(situation, "id", openfiscaResult, true, true)
     })
 
     it("should extract eligibles droits from openfisca result", function () {
@@ -140,7 +140,7 @@ describe("computeAides", function () {
 
   describe("computeAides extraction of local partenaire without prestation", function () {
     beforeEach(function () {
-      droits = compute(situation, "id", openfiscaResult)
+      droits = compute(situation, "id", openfiscaResult, false, true)
     })
 
     it("should exclude local partenaire without prestation", function () {
@@ -154,7 +154,7 @@ describe("computeAides", function () {
 
   describe("computeAides exclude private aids", function () {
     beforeEach(function () {
-      droits = compute(situation, "id", openfiscaResult)
+      droits = compute(situation, "id", openfiscaResult, false, true)
     })
 
     it("should exclude private aid", function () {
@@ -173,7 +173,7 @@ describe("computeAides", function () {
       openfiscaResult.familles._.cmu_c = {
         "2014-11": true,
       }
-      droits = compute(situation, "id", openfiscaResult)
+      droits = compute(situation, "id", openfiscaResult, false, true)
 
       const css = droits.droitsEligibles.find(
         (droit) => droit.id === "css_participation_forfaitaire"
@@ -186,7 +186,7 @@ describe("computeAides", function () {
       openfiscaResult.familles._.cmu_c = {
         "2014-11": false,
       }
-      droits = compute(situation, "id", openfiscaResult)
+      droits = compute(situation, "id", openfiscaResult, false, true)
 
       const css = droits.droitsEligibles.find(
         (droit) => droit.id === "css_participation_forfaitaire"


### PR DESCRIPTION
Liée à #4531 
A merge avant la #4545

Il n'y a plus d'erreur dans les logs, comme c'est présent dans la PR https://github.com/betagouv/aides-jeunes/pull/4556