### PR TITLE
Répare la génération du fichier de stats en l'absence de données Matomo

### DIFF
--- a/backend/lib/stats/funnel-service.ts
+++ b/backend/lib/stats/funnel-service.ts
@@ -251,12 +251,14 @@ const getMatomoEventsData = async (
   const matomoEventData = await callMatomoAPI(piwikParameters)
   const dateKey = beginRange.format("YYYY-MM")
   return {
-    showAccompanimentCount: matomoEventData[dateKey].find(
-      (d) => d.label === "show-accompaniment-link",
-    )["nb_events"],
-    clickAccompanimentCount: matomoEventData[dateKey].find(
-      (d) => d.label === "click-accompaniment-link",
-    )["nb_events"],
+    showAccompanimentCount:
+      matomoEventData[dateKey].find(
+        (d) => d.label === "show-accompaniment-link",
+      )?.["nb_events"] || 0,
+    clickAccompanimentCount:
+      matomoEventData[dateKey].find(
+        (d) => d.label === "click-accompaniment-link",
+      )?.["nb_events"] || 0,
   }
 }
 


### PR DESCRIPTION
Corrige

```
(ma) ➜  aides-jeunes git:(main) node --loader ts-node/esm ./backend/lib/stats/index.ts
(node:2884713) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("ts-node/esm", pathToFileURL("./"));'
(Use `node --trace-warnings ...` to show where the warning was created)
(node:2884713) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
DB connected
TypeError: Cannot read properties of undefined (reading 'nb_events')
    at getMatomoEventsData (file:///home/thomas/repos/aides-jeunes/backend/lib/stats/funnel-service.ts:222:108)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Promise.allSettled (index 3)
    at async getFunnelData (file:///home/thomas/repos/aides-jeunes/backend/lib/stats/funnel-service.ts:238:79)
Returning empty data
``