### PR TITLE
met à jour les aides

### DIFF
--- a/data/benefits/javascript/caf-drome-aide-bafa-session-approfondissement-qualification.yml
+++ b/data/benefits/javascript/caf-drome-aide-bafa-session-approfondissement-qualification.yml
@@ -1,21 +1,22 @@
 label: aide au BAFA pour une session d’approfondissement ou de qualification
 institution: caf_drome
-description: L'aide au BAFA pour une session d'approfondissement ou de
-  qualification est une aide locale mise à disposition par la CAF de la Drôme
-  pour vous aider à financer votre session en complément de l'aide nationale
-  apportée par la CAF.
+description:
+  La CAF de la Drôme vous aide à financer votre session d'approfondissement ou de qualification
+  (troisième et dernière étape du diplôme du BAFA) en complément de l'aide nationale apportée par la CNAF.
+  La CAF de la Drôme verse cette aide à l'organisme de formation qui la déduit du montant de l'inscription
+  que vous devez payer (vous ne payez que la part restant à votre charge).
 conditions:
   - Avoir commencé une formation pour obtenir le brevet d’aptitude à la fonction
     d’animateur de centre de vacances et de loisirs (BAFA).
   - Ne pas avoir déjà obtenu la totalité du financement par d'autres organismes.
-link: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/vie-professionnelle/entree-dans-le-vie-active/aide-financiere-pour-passer-le-bafa
-instructions: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/vie-professionnelle/entree-dans-le-vie-active/aide-financiere-pour-passer-le-bafa
+link: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/vie-professionnelle/aides-au-bafa
+instructions: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/vie-professionnelle/aides-au-bafa
 prefix: l’
 type: float
 unit: €
 periodicite: ponctuelle
 legend: maximum
-montant: 106
+montant: 225
 interestFlag: _interetBafa
 conditions_generales:
   - type: age

--- a/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
+++ b/data/benefits/javascript/caf-drome-aide-bafa-session-generale.yml
@@ -1,28 +1,30 @@
 label: aide locale au BAFA pour une session de formation générale
 institution: caf_drome
-description: L'aide au BAFA pour une session de formation générale est une aide
-  locale mise à disposition par la CAF de la Drôme pour vous aider à financer
-  votre session en complément de l'aide nationale apportée par la CAF.
+description:
+  La CAF de la Drôme vous aide à financer votre session de formation générale
+  (première étape du diplôme du BAFA) en complément de l'aide nationale apportée par la CNAF.
+  La CAF de la Drôme verse cette aide à l'organisme de formation qui la déduit du montant de l'inscription
+  que vous devez payer (vous ne payez que la part restant à votre charge).
 conditions:
-  - Etre allocataire de la Caf de la Drôme au moment du stage (ou enfant d'un
+  - Etre allocataire de la CAF de la Drôme au moment du stage (ou enfant d'un
     allocataire drômois).
-  - Ne pas avoir déjà obtenu la totalité du financement du Bafa par d'autres
+  - Ne pas avoir déjà obtenu la totalité du financement du BAFA par d'autres
     organismes.
 conditions_generales:
   - type: age
     operator: ">="
-    value: 17
+    value: 16
   - type: departements
     values:
       - "26"
   - type: quotient_familial
     period: month
-    value: 785
+    value: 885
     operator: "<="
 profils: []
-link: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/vie-professionnelle/entree-dans-le-vie-active/aide-financiere-pour-passer-le-bafa
+link: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/vie-professionnelle/aides-au-bafa
 form: https://www.caf.fr/sites/default/files/medias/261/allocataire/vie-professionnelle/formulaire-%20bafa-formation-generale.pdf
-instructions: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/vie-professionnelle/entree-dans-le-vie-active/aide-financiere-pour-passer-le-bafa
+instructions: https://www.caf.fr/allocataires/caf-de-la-drome/offre-de-service/vie-professionnelle/aides-au-bafa
 prefix: l’
 type: float
 unit: €

--- a/data/benefits/javascript/caf-nord-aide-vacances.yml
+++ b/data/benefits/javascript/caf-nord-aide-vacances.yml
@@ -28,4 +28,4 @@ unit: "%"
 periodicite: ponctuelle
 legend: du prix du séjour maximum
 montant: 75
-link: https://www.caf.fr/allocataires/caf-du-nord/offre-de-service/vie-personnelle/les-aides-vacaf
+link: https://www.caf.fr/allocataires/caf-du-nord/offre-de-service/vie-personnelle/vacaf

--- a/data/benefits/javascript/ville-montpellier-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-montpellier-bourse-communale-au-permis-de-conduire.yml
@@ -25,3 +25,4 @@ legend: ""
 montant: 200
 link: https://www.montpellier.fr/4241-dispositifs-d-aide-a-l-emploi-pour-les-jeunes.htm
 instructions: https://www.montpellier.fr/uploads/Document/ab/WEB_CHEMIN_11448_1291216968.pdf
+private: true


### PR DESCRIPTION
3 aides mises à jour (aides bafa de la Caf de la drome et aide vacances de la Caf du nord) et une dispositif supprimé (bourse au permis de la ville de Montpellier).