### PR TITLE
Suppression du mode Replay de Sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,13 +47,8 @@ if (process.env?.VITE_SENTRY_FRONTEND_DSN) {
     app,
     dsn: process.env.VITE_SENTRY_FRONTEND_DSN,
     environment: process.env.VITE_CONTEXT,
-    integrations: [
-      Sentry.browserTracingIntegration({ router }),
-      Sentry.replayIntegration(),
-    ],
+    integrations: [Sentry.browserTracingIntegration({ router })],
     tracesSampleRate: 0.1,
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
     debug: "development" === process.env.VITE_CONTEXT,
   })
 }


### PR DESCRIPTION
On s'en sert très peu et cela prend de la ressource pour pas grand chose de très utile pour le moment.