### PR TITLE
Màj la description du Prêt Etudiant Garanti par l'Etat

### DIFF
--- a/data/benefits/openfisca/garantie_pret_etudiant_eligibilite.yml
+++ b/data/benefits/openfisca/garantie_pret_etudiant_eligibilite.yml
@@ -1,6 +1,6 @@
 label: prêt étudiant garanti par l'État
 institution: etat
-description: Le prêt étudiant est ouvert à l'ensemble des étudiants sans conditions de ressources et sans caution parentale ou d'un tiers. Avec la possibilité de rembourser l'emprunt de manière différée.
+description: Le prêt étudiant est ouvert à l'ensemble des étudiants sans conditions de ressources et sans caution parentale ou d'un tiers. Vous avez la possibilité de commencer à rembourser l'emprunt de manière différée, quand vous aurez terminé vos études et trouvé un travail.
 link: https://www.etudiant.gouv.fr/fr/pret-etudiant-garanti-par-l-etat-1723
 instructions: https://www.etudiant.gouv.fr/fr/pret-etudiant-garanti-par-l-etat-1723#item2
 prefix: le


### PR DESCRIPTION
Précise la description du Prêt étudiant garanti par l'Etat, pour qu'il soit clair que l'étudiant peut demander ce prêt même s'il n'a pas encore de revenus.

Lié à [#4656](https://github.com/betagouv/aides-jeunes/issues/4656)