### PR TITLE
Fix: empêche la fermeture de la modale de chargement des résultats lors d'un clic extérieur

### DIFF
--- a/src/components/loading-modal.vue
+++ b/src/components/loading-modal.vue
@@ -4,6 +4,7 @@
     role="dialog"
     class="fr-modal fr-modal--opened"
     open="true"
+    data-fr-concealing-backdrop="false"
   >
     <div class="fr-container fr-container--fluid fr-container-md">
       <div class="fr-grid-row fr-grid-row--center">


### PR DESCRIPTION
Source: https://storybook.systeme-de-design.gouv.fr/?path=/docs/modal--docs