### PR TITLE
Aide terminée - Bafa / service civique

### DIFF
--- a/cypress/e2e/handicap.cy.js
+++ b/cypress/e2e/handicap.cy.js
@@ -23,7 +23,7 @@ context("Full simulation", () => {
     foyer.fill_en_couple(false)
 
     logement.fill__logementType("sansDomicile")
-    logement.fill_depcom("94120")
+    logement.fill_depcom("74000")
     logement.fill__difficultes_acces_ou_frais_logement(true)
     logement.fill__nombreMoisEntreeLogement(-12)
 

--- a/cypress/e2e/handicap.cy.js
+++ b/cypress/e2e/handicap.cy.js
@@ -31,11 +31,16 @@ context("Full simulation", () => {
     revenu.fillConstantRevenu(1101.42)
 
     projet.fill__interetsAidesVelo([])
-    projet.fill__interetBafa(false)
+    projet.fill__interetBafa(true)
     projet.fill__interetPermisDeConduire(false)
     projet.fill__interetAidesSanitaireSocial(false)
 
     results.wait()
+    results.hasBafaGroupPreviewBenefit(true)
+    navigate.goToBafaBenefitsPage()
+    results.hasBafaBenefit()
+    results.back()
+
     results.hasAAH()
     navigate.goRecap()
     navigate.checkRecap()

--- a/cypress/e2e/student.cy.js
+++ b/cypress/e2e/student.cy.js
@@ -24,7 +24,7 @@ context("Full simulation", () => {
     foyer.fill__situation("separes")
     foyer.fill_bourse_criteres_sociaux_nombre_enfants_a_charge(1)
     foyer.fill_bourse_criteres_sociaux_nombre_enfants_a_charge_dans_enseignement_superieur(
-      1,
+      1
     )
 
     logement.fill__logementType("locataire")
@@ -39,7 +39,7 @@ context("Full simulation", () => {
     logement.fill__en_france(true)
     logement.fill_depcom(
       "75001",
-      "_bourseCriteresSociauxCommuneDomicileFamilial",
+      "_bourseCriteresSociauxCommuneDomicileFamilial"
     )
     logement.fill__nombreMoisEntreeLogement(-2)
 

--- a/cypress/e2e/student.cy.js
+++ b/cypress/e2e/student.cy.js
@@ -24,7 +24,7 @@ context("Full simulation", () => {
     foyer.fill__situation("separes")
     foyer.fill_bourse_criteres_sociaux_nombre_enfants_a_charge(1)
     foyer.fill_bourse_criteres_sociaux_nombre_enfants_a_charge_dans_enseignement_superieur(
-      1
+      1,
     )
 
     logement.fill__logementType("locataire")
@@ -39,7 +39,7 @@ context("Full simulation", () => {
     logement.fill__en_france(true)
     logement.fill_depcom(
       "75001",
-      "_bourseCriteresSociauxCommuneDomicileFamilial"
+      "_bourseCriteresSociauxCommuneDomicileFamilial",
     )
     logement.fill__nombreMoisEntreeLogement(-2)
 
@@ -55,7 +55,6 @@ context("Full simulation", () => {
     projet.fill__dureeMoisEtudesEtranger(2)
 
     results.wait()
-    results.hasBafaGroupPreviewBenefit(true)
     navigate.goToBafaBenefitsPage()
     results.hasBafaBenefit()
     results.back()

--- a/cypress/e2e/student.cy.js
+++ b/cypress/e2e/student.cy.js
@@ -55,9 +55,7 @@ context("Full simulation", () => {
     projet.fill__dureeMoisEtudesEtranger(2)
 
     results.wait()
-    navigate.goToBafaBenefitsPage()
     results.hasBafaBenefit()
-    results.back()
 
     results.hasVeloGroupPreviewBenefit(true)
     navigate.goToAidesVeloBenefitsPage()

--- a/data/benefits/javascript/etat-aide-nationale-service-civique-bafa-bafd.yml
+++ b/data/benefits/javascript/etat-aide-nationale-service-civique-bafa-bafd.yml
@@ -13,3 +13,4 @@ periodicite: ponctuelle
 montant: 100
 link: https://www.jeunes.gouv.fr/une-aide-financiere-de-100eu-pour-les-volontaires-en-service-civique-pour-passer-leur-bafa-bafd
 instructions: https://www.asp-public.fr/aides/aide-a-la-formation-bafa-bafd-dans-le-cadre-du-service-civique
+private: true


### PR DESCRIPTION
La date limite de dépôt des demandes est fixée au 30 novembre 2024 inclus.
Source : https://www.jeunes.gouv.fr/une-aide-financiere-de-100eu-pour-les-volontaires-en-service-civique-pour-passer-leur-bafa-bafd