### PR TITLE
fix: améloration vitesse chargement page d'accueil

### DIFF
--- a/src/components/home/hero-section.vue
+++ b/src/components/home/hero-section.vue
@@ -12,18 +12,6 @@ const benefitsNumber = process.env.VITE_BENEFIT_COUNT
 
 const hasExistingSituation = computed(() => store.passSanityCheck)
 
-const aideDomains = ref([
-  "logement",
-  "santé",
-  "famille",
-  "transports",
-  "études",
-  "formation",
-  "travail",
-  "loisirs",
-  "vacances",
-])
-
 const eventActionResume = EventAction.ReprendreMaSimulation
 const eventCategoryHome = EventCategory.Home
 
@@ -62,8 +50,8 @@ function next() {
           Découvrez toutes les aides financières auxquelles vous avez droit en
           matière de
           <b
-            >{{ aideDomains.slice(0, -1).join(", ") }} et
-            {{ aideDomains[aideDomains.length - 1] }}</b
+            >logement, transport, santé, formation, emploi, culture, sport et
+            alimentation</b
           >.
         </p>
         <p class="fr-text--xs fr-mb-2w fr-text--disabled">

--- a/src/components/home/hero-section.vue
+++ b/src/components/home/hero-section.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from "vue"
+import { computed } from "vue"
 import { EventAction, EventCategory } from "@lib/enums/event.js"
 import { useStore } from "@/stores/index.js"
 import { useRoute, useRouter } from "vue-router"


### PR DESCRIPTION
Section particulièrement lente qu'on peut améliorer en plaçant le texte en dur à la place d'une génération dynamique (cf. https://pagespeed.web.dev/analysis/https-mes-aides-1jeune1solution-beta-gouv-fr/kge02ikwdz?form_factor=mobile)

![image](https://github.com/user-attachments/assets/2cdad982-ceec-4ff5-b52f-98dcf74b3ff9)

![image](https://github.com/user-attachments/assets/3afd5b61-4134-45b8-86b0-73d9f1f691ff)
