### PR TITLE
Ajout groupe de boutons de démarrage de simulation depuis la page "Toutes les aides"

### DIFF
--- a/src/components/buttons/back-button.vue
+++ b/src/components/buttons/back-button.vue
@@ -2,8 +2,13 @@
 <template>
   <component
     :is="asLink ? 'router-link' : 'button'"
-    class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-arrow-left-line"
-    :class="{ 'fr-btn--sm': size === 'small' }"
+    :class="[
+      'fr-btn',
+      `fr-btn--${size === 'small' ? 'sm' : 'md'}`,
+      `fr-btn--${btnType}`,
+      'fr-btn--icon-left',
+      'fr-icon-arrow-left-line',
+    ]"
     :type="asLink ? undefined : 'button'"
     :to="asLink ? to : undefined"
     @click="asLink ? undefined : goBack()"
@@ -35,6 +40,10 @@ const props = defineProps({
   to: {
     type: String,
     default: "/",
+  },
+  btnType: {
+    type: String,
+    default: "secondary",
   },
 })
 const route = useRoute()

--- a/src/components/buttons/home-simulation-group-buttons.vue
+++ b/src/components/buttons/home-simulation-group-buttons.vue
@@ -1,32 +1,39 @@
 <script setup lang="ts">
 import { computed, getCurrentInstance } from "vue"
 import { useStore } from "@/stores/index.js"
-import { useRoute } from "vue-router"
+import { useRoute, useRouter } from "vue-router"
 import { EventAction, EventCategory } from "@lib/enums/event.js"
-
-const { proxy } = getCurrentInstance() as any
 
 const store = useStore()
 const route = useRoute()
+const router = useRouter()
+
+const { proxy } = getCurrentInstance() as any
+const SIMULATION_START_PATH = "/simulation/individu/demandeur/date_naissance"
 
 const hasExistingSituation = computed(() => store.passSanityCheck)
 
 const ctaLabel = computed(() =>
   hasExistingSituation.value
     ? "Commencer une nouvelle simulation"
-    : "Je commence"
+    : "Commencer une simulation"
 )
 
-const newSituation = () => {
-  store.clear(route.query.external_id as string)
-  next()
-}
-
-const next = () => {
+const initializeOpenfiscaParameters = () => {
   store.setOpenFiscaParameters()
   if (process.env.VITE_CONTEXT !== "production") {
     store.verifyBenefitVariables()
   }
+}
+
+const newSituation = () => {
+  store.clear(route.query.external_id as string)
+  initializeOpenfiscaParameters()
+  router.push(SIMULATION_START_PATH)
+}
+
+const resumeSimulation = () => {
+  initializeOpenfiscaParameters()
   proxy?.$push()
 }
 </script>
@@ -40,7 +47,7 @@ const next = () => {
           category: EventCategory.Home,
         }"
         class="fr-btn"
-        @click="next"
+        @click="resumeSimulation"
       >
         Reprendre ma simulation
       </button>
@@ -60,7 +67,7 @@ const next = () => {
         v-analytics="{ action: ctaLabel, category: EventCategory.Home }"
         class="fr-btn"
         data-testid="new-simulation"
-        to="/simulation/individu/demandeur/date_naissance"
+        :to="SIMULATION_START_PATH"
         @click="newSituation"
       >
         {{ ctaLabel }}

--- a/src/components/buttons/home-simulation-group-buttons.vue
+++ b/src/components/buttons/home-simulation-group-buttons.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance } from "vue"
+import { computed, getCurrentInstance, defineProps } from "vue"
 import { useStore } from "@/stores/index.js"
 import { useRoute, useRouter } from "vue-router"
 import { EventAction, EventCategory } from "@lib/enums/event.js"
@@ -36,10 +36,33 @@ const resumeSimulation = () => {
   initializeOpenfiscaParameters()
   proxy?.$push()
 }
+
+const props = defineProps({
+  horizontal: {
+    type: Boolean,
+    default: false,
+  },
+  size: {
+    type: String,
+    default: null,
+  },
+  reverse: {
+    type: Boolean,
+    default: false,
+  },
+})
 </script>
 
 <template>
-  <ul class="fr-btns-group">
+  <ul
+    class="fr-btns-group"
+    :class="{
+      'fr-btns-group--inline-md': props.horizontal,
+      'fr-btns-group--sm': props.size === 'small',
+      'fr-btns-group--inline-reverse': props.reverse,
+      'fr-btns-group--right': props.reverse,
+    }"
+  >
     <li v-if="hasExistingSituation">
       <button
         v-analytics="{

