### PR TITLE
Revert "Chore(deps): Bump openfisca-core[web-api] from 41.5.5 to 43.2.2 in /openfisca"

### DIFF
--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,6 +1,6 @@
 gunicorn>=21.2.0
-pytest==8.3.3
-Openfisca-France==169.3.1
-Openfisca-Core[web-api]==43.2.2
-OpenFisca-France-Local[excel-reader]==6.15.1
-Openfisca-Paris==5.5.9
+pytest==7.2.2
+Openfisca-France==168.0.14
+Openfisca-Core[web-api]==41.5.5
+OpenFisca-France-Local[excel-reader]==6.14.0
+Openfisca-Paris==5.5.5


### PR DESCRIPTION
Reverts betagouv/aides-jeunes#4669

⚠️ Ces mises à jour fonctionnent en préproduction mais ne fonctionnent pas en production ⚠️ 