### PR TITLE
Livret A - par defaut 0 pour éviter une erreur dans open-fisca

### DIFF
--- a/src/views/simulation/Ressources/patrimoine.vue
+++ b/src/views/simulation/Ressources/patrimoine.vue
@@ -274,7 +274,7 @@ export default {
         (patrimoines, patrimoineType) => ({
           ...patrimoines,
           [patrimoineType.id]:
-            this.demandeur[patrimoineType.id][this.periodKey],
+            this.demandeur[patrimoineType.id][this.periodKey] || 0,
         }),
         {}
       )


### PR DESCRIPTION
Le détail du bug et du scénario de test est défini dans le ticket.