### PR TITLE
Corrige le nom du test d'intégration - condition d'aide

### DIFF
--- a/tests/integration/benefits-description.spec.ts
+++ b/tests/integration/benefits-description.spec.ts
@@ -152,7 +152,7 @@ describe("benefit descriptions", function () {
             describe("conditions", function () {
               benefit.conditions.forEach((condition) => {
                 describe(`condition: '${condition}'`, function () {
-                  it("should end with a comma.", function () {
+                  it("should end with a point.", function () {
                     expect(condition).toMatch(/\.$/)
                   })
                   if (condition.includes('target="_blank"')) {


### PR DESCRIPTION
Ce test vérifie la présence d'un point en fin de phrase à la place d'une virgule