### PR TITLE
Ajout du type codespostaux et gestion d'un dispositif ciblé pour Strasbourg

### DIFF
--- a/contribuer/public/admin/config.yml
+++ b/contribuer/public/admin/config.yml
@@ -145,6 +145,15 @@ fields:
         name: values
         widget: list
         hint: Pour saisir plusieurs communes, séparez les codes INSEE des communes par une virgule.
+  field_codespostaux: &field_codespostaux
+    label: Condition géographique codes postaux
+    name: codespostaux
+    widget: object
+    fields:
+      - label: Code postaux des communes
+        name: values
+        widget: list
+        hint: Pour saisir plusieurs codes postaux, séparez les codes des communes par une virgule.
   field_boursier: &field_boursier
     <<: *field_empty
     label: Boursier
@@ -822,6 +831,7 @@ fields:
       - *field_epcis
       - *field_excluded_epcis
       - *field_communes
+      - *field_codespostaux
       - *field_regime_securite_sociale
       - *field_quotient_familial
       - *field_formation_sanitaire_social

--- a/data/benefits/javascript/ville-strasbourg-accompagnement.yml
+++ b/data/benefits/javascript/ville-strasbourg-accompagnement.yml
@@ -1,0 +1,13 @@
+label: rendez-vous téléphonique d’accompagnement personnalisé
+institution: ville_montpellier
+description: Vous avez besoin d’aide pour comprendre votre résultat de simulation et effectuer vos démarches ? Prenez un rendez-vous pour être rappelé au téléphone par un agent chargé d’accès aux droits du Centre Communal d’Action Sociale de Montpellier.
+prefix: le
+conditions_generales:
+  - type: codespostaux
+    values:
+      - "67100"
+type: bool
+periodicite: autre
+teleservice: https://mon.strasbourg.eu/bienvenue
+link: https://mon.strasbourg.eu/bienvenue
+top: -1

--- a/data/benefits/javascript/ville-strasbourg-accompagnement.yml
+++ b/data/benefits/javascript/ville-strasbourg-accompagnement.yml
@@ -1,6 +1,6 @@
 label: rendez-vous téléphonique d’accompagnement personnalisé
-institution: ville_montpellier
-description: Vous avez besoin d’aide pour comprendre votre résultat de simulation et effectuer vos démarches ? Prenez un rendez-vous pour être rappelé au téléphone par un agent chargé d’accès aux droits du Centre Communal d’Action Sociale de Montpellier.
+institution: strasbourg_eurometropole
+description: Vous avez besoin d’aide pour comprendre votre résultat de simulation et effectuer vos démarches ? Prenez un rendez-vous pour être rappelé au téléphone par un agent chargé d’accès aux droits de la ville de Strasbourg.
 prefix: le
 conditions_generales:
   - type: codespostaux

--- a/lib/benefits/compute-javascript.ts
+++ b/lib/benefits/compute-javascript.ts
@@ -90,6 +90,7 @@ const COMMUNE_PARAMETERS = {
   departements: "_departement",
   communes: "depcom",
   epcis: "_epci",
+  codespostaux: "_codePostal",
 }
 
 export function testGeographicalEligibility(
@@ -194,6 +195,9 @@ export const CONDITION_STRATEGY: Conditions = {
     },
   },
   regions: {
+    test: testGeographicalEligibility,
+  },
+  codespostaux: {
     test: testGeographicalEligibility,
   },
   departements: {

--- a/tests/integration/benefits-description.spec.ts
+++ b/tests/integration/benefits-description.spec.ts
@@ -182,6 +182,7 @@ describe("benefit descriptions", function () {
                       condition.type === "departements" ||
                       condition.type === "communes" ||
                       condition.type === "epcis" ||
+                      condition.type === "codespostaux" ||
                       condition.type === "attached_to_institution"
                     )
                   }

--- a/tests/integration/schema-validation-benefits-javascript.spec.ts
+++ b/tests/integration/schema-validation-benefits-javascript.spec.ts
@@ -4,7 +4,6 @@ import fs from "fs"
 
 import { validateFile, getCollectionSchema } from "@root/data/schemas.js"
 const benefitSchema = getCollectionSchema("benefits_javascript")
-
 const dataDir = path.join(new URL(".", import.meta.url).pathname, "../../data")
 const benefitFiles = fs
   .readdirSync(`${dataDir}/benefits/javascript`)

--- a/tests/unit/compute-javascript-benefits.spec.ts
+++ b/tests/unit/compute-javascript-benefits.spec.ts
@@ -170,6 +170,19 @@ describe("computeAides", function () {
     ).toBe(true)
   })
 
+  it("verify the result when a codespostaux is in benefit's EPCI", function () {
+    situation.menage._codePostal = "67100"
+    expect(
+      testGeographicalEligibility(
+        {
+          type: "codespostaux",
+          values: ["67100"],
+        },
+        { situation }
+      )
+    ).toBe(true)
+  })
+
   it("adds the benefit amount when eligible", function () {
     const openfiscaRequest = buildOpenFiscaRequest(situation)
     computeJavascriptBenefits(benefits, situation, openfiscaRequest)


### PR DESCRIPTION
En septembre on mettra en ligne le dispositif d'accompagnement pour les habitants de Neudorf Musau, d'où la nécessité de pouvoir cibler uniquement le code postal en question.

il y a 3 codes postaux à Strasbourg :
67000 pour le centre et le nord-est
67100 pour le sud et sud est (inclus Neudorf Musau qui est le quartier de l'expérimentation)
67200 pour l'ouest 