### PR TITLE
Met à jour 6 aides et supprime 2 aides

### DIFF
--- a/data/benefits/dynamic/fsl.ts
+++ b/data/benefits/dynamic/fsl.ts
@@ -112,9 +112,7 @@ export const FSL_BY_INSTITUTION_SLUG = {
   },
   intercommunalite_brest_metropole: {
     label: "de Brest Métropole",
-    link: "https://infosociale.finistere.fr/etablissement/brest-metropole-fsl-fonds-de-solidarite-logement/",
-    instructions:
-      "https://infosociale.finistere.fr/etablissement/brest-metropole-fsl-fonds-de-solidarite-logement/",
+    link: "https://brest.fr/gerer-mon-quotidien/logement/demander-le-fonds-de-solidarite-logement-fsl",
   },
   departement_gard: {
     label: "du département du Gard",

--- a/data/benefits/javascript/caf-loiret-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loiret-aide-bafa-approfondissement.yml
@@ -1,9 +1,11 @@
 label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_loiret
-description: L'aide à la formation du BAFA est une aide locale mise à
-  disposition par la CAF du Loiret pour vous aider à financer votre session
-  d’approfondissement ou de qualification en complément de l'aide nationale
-  apportée par la CAF.
+description:
+  La CAF du Loiret vous aide à financer votre session de formation d'approfondissement
+  (troisième et dernière étape du diplôme du BAFA) en complément de l'aide nationale apportée par la CNAF.
+  Le dossier de demande doit être complété, signé et adressé à la CAF du Loiret à l’issue
+  de la formation d'approfondissement, dans un délai maximum de 3 mois. L’aide est versée en une seule fois
+  au jeune ou à sa famille.
 prefix: l’
 conditions_generales:
   - type: age
@@ -18,13 +20,13 @@ conditions_generales:
 profils: []
 conditions:
   - Être allocataire ou rattaché au dossier allocataire de vos parents.
-  - Adresser votre demande à la CAF, dans un délai maximum de trois mois après
-    la date de début de la session d'approfondissement.
+  - Adresser votre demande à la CAF, dans un délai maximum de trois mois à l'issue de la session d'approfondissement.
 interestFlag: _interetBafa
 type: float
 unit: €
 periodicite: ponctuelle
 legend: maximum
-montant: 250
-link: https://www.caf.fr/sites/default/files/medias/451/Vie-professionnelle/Bafa_%202024.pdf
-form: https://www.caf.fr/sites/default/files/medias/451/Vie-professionnelle/2024-Formulaire-Bafa-Caf45.pdf
+montant: 200
+link: https://caf.fr/allocataires/caf-du-loiret/offre-de-service/vie-professionnelle/vous-souhaitez-devenir-animateur-grace-au-bafa-bafd
+instructions: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/Bafa_2025.pdf
+form: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/2025-Formulaire-Bafa-Caf45.pdf

--- a/data/benefits/javascript/caf-loiret-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loiret-aide-bafa-generale.yml
@@ -1,8 +1,11 @@
 label: aide au BAFA pour une session de formation générale
 institution: caf_loiret
-description: L'aide à la formation du BAFA est une aide locale mise à
-  disposition par la CAF du Loiret pour vous aider à financer votre session en
-  complément de l'aide nationale apportée par la CAF.
+description:
+  La CAF du Loiret vous aide à financer votre session de formation générale
+  (première étape du diplôme du BAFA) en complément de l'aide nationale apportée par la CNAF.
+  Le dossier de demande doit être complété, signé et adressé à la CAF du Loiret à l’issue
+  de la formation générale, dans un délai maximum de 3 mois. L’aide est versée en une seule fois
+  au jeune ou à sa famille.
 prefix: l’
 conditions_generales:
   - type: age
@@ -17,13 +20,13 @@ conditions_generales:
 profils: []
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.
-  - Adresser votre demande à la CAF, dans un délai maximum de trois mois après
-    la date de début de la formation générale.
+  - Adresser votre demande à la CAF du Loiret, dans un délai maximum de trois mois à l'issue de la formation générale.
 interestFlag: _interetBafa
 type: float
 unit: €
 periodicite: ponctuelle
 legend: maximum
-montant: 350
-link: https://www.caf.fr/sites/default/files/medias/451/Vie-professionnelle/Bafa_%202024.pdf
-form: https://www.caf.fr/sites/default/files/medias/451/Vie-professionnelle/2024-Formulaire-Bafa-Caf45.pdf
+montant: 300
+link: https://caf.fr/allocataires/caf-du-loiret/offre-de-service/vie-professionnelle/vous-souhaitez-devenir-animateur-grace-au-bafa-bafd
+instructions: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/Bafa_2025.pdf
+form: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/2025-Formulaire-Bafa-Caf45.pdf

--- a/data/benefits/javascript/departement_landes-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/departement_landes-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
@@ -1,8 +1,11 @@
-label: "Aide au financement du permis de conduire : Permis citoyen"
+label: Aide au financement du permis de conduire au titre d'un parcours d'engagement
 institution: departement_landes
-description: Ce dispositif permet aux jeunes Landais de financer
-  leur permis de conduire en contrepartie d’une mission bénévole de 40 heures
-  réalisée dans une collectivité ou une association des Landes. Les demandes de
+description:
+  Ce dispositif permet aux jeunes Landais de financer leur permis de conduire
+  en contrepartie d’un parcours d'engagement. Il peut s'agir d'un service civique,
+  d'un engagement au sein du Corps Européen de Solidarité, d'un mandat de  conseiller municipal /intercommunal des jeunes et des enfants,
+  d'un mandat au sein d’une Association Temporaire d’Enfants Citoyens (ATEC) ou d’une Junior Association,
+  ou d'une mission bénévole de 40 heures réalisée dans une association des Landes. Les demandes de
   bourse sont à effectuer en ligne.
 prefix: l’
 conditions_generales:
@@ -15,9 +18,11 @@ conditions_generales:
   - type: age
     operator: <=
     value: 30
+conditions:
+  - Réaliser un parcours d'engagement.
 voluntary_conditions:
   - Être engagé dans une mission bénévole de 40 heures minimum dans une
-    collectivité ou une association des Landes.
+    collectivité ou une association des Landes, si vous avez choisi de vous engager comme bénévole.
 profils: []
 interestFlag: _interetPermisDeConduire
 type: float
@@ -25,5 +30,5 @@ unit: €
 periodicite: ponctuelle
 legend: maximum
 montant: 450
-link: https://www.landes.fr/detail-aide?id_aide=161
-teleservice: https://messervices.landes.fr/
+link: https://m.landes.fr/detail-une-aide?id_aide=161
+instructions: https://m.landes.fr/detail-une-aide?id_aide=161

--- a/data/benefits/javascript/departement_landes-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/departement_landes-aide-au-financement-du-permis-de-conduire-permis-citoyen.yml
@@ -2,11 +2,9 @@ label: Aide au financement du permis de conduire au titre d'un parcours d'engage
 institution: departement_landes
 description:
   Ce dispositif permet aux jeunes Landais de financer leur permis de conduire
-  en contrepartie d’un parcours d'engagement. Il peut s'agir d'un service civique,
-  d'un engagement au sein du Corps Européen de Solidarité, d'un mandat de  conseiller municipal /intercommunal des jeunes et des enfants,
-  d'un mandat au sein d’une Association Temporaire d’Enfants Citoyens (ATEC) ou d’une Junior Association,
-  ou d'une mission bénévole de 40 heures réalisée dans une association des Landes. Les demandes de
-  bourse sont à effectuer en ligne.
+  en contrepartie d’un parcours d'engagement (service civique, engagement au sein du Corps Européen de Solidarité,
+  mandat de conseiller municipal/intercommunal des jeunes, mandat au sein d’une Association Temporaire d’Enfants Citoyens (ATEC)
+  ou d’une Junior Association, mission bénévole de 40 heures réalisée dans une association des Landes).
 prefix: l’
 conditions_generales:
   - type: departements

