### PR TITLE
chore: reduce sentry tracesSampleRate

### DIFF
--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -118,7 +118,7 @@ const config: Configuration = {
     project: process.env.SENTRY_BACKEND_PROJECT,
     environment: process.env.NODE_ENV,
     integrations: [nodeProfilingIntegration()],
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 0.1,
     profilesSampleRate: 1.0,
     debug: "development" === process.env.NODE_ENV,
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ if (process.env?.VITE_SENTRY_FRONTEND_DSN) {
       Sentry.browserTracingIntegration({ router }),
       Sentry.replayIntegration(),
     ],
-    tracesSampleRate: 1.0,
+    tracesSampleRate: 0.1,
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1.0,
     debug: "development" === process.env.VITE_CONTEXT,


### PR DESCRIPTION
Reduce sentry `tracesSampleRate` as it produces +170k events/day

<img width="801" alt="Capture d’écran 2024-09-17 à 13 49 09" src="https://github.com/user-attachments/assets/b70e8d03-7b4d-4827-a18d-507f2737e2be">
