### PR TITLE
Cache trois aides de la région Pays de la Loire.

### DIFF
--- a/data/benefits/javascript/region-pays-de-la-loire-acces-emploi-parcours-tpme.yml
+++ b/data/benefits/javascript/region-pays-de-la-loire-acces-emploi-parcours-tpme.yml
@@ -17,3 +17,4 @@ unit: €
 periodicite: autre
 link: https://www.paysdelaloire.fr/les-aides/region-formation-acces-emploi-parcours-tpme
 instructions: https://www.paysdelaloire.fr/les-aides/region-formation-acces-emploi-parcours-tpme
+private: true

--- a/data/benefits/javascript/region-pays-de-la-loire-aide-covoiturage.yml
+++ b/data/benefits/javascript/region-pays-de-la-loire-aide-covoiturage.yml
@@ -21,3 +21,4 @@ conditions:
 type: bool
 periodicite: autre
 link: https://aleop.paysdelaloire.fr/mes-solutions-de-mobilite/covoiturez-moins-cher-avec-la-region-pays-de-la-loire
+private: true

--- a/data/benefits/javascript/region_pays_de_la_loire-aide-à-l’achat-d’un-vélo-pliant-ou-à-assistance-électrique-vae.yml
+++ b/data/benefits/javascript/region_pays_de_la_loire-aide-à-l’achat-d’un-vélo-pliant-ou-à-assistance-électrique-vae.yml
@@ -17,3 +17,4 @@ prefix: l’
 type: bool
 unit: €
 periodicite: autre
+private: true


### PR DESCRIPTION
Email envoyé à la région pour confirmer que ces dispositifs ont bien été supprimés.
Réponse de la région : "Bonjour suite aux arbitrages budgétaires de décembre dernier, certaines de nos aides ont en effet été suspendues. Si le lien ne fonctionne plus vous pouvez retirer la fiche en question.
Bonne journée"