### PR TITLE
Meilleure gestion d'erreur dans les numéros de téléphone

### DIFF
--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -82,10 +82,13 @@ export async function persist(req: Request, res: Response) {
       return createSimulationRecapUrl(req, res)
     }
   } catch (error: any) {
-    Sentry.captureException(error)
     if (error.name === "ValidationError") {
+      if (!error.message || !error.message?.includes("wrongPhoneNumber")) {
+        Sentry.captureException(error)
+      }
       return res.status(403).send(error.message)
     } else {
+      Sentry.captureException(error)
       return res.status(500).send(`Error while persisting followup`)
     }
   }

--- a/backend/models/followup-schema.ts
+++ b/backend/models/followup-schema.ts
@@ -22,7 +22,7 @@ const FollowupSchema = new mongoose.Schema<Followup, FollowupModel>(
       type: String,
       validate: {
         validator: validator.isMobilePhone,
-        message: "wrongPhoneNumber",
+        message: "Numéro de téléphone invalide",
         isAsync: false,
       },
     },

--- a/backend/models/followup-schema.ts
+++ b/backend/models/followup-schema.ts
@@ -22,7 +22,7 @@ const FollowupSchema = new mongoose.Schema<Followup, FollowupModel>(
       type: String,
       validate: {
         validator: validator.isMobilePhone,
-        message: "Numéro de téléphone invalide",
+        message: "wrongPhoneNumber",
         isAsync: false,
       },
     },

--- a/src/components/modals/errors-email-and-sms-modal.vue
+++ b/src/components/modals/errors-email-and-sms-modal.vue
@@ -18,12 +18,7 @@ const recapEmailState = computed(() => store.recapEmailState)
         "
         class="fr-alert fr-alert--error"
       >
-        <p v-if="recapPhoneState === 'wrongPhoneNumber'">
-          Le numéro de téléphone est invalide. Nous vous recommandons de
-          vérifier votre numéro de téléphone ou de saisir uniquement votre
-          adresse e-mail.
-        </p>
-        <p v-else>
+        <p>
           Une erreur s'est produite dans l'envoi par
           {{
             recapPhoneState === "error" && recapEmailState === "error"

--- a/src/components/modals/errors-email-and-sms-modal.vue
+++ b/src/components/modals/errors-email-and-sms-modal.vue
@@ -11,10 +11,19 @@ const recapEmailState = computed(() => store.recapEmailState)
   <div class="fr-pb-3w">
     <div v-if="recapPhoneState != 'waiting' && recapEmailState != 'waiting'">
       <div
-        v-if="recapPhoneState === 'error' || recapEmailState === 'error'"
+        v-if="
+          recapPhoneState === 'error' ||
+          recapEmailState === 'error' ||
+          recapPhoneState === 'wrongPhoneNumber'
+        "
         class="fr-alert fr-alert--error"
       >
-        <p>
+        <p v-if="recapPhoneState === 'wrongPhoneNumber'">
+          Le numéro de téléphone est invalide. Nous vous recommandons de
+          vérifier votre numéro de téléphone ou de saisir uniquement votre
+          adresse e-mail.
+        </p>
+        <p v-else>
           Une erreur s'est produite dans l'envoi par
           {{
             recapPhoneState === "error" && recapEmailState === "error"

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -215,13 +215,8 @@ const ctaText = ref(computeCtaText())
   <div class="fr-modal__content">
     <p>
       Si vous le souhaitez nous pouvons vous recontacter à deux reprises pour
-      faire le point sur les démarches que vous avez faites et les blocages que
-      vous avez rencontrés.
+      faire le point sur vos démarches et sur les blocages rencontrés.
     </p>
-    <p
-      >Vous pouvez saisir uniquement votre adresse e-mail pour être sur de
-      recevoir le recapitulatif.</p
-    >
     <form class="fr-form fr-my-2w" @submit.prevent="sendRecap(true)">
       <div class="fr-form-group">
         <label class="fr-label" for="email"
@@ -251,6 +246,10 @@ const ctaText = ref(computeCtaText())
         >Une adresse email valide doit être indiquée.
       </WarningMessage>
     </form>
+    <p
+      >Vous pouvez saisir uniquement l'adresse e-mail pour recevoir le
+      récapitulatif.</p
+    >
     <form
       v-if="showSms"
       class="fr-form fr-my-2w"

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -82,8 +82,13 @@ const sendRecap = async (surveyOptin) => {
       )
     }
   } catch (error) {
-    console.error(error)
-    Sentry.captureException(error)
+    if (
+      !error?.response?.data ||
+      !error?.response?.data.includes("wrongPhoneNumber")
+    ) {
+      console.error(error)
+      Sentry.captureException(error)
+    }
   }
 }
 
@@ -142,10 +147,18 @@ const sendRecapByEmailAndSms = async (surveyOptin) => {
     store.setModalState(undefined)
     await postFollowup(surveyOptin, emailValue.value, phoneValue.value)
   } catch (error) {
-    Sentry.captureException(error)
-    store.setFormRecapState("error")
+    if (
+      error?.response?.data &&
+      error?.response?.data.includes("wrongPhoneNumber")
+    ) {
+      store.setFormRecapState("wrongPhoneNumber")
+    } else {
+      Sentry.captureException(error)
+      store.setFormRecapState("error")
+    }
     throw error
   }
+
   store.setFormRecapState("ok")
   phoneValue.value = undefined
   emailValue.value = undefined
@@ -166,6 +179,7 @@ const sendRecapBySms = async (surveyOptin) => {
     store.setFormRecapPhoneState("error")
     throw error
   }
+
   store.setFormRecapPhoneState("ok")
   phoneValue.value = undefined
 }

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -82,10 +82,7 @@ const sendRecap = async (surveyOptin) => {
       )
     }
   } catch (error) {
-    if (
-      !error?.response?.data ||
-      !error?.response?.data.includes("wrongPhoneNumber")
-    ) {
+    if (!error?.response?.data?.includes("Invalid")) {
       console.error(error)
       Sentry.captureException(error)
     }
@@ -147,10 +144,7 @@ const sendRecapByEmailAndSms = async (surveyOptin) => {
     store.setModalState(undefined)
     await postFollowup(surveyOptin, emailValue.value, phoneValue.value)
   } catch (error) {
-    if (
-      error?.response?.data &&
-      error?.response?.data.includes("wrongPhoneNumber")
-    ) {
+    if (error?.response?.data?.includes("Numéro de téléphone invalide")) {
       store.setFormRecapState("wrongPhoneNumber")
     } else {
       Sentry.captureException(error)
@@ -224,6 +218,10 @@ const ctaText = ref(computeCtaText())
       faire le point sur les démarches que vous avez faites et les blocages que
       vous avez rencontrés.
     </p>
+    <p
+      >Vous pouvez saisir uniquement votre adresse e-mail pour être sur de
+      recevoir le recapitulatif.</p
+    >
     <form class="fr-form fr-my-2w" @submit.prevent="sendRecap(true)">
       <div class="fr-form-group">
         <label class="fr-label" for="email"


### PR DESCRIPTION
Une première itération pour réduire le volume d'erreur dans Sentry.
D'autres itérations avec d'autres PR sont à prévoir, notamment envoyer potentiellement l'e-mail même si le numéro de téléphone n'est pas bon.