### PR TITLE
Cache deux aides et Met à jour une aide.

### DIFF
--- a/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
+++ b/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
@@ -1,9 +1,11 @@
-label: Aides au BAFA et BAFD pour une formation générale, d'approfondissement ou
-  de qualification
+label: Aides au BAFA ou BAFD
 institution: caf_ille_et_vilaine
-description: L'aide à la formation au BAFD est une aide locale mise à
-  disposition par la CAF d'Ille-et-Vilaine pour vous aider à financer votre
-  session en complément de l'aide nationale apportée par la CAF. Son montant dépend de votre quotient familial.
+description:
+  Le brevet d’aptitude aux fonctions d’animateur (BAFA) et le brevet d’aptitude
+  aux fonctions de directeur (BAFD) sont des diplômes qui permettent d’encadrer
+  des enfants et des adolescents en accueil collectif de mineurs. La Caf d'Ille-et-Vilaine
+  vous aide à financer ces formations, sous conditions de ressources. Cette aide est cumulable
+  avec celle de la CNAF et son montant dépend de votre quotient familial.
 prefix: les
 conditions_generales:
   - type: age
@@ -14,11 +16,11 @@ conditions_generales:
       - "35"
   - type: quotient_familial
     period: month
-    value: 750
+    value: 700
     operator: "<="
 profils: []
 interestFlag: _interetBafa
 type: bool
 periodicite: autre
 link: https://caf.fr/allocataires/caf-d-ille-et-vilaine/offre-de-service/vie-professionnelle/je-passe-le-bafa-ou-le-bafd
-form: https://caf.fr/sites/default/files/medias/351/Offre-de-service/vie-professionnelle/aide-au-bafa-bafd/Formulaire_bafa_2023.pdf
+form: https://caf.fr/sites/default/files/medias/351/Offre-de-service/vie-professionnelle/aide-au-bafa-bafd/Formulaire%20BAFA-2025_mod%C3%A8le.pdf

--- a/data/benefits/javascript/caf_saone_et_loire-aide-à-lautonomie-des-jeunes.yml
+++ b/data/benefits/javascript/caf_saone_et_loire-aide-à-lautonomie-des-jeunes.yml
@@ -42,3 +42,4 @@ legend: maximum
 montant: 1000
 link: https://www.caf.fr/allocataires/caf-de-saone-et-loire/offre-de-service/logement/l-aide-l-autonomie-des-jeunes#:~:text=Les%20conditions%20%C3%A0%20remplir%20et,%C3%A9gal%20%C3%A0%201%20200%20euros.&text=%3E%20montant%20et%20nature%20de%20l,maximum%20de%201%20000%20euros.
 form: https://www.caf.fr/sites/default/files/medias/711/Allocataires/Logement/Documents/demande_aide_autonomie_jeunes.pdf
+private: true

--- a/data/benefits/javascript/departement-val-d-oise-bourse-aux-apprentis.yml
+++ b/data/benefits/javascript/departement-val-d-oise-bourse-aux-apprentis.yml
@@ -21,3 +21,4 @@ type: float
 unit: €
 periodicite: annuelle
 montant: 230
+private: true


### PR DESCRIPTION
Prise de contact avec les deux collectivités concernées pour vérifier si les dispositifs sont reconduits.
bourse aux apprentis du val d'oise : à vérifier fin février
aide à l'autonomie des jeunes de la Caf de Saône et Loire : cette aide a été supprimée et "remplacée" par une aide au covoiturage pour les jeunes

Mise à jour de l'aide BAFA-BAFD de la Caf d'Ille-et-Vilaine dont l'url a été modifiée.