### PR TITLE
Met à jour le FSL des Alpes de Haute Provence. Cache les dispositifs "jeunes à l'international" de la région Bretagne.

### DIFF
--- a/data/benefits/dynamic/fsl.ts
+++ b/data/benefits/dynamic/fsl.ts
@@ -23,8 +23,8 @@ export const FSL_BY_INSTITUTION_SLUG = {
   },
   departement_alpes_de_haute_provence: {
     label: "du département des Alpes-de-Haute-Provence",
-    link: "https://www.mondepartement04.fr/insertion/acces-au-logement",
-    instructions: "https://www.mondepartement04.fr/insertion/acces-au-logement",
+    link: "https://www.mondepartement04.fr/insertion/le-fonds-de-solidarite-pour-le-logement",
+    form: "https://www.mondepartement04.fr/fileadmin/mediatheque/cg04/document/03-services-habitants/FSL/FSL_FORMULAIRE_01-2022.pdf",
   },
   departement_hautes_alpes: {
     label: "du département des Hautes Alpes",

--- a/data/benefits/javascript/bretagne-jeune-international.yml
+++ b/data/benefits/javascript/bretagne-jeune-international.yml
@@ -35,3 +35,4 @@ periodicite: mensuelle
 legend: maximum
 montant: 200
 interestFlag: _interetEtudesEtranger
+private: true

--- a/data/benefits/javascript/region-bretagne-bourse-international-bts-dut.yml
+++ b/data/benefits/javascript/region-bretagne-bourse-international-bts-dut.yml
@@ -32,3 +32,4 @@ periodicite: mensuelle
 legend: maximum
 montant: 200
 interestFlag: _interetEtudesEtranger
+private: true

--- a/data/benefits/javascript/region-bretagne-bourse-international-formation-sanitaires-sociales.yml
+++ b/data/benefits/javascript/region-bretagne-bourse-international-formation-sanitaires-sociales.yml
@@ -30,3 +30,4 @@ periodicite: mensuelle
 legend: maximum
 montant: 200
 interestFlag: _interetEtudesEtranger
+private: true

--- a/data/benefits/javascript/region-bretagne-bourse-international-lycee-pro.yml
+++ b/data/benefits/javascript/region-bretagne-bourse-international-lycee-pro.yml
@@ -32,3 +32,4 @@ unit: €
 periodicite: ponctuelle
 montant: 460
 interestFlag: _interetEtudesEtranger
+private: true


### PR DESCRIPTION
email de la région Bretagne :
"Suite à votre question, je vous informe que le dispositif régional « jeunes à l’international » a été supprimé à l’issue de l’année scolaire et universitaire 2023/24. Il est remplacé par une nouvelle action : B-MONDE « mobilité individuelle ».
 
Vous trouverez ci-dessus le lien internet :
 
 
https://www.bretagne.bzh/aides/fiches/b-monde-mobilite-individuelle/"