### PR TITLE
Fixbug adresse destination invalide (envoi de SMS)

### DIFF
--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -61,8 +61,8 @@ export async function persist(req: Request, res: Response) {
         email,
         phone
       )
-      if (phone) await sendSimulationResultsSms(followup)
       if (email) await sendSimulationResultsEmail(followup)
+      if (phone) await sendSimulationResultsSms(followup)
       return res.send({ result: "OK" })
     }
 

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -222,7 +222,6 @@ export async function logSurveyLinkClick(req: Request, res: Response) {
     res.redirect(redirectUrl)
   } catch (error) {
     Sentry.captureException(error)
-    console.error("error", error)
     return res.sendStatus(ErrorStatus.NotFound)
   }
 }

--- a/backend/lib/messaging/email/email-service.ts
+++ b/backend/lib/messaging/email/email-service.ts
@@ -7,13 +7,14 @@ import { EmailType } from "../../../../lib/enums/messaging.js"
 import { SurveyType } from "../../../../lib/enums/survey.js"
 import { Survey } from "../../../../lib/types/survey.js"
 import { Followup } from "../../../../lib/types/followup.js"
+import { ErrorType } from "../../../../lib/enums/error.js"
 import dayjs from "dayjs"
 
 export async function sendSimulationResultsEmail(
   followup: Followup
 ): Promise<Followup> {
   if (!followup.email) {
-    throw new Error("Missing followup email")
+    throw new Error(ErrorType.MissingFollowupEmail)
   }
   const render: any = await emailRender(EmailType.SimulationResults, followup)
   const sendEmailSmtpResponse = await sendEmailSmtp({

--- a/backend/lib/messaging/sms/sms-service.ts
+++ b/backend/lib/messaging/sms/sms-service.ts
@@ -103,10 +103,13 @@ export async function sendSimulationResultsSms(
     followup.smsSentAt = dayjs().toDate()
     followup.smsMessageId = data.messageIds[0]
     return await followup.save()
-  } catch (err) {
-    Sentry.captureException(err)
-    followup.smsError = JSON.stringify(err, null, 2)
-    throw err
+  } catch (error: any) {
+    // Avoid sending invalid destination address error to sentry
+    if (!error?.message?.includes("Invalid destination address")) {
+      Sentry.captureException(error)
+    }
+    followup.smsError = JSON.stringify(error, null, 2)
+    throw error
   }
 }
 

--- a/backend/lib/messaging/sms/sms-service.ts
+++ b/backend/lib/messaging/sms/sms-service.ts
@@ -1,10 +1,14 @@
 import axios from "axios"
 import config from "../../../config/index.js"
-import { phoneNumberFormatting } from "./../../../../lib/phone-number.js"
+import {
+  phoneNumberFormatting,
+  phoneNumberValidation,
+} from "./../../../../lib/phone-number.js"
 import { SmsType } from "../../../../lib/enums/messaging.js"
 import { Followup } from "../../../../lib/types/followup.js"
 import { Survey } from "../../../../lib/types/survey.d.js"
 import { SurveyType } from "../../../../lib/enums/survey.js"
+import { ErrorType } from "../../../../lib/enums/error.js"
 import dayjs from "dayjs"
 import Sentry from "@sentry/node"
 
@@ -69,7 +73,16 @@ export async function sendSimulationResultsSms(
 ): Promise<Followup> {
   try {
     if (!followup.phone) {
-      throw new Error("Missing followup phone")
+      throw new Error(ErrorType.MissingFollowupPhone)
+    }
+
+    if (
+      !phoneNumberValidation(
+        followup.phone,
+        config.smsService.internationalDiallingCodes
+      )
+    ) {
+      throw new Error(ErrorType.UnsupportedPhoneNumberFormat)
     }
 
     const { username, password } = await getSMSConfig()

--- a/backend/lib/messaging/sms/sms-service.ts
+++ b/backend/lib/messaging/sms/sms-service.ts
@@ -108,7 +108,8 @@ export async function sendSimulationResultsSms(
     if (!error?.message?.includes("Invalid destination address")) {
       Sentry.captureException(error)
     }
-    followup.smsError = JSON.stringify(error, null, 2)
+    followup.smsError = error?.message
+    await followup.save()
     throw error
   }
 }

--- a/lib/enums/error.ts
+++ b/lib/enums/error.ts
@@ -1,0 +1,20 @@
+export enum ErrorType {
+  UnsupportedPhoneNumberFormat = "Unsupported phone number format",
+  PersistingFollowup = "Persisting followup error",
+  MissingFollowupPhone = "Missing followup phone",
+  MissingFollowupEmail = "Missing followup email",
+  UnknownSurveyType = "Unknown survey type",
+}
+
+export enum ErrorStatus {
+  BadRequest = 400,
+  Unauthorized = 401,
+  Forbidden = 403,
+  UnprocessableEntity = 422,
+  NotFound = 404,
+  InternalServerError = 500,
+}
+
+export enum ErrorName {
+  ValidationError = "ValidationError",
+}

--- a/src/components/modals/errors-email-and-sms-modal.vue
+++ b/src/components/modals/errors-email-and-sms-modal.vue
@@ -32,7 +32,7 @@ const recapEmailState = computed(() => store.recapEmailState)
         <p>
           Une erreur s'est produite dans l'envoi du récapitulatif par SMS :
           l'adresse de destination est invalide. Veuillez réessayer avec un
-          numéro valide ou utiliser l'envoi par email.
+          numéro valide ou utiliser l'envoi par email seulement.
         </p>
       </div>
       <div

--- a/src/components/modals/errors-email-and-sms-modal.vue
+++ b/src/components/modals/errors-email-and-sms-modal.vue
@@ -26,6 +26,16 @@ const recapEmailState = computed(() => store.recapEmailState)
         </p>
       </div>
       <div
+        v-if="recapPhoneState === 'invalid-address'"
+        class="fr-alert fr-alert--error"
+      >
+        <p>
+          Une erreur s'est produite dans l'envoi du récapitulatif par SMS :
+          l'adresse de destination est invalide. Veuillez réessayer avec un
+          numéro valide ou utiliser l'envoi par email.
+        </p>
+      </div>
+      <div
         v-if="recapPhoneState === 'ok' && recapEmailState === 'ok'"
         class="fr-alert fr-alert--success"
       >

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -81,9 +81,12 @@ const sendRecap = async (surveyOptin) => {
         ABTestingService.getValues().CTA_EmailRecontact
       )
     }
-  } catch (error) {
-    console.error(error)
-    Sentry.captureException(error)
+  } catch (error: any) {
+    if (!error?.response?.data?.includes("Invalid destination address")) {
+      Sentry.captureException(error)
+    } else {
+      store.setFormRecapPhoneState("invalid-address")
+    }
   }
 }
 
@@ -181,7 +184,6 @@ const sendRecapByEmail = async (surveyOptin) => {
     store.setModalState(undefined)
     await postFollowup(surveyOptin, emailValue.value)
   } catch (error) {
-    Sentry.captureException(error)
     store.setFormRecapEmailState("error")
     throw error
   }


### PR DESCRIPTION
Certains numéros de SMS sont validés par le front mais ne sont pas valides pour autant en backend. Cela générait un statut `waiting` à `true` avec un chargement infini sur le front sans aucune gestion d'erreur.

<details>
  <summary>Exemple de numéro invalide avec chargement infini en cliquant ici</summary>
  +594 696 00 01 02
</details>

Cette correction remonte l'erreur "adresse de destination invalide" soulevée par le backend et l'interprète sur le front avec un message spécifique pour éviter le loading infini.

[Bug sentry associé](https://sentry.incubateur.net/organizations/betagouv/issues/124629/?referrer=alert_email&alert_type=email&alert_timestamp=1728399498193&alert_rule_id=142&notification_uuid=3d146d9a-3a1c-4f4d-8eba-a6c8641d1268&environment=development)