--- a/data/benefits/javascript/region-ile-de-france-vehicules-propres.yml
+++ b/data/benefits/javascript/region-ile-de-france-vehicules-propres.yml
@@ -25,3 +25,4 @@ unit: €
 periodicite: ponctuelle
 legend: maximum
 montant: 3000
+private: true

--- a/data/benefits/javascript/ville-dunkerque-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-dunkerque-bourse-communale-au-permis-de-conduire.yml
@@ -4,8 +4,7 @@ description:
   Les villes de Dunkerque, Saint-Pol-sur-Mer et Fort-Mardyck permettent
   à certains jeunes aux ressources modestes de bénéficier du financement d'une partie de leur permis B,
   en échange de 50 heures d'engagement bénévole dans une association.
-  Les bourses sont attribuées après un passage en commission et si votre dossier est sélectionné,
-  l’aide est versée directement à l’auto-école une fois la totalité des heures de bénévolat réalisée.
+  Si votre dossier est sélectionné, la bourse est versée à l’auto-école une fois la totalité des heures de bénévolat réalisée.
 prefix: la
 conditions_generales:
   - type: communes

--- a/data/benefits/javascript/ville-dunkerque-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-dunkerque-bourse-communale-au-permis-de-conduire.yml
@@ -1,16 +1,18 @@
 label: Bourse communale au permis de conduire
 institution: ville_dunkerque
 description:
-  La ville de Dunkerque permet à certains jeunes aux ressources  modestes de bénéficier du financement
-  d'une partie de leur permis B, en échange de 50 heures de travail bénévole
-  dans une association ou un service municipal. L’aide est versée directement à l’auto-école une fois la totalité des heures de bénévolat réalisée.
+  Les villes de Dunkerque, Saint-Pol-sur-Mer et Fort-Mardyck permettent
+  à certains jeunes aux ressources modestes de bénéficier du financement d'une partie de leur permis B,
+  en échange de 50 heures d'engagement bénévole dans une association.
+  Les bourses sont attribuées après un passage en commission et si votre dossier est sélectionné,
+  l’aide est versée directement à l’auto-école une fois la totalité des heures de bénévolat réalisée.
 prefix: la