--- a/src/components/buttons/home-simulation-group-buttons.vue
+++ b/src/components/buttons/home-simulation-group-buttons.vue
@@ -22,7 +22,7 @@ const ctaLabel = computed(() =>
 const initializeOpenfiscaParameters = () => {
   store.setOpenFiscaParameters()
   if (process.env.VITE_CONTEXT !== "production") {
-    store.verifyBenefitVariables()
+    store.verifyOpenfiscaBenefitVariables()
   }
 }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -322,7 +322,7 @@ router.beforeEach((to, from, next) => {
       process.env.VITE_CONTEXT !== "production" ||
       to?.redirectedFrom?.fullPath === "/init-ci"
     ) {
-      store.verifyBenefitVariables()
+      store.verifyOpenfiscaBenefitVariables()
     }
 
     if (

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -546,7 +546,7 @@ export const useStore = defineStore("store", {
           this.openFiscaParameters = response.data
         })
     },
-    verifyBenefitVariables() {
+    verifyOpenfiscaBenefitVariables() {
       return axios
         .get("/api/openfisca/missingbenefits")
         .then((response) => response.data)

--- a/src/styles/aides-jeunes.css
+++ b/src/styles/aides-jeunes.css
@@ -149,9 +149,11 @@ textarea {
 }
 
 .fr-btn--close,
-.fr-btn--tertiary-no-outline {
+.fr-btn--tertiary-no-outline,
+.fr-btn--tertiary {
   color: var(--main-color);
 }
+
 .fr-btn--icon-center {
   justify-content: center !important;
 }

--- a/src/styles/aides-jeunes.css
+++ b/src/styles/aides-jeunes.css
@@ -280,6 +280,13 @@ textarea {
   text-align: right;
 }
 
+.aj-home-group-buttons-container {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  align-items: center;
+}
+
 @media (max-width: 576px) {
   .aj-hero-section {
     max-height: none;
@@ -295,6 +302,11 @@ textarea {
 @media (max-width: 767px) {
   body[data-action-buttons="true"] {
     padding-bottom: 72px;
+  }
+
+  .aj-home-group-buttons-container {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .aj-action-buttons {

--- a/src/views/liste-aides.vue
+++ b/src/views/liste-aides.vue
@@ -1,19 +1,25 @@
 <template>
   <article class="fr-article">
     <div class="fr-grid-row fr-grid-row--gutters">
-      <div class="fr-col-12 fr-col-md-4">
+      <div class="fr-col-12">
         <h1>Toutes les aides</h1>
-        <BackButton
-          size="small"
-          data-testid="benefits-liste-back-button"
-          as-link
-          to="/"
-        >
-          Retour à l'accueil
-        </BackButton>
       </div>
-      <div class="fr-col-12 fr-col-md-5 fr-col-offset-md-3">
-        <HomeSimulationGroupButtons />
+      <div class="aj-home-group-buttons-container">
+        <div class="fr-mb-2w fr-mr-2w">
+          <BackButton
+            data-testid="benefits-liste-back-button"
+            as-link
+            to="/"
+            size="small"
+          >
+            Retour à l'accueil
+          </BackButton>
+        </div>
+        <HomeSimulationGroupButtons
+          :horizontal="true"
+          size="small"
+          :reverse="true"
+        />
       </div>
     </div>
 
@@ -240,3 +246,5 @@ const alertClass = computed(() =>
   countFilteredBenefits() > 0 ? "fr-alert--success" : "fr-alert--error"
 )
 </script>
+
+<style scoped></style>

--- a/src/views/liste-aides.vue
+++ b/src/views/liste-aides.vue
@@ -1,18 +1,26 @@
 <template>
   <article class="fr-article">
-    <h1>Toutes les aides</h1>
-    <BackButton
-      size="small"
-      data-testid="benefits-liste-back-button"
-      class="fr-mb-2w"
-      as-link
-      to="/"
-    >
-      Retour à l'accueil
-    </BackButton>
-    <div>
-      <p class="fr-badge fr-mb-2w">Total : {{ benefitsCount }} aides</p>
+    <div class="fr-grid-row fr-grid-row--gutters">
+      <div class="fr-col-12 fr-col-md-4">
+        <h1>Toutes les aides</h1>
+        <BackButton
+          size="small"
+          data-testid="benefits-liste-back-button"
+          as-link
+          to="/"
+        >
+          Retour à l'accueil
+        </BackButton>
+      </div>
+      <div class="fr-col-12 fr-col-md-5 fr-col-offset-md-3">
+        <HomeSimulationGroupButtons />
+      </div>
     </div>
+
+    <div>
+      <p class="fr-badge fr-my-2w">Total : {{ benefitsCount }} aides</p>
+    </div>
+
     <div class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col-12 fr-col-md-6">
         <div class="fr-form-group">
@@ -123,7 +131,7 @@ import CommuneMethods from "@/lib/commune.js"
 import { Commune } from "@lib/types/commune.d.js"
 import { capitalize, normalizeString } from "@lib/utils.js"
 import BackButton from "@/components/buttons/back-button.vue"
-
+import HomeSimulationGroupButtons from "@/components/buttons/home-simulation-group-buttons.vue"
 const zipCode = ref<string | null>(null)
 const selectedCommune = ref<Commune | null>(null)
 const searchTerms = ref<string | null>(null)
@@ -232,3 +240,15 @@ const alertClass = computed(() =>
   countFilteredBenefits() > 0 ? "fr-alert--success" : "fr-alert--error"
 )
 </script>
+
+<style scoped>
+:deep(.fr-btns-group) {
+  justify-content: flex-end;
+}
+
+@media (max-width: 768px) {
+  :deep(.fr-btns-group) {
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/src/views/liste-aides.vue
+++ b/src/views/liste-aides.vue
@@ -247,5 +247,3 @@ const alertClass = computed(() =>
   countFilteredBenefits() > 0 ? "fr-alert--success" : "fr-alert--error"
 )
 </script>
-
-<style scoped></style>

--- a/src/views/liste-aides.vue
+++ b/src/views/liste-aides.vue
@@ -240,15 +240,3 @@ const alertClass = computed(() =>
   countFilteredBenefits() > 0 ? "fr-alert--success" : "fr-alert--error"
 )
 </script>
-
-<style scoped>
-:deep(.fr-btns-group) {
-  justify-content: flex-end;
-}
-
-@media (max-width: 768px) {
-  :deep(.fr-btns-group) {
-    justify-content: flex-start;
-  }
-}
-</style>

--- a/src/views/liste-aides.vue
+++ b/src/views/liste-aides.vue
@@ -11,6 +11,7 @@
             as-link
             to="/"
             size="small"
+            btn-type="tertiary"
           >
             Retour à l'accueil
           </BackButton>


### PR DESCRIPTION
Ajout du bouton sur la page de la liste des aides - lisible commit par commit.

UI proposée (ouvert à vos suggestions car je pense qu'on peut probablement faire mieux) :

### Desktop 
![image](https://github.com/user-attachments/assets/453e2be5-02ac-45da-a121-07b4333fd3c4)
![image](https://github.com/user-attachments/assets/f36a25c4-1477-4992-b82b-9dbb61afd67f)


### Mobile 
![image](https://github.com/user-attachments/assets/4125f37f-36f1-4492-b1dd-043a72427525)
![image](https://github.com/user-attachments/assets/10c69dd7-e866-41f1-8d69-c3b72b1153c5)

