### PR TITLE
Ajout des autres villes de la mutuelle communal

### DIFF
--- a/data/benefits/openfisca/montpellier_mutuelle_communale.yml
+++ b/data/benefits/openfisca/montpellier_mutuelle_communale.yml
@@ -1,7 +1,7 @@
 label: mutuelle communale de la ville de Montpellier
 institution: ville_montpellier
 description:
-  La Ville de Montpellier propose à ses habitants une mutuelle communale à des tarifs avantageux,
+  La Ville de Montpellier ainsi que Clapiers, Le Crès, Murviel-lès-Montpellier, Saint-Geniès-des-Mourgues et Sussargues propose à leurs habitants une mutuelle communale à des tarifs avantageux,
   accessible à toutes les personnes résidant dans la ville ainsi qu'aux personnes étudiant dans les établissements
   de Montpellier. Un accompagnement à la souscription est également proposé pour aider à choisir l’offre qui
   correspond le mieux aux besoins et au budget des bénéficiaires.

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -2,6 +2,6 @@ gunicorn>=21.2.0
 pytest==8.3.3
 Openfisca-France==169.13.0
 Openfisca-Core[web-api]==43.2.7
-OpenFisca-France-Local[excel-reader]==6.17.1
+OpenFisca-France-Local[excel-reader]==6.17.2
 Openfisca-Paris==5.5.9
 typing_extensions==4.12.2

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -2,6 +2,6 @@ gunicorn>=21.2.0
 pytest==8.3.3
 Openfisca-France==169.13.0
 Openfisca-Core[web-api]==43.2.7
-OpenFisca-France-Local[excel-reader]==6.17.2
+OpenFisca-France-Local[excel-reader]==6.17.3
 Openfisca-Paris==5.5.9
 typing_extensions==4.12.2


### PR DESCRIPTION
Besoin de ton avis @yasmine-glitch car l'institution associée reste Montpellier et non chaque commune proposant le dispositif.