-voluntary_conditions:
-  - Être engagé dans une mission bénévole de 50 heures minimum dans une association ou un service municipal.
 conditions_generales:
   - type: communes
     values:
       - "59183"
+      - "59540"
+      - "59248"
   - type: age
     operator: ">="
     value: 16
@@ -19,16 +21,16 @@ conditions_generales:
     value: 30
   - type: quotient_familial
     operator: <=
-    value: 1027
+    value: 1077
     period: month
 profils: []
 conditions:
-  - Résider dans la ville de Dunkerque ou une commune associée depuis au moins deux ans.
+  - Résider à Dunkerque, Saint-Pol-sur-Mer ou Fort-Mardyck depuis au moins deux ans.
+  - Prendre contact avec l'équipe "Parcours de réussite" de votre ville pour compléter votre dossier de demande de bourse.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €
 periodicite: autre
 montant: 600
-link: https://www.ville-dunkerque.fr/vous/jeunes-12-30-ans/parcours-de-reussite-jai-besoin-dun-coup-de-pouce
-form: https://www.ville-dunkerque.fr/fileadmin/user_upload/Jeunes_a_Dunkerque/2022/parcoursdereussite/Dossier_Mon_parcours_de_reussite_2023/Dossier_Mon_parcours_de_reussite_2023-2024.pdf
-instructions: https://www.ville-dunkerque.fr/fileadmin/user_upload/Jeunes_a_Dunkerque/2022/parcoursdereussite/Dossier_Mon_parcours_de_reussite_2023/Fiche_Aide_aux_permis_BAFA_BAFD_BNSSA.pdf
+link: https://www.ville-dunkerque.fr/vous/jeunes-12-30-ans/parcours-de-reussite-2
+instructions: https://www.ville-dunkerque.fr/fileadmin/user_upload/Jeunes_a_Dunkerque/Nouveau_fichier_parcours_de_reussite/DOSSIER_Parcours_de_Reussite.pdf

--- a/data/benefits/javascript/ville_villeurbanne_bourse_communale_permis_de_conduire.yml
+++ b/data/benefits/javascript/ville_villeurbanne_bourse_communale_permis_de_conduire.yml
@@ -1,11 +1,10 @@
 label: Bourse communale au permis de conduire
 institution: ville_villeurbanne
 description:
-  La ville de Villeurbanne propose une bourse au permis B afin d’aider les jeunes
-  pour qui l'accès au permis représente souvent un investissement lourd. En échange
-  de quelques heures de travaux d'utilité collective sous forme de chantier Jeune,
-  une bourse municipale de 500 €, soit plus du tiers du montant total du permis
-  de conduire, est directement versée à l'auto-école.
+  La bourse au permis de conduire est un dispositif qui permet aux jeunes de Villeurbanne
+  de financer une partie de leur formation du permis B. En contrepartie de la réalisation
+  de 35 heures de missions d’utilité publique, une bourse est versée directement
+  à l’auto-école dans laquelle est inscrit le jeune.
 prefix: la
 conditions_generales:
   - type: communes
@@ -13,7 +12,7 @@ conditions_generales:
       - "69266"
   - type: age
     operator: ">="
-    value: 18
+    value: 17
   - type: age
     operator: "<="
     value: 25
@@ -23,11 +22,11 @@ conditions:
   - Être dans l’impossibilité de payer la totalité du permis.
   - Avoir un projet d'insertion professionnelle.
 voluntary_conditions:
-  - Vous engager à réaliser quelques heures de travaux d'utilité collective sous forme de chantier Jeune.
+  - Vous engager à réaliser 35 heures de missions d’utilité publique.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €
 periodicite: ponctuelle
 montant: 500
 link: https://www.villeurbanne.fr/demarches/jeunesse/demander-une-bourse-au-permis-de-conduire
-teleservice: https://demarches.villeurbanne.fr/contacter-la-mairie/transmettre-mon-dossier-au-bij/
+form: https://www.villeurbanne.fr/docutheque/jeunesse/dossier-bpc-2025

--- a/data/benefits/openfisca/ile_de_france_aide_achat_voiture_electrique.yml
+++ b/data/benefits/openfisca/ile_de_france_aide_achat_voiture_electrique.yml
@@ -21,3 +21,4 @@ entity: individus
 openfiscaPeriod: thisMonth
 legend: maximum
 periodicite: ponctuelle
+private: true


### PR DESCRIPTION
Suppression :
Ile de France : les dispositif d'aide à l'achat d'une voiture électrique et de rétrofit sont supprimés à compter du 1er mai (2)
Mise à jour :
- fsl métropole de brest (1)
- aide bafa général et approfondissement caf du loiret (2)
- aide permis département des landes, ville dunkerque, vile villeurbanne (3)