### PR TITLE
Corrige l'affichage des aides sur la page dédiée

### DIFF
--- a/src/views/aide.vue
+++ b/src/views/aide.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="fr-article">
+  <div>
     <h1>Détail de l'aide</h1>
     <BackButton to="/aides" size="small" as-link class="fr-mb-2w">
       Retour à la liste des aides
@@ -12,7 +12,7 @@
       :ressources-year-minus-two-captured="true"
     />
     <DroitsContributions :droit="benefit" :show-contribution-links="true" />
-  </article>
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
AVANT
<img width="1567" height="1359" alt="Screenshot 2025-08-14 at 16-01-28 Simulateur d'aides 1jeune1solution" src="https://github.com/user-attachments/assets/f811b3a5-9f9a-4349-bdda-0e5da9e3e4db" />


APRES

<img width="1567" height="1359" alt="Screenshot 2025-08-14 at 16-01-51 Simulateur d'aides 1jeune1solution" src="https://github.com/user-attachments/assets/576b74c2-6048-4196-8fea-4bef4dfa2fb1" />


Il y a un
```css
.fr-article h2 {
  margin-top: 36px;
}
```
qui fout le bazar.