### PR TITLE
Corrige la marge supérieure du titre d'une aide (liste des aides)

### DIFF
--- a/src/styles/aides-jeunes.css
+++ b/src/styles/aides-jeunes.css
@@ -236,8 +236,11 @@ textarea {
   flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-
   gap: 32px;
+}
+
+.aj-benefit-header h2 {
+  margin-top: 0 !important;
 }
 
 .aj-benefit-name {


### PR DESCRIPTION
Correctif alternatiff à https://github.com/betagouv/aides-jeunes/pull/4979

# Avant
<img width="569" height="547" alt="image" src="https://github.com/user-attachments/assets/c2e0b238-1cc2-4dbf-9788-2f6a3c2508cc" />

# Après
<img width="569" height="547" alt="image" src="https://github.com/user-attachments/assets/199924d1-92fe-48e9-b11e-3fd826a783a9" />