### PR TITLE
Ajoute le bouton des lieux proches de chez soi à la fin du sondage

### DIFF
--- a/src/components/trouver-interlocuteur.vue
+++ b/src/components/trouver-interlocuteur.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-container fr-px-0 fr-mb-0 fr-py-2w">
+  <div class="fr-container fr-px-0 fr-mb-0">
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
       <div class="fr-col-12 fr-col-lg-7">
         <h2 class="fr-text--lead">Trouver de l'aide près de chez moi ?</h2>
@@ -17,7 +17,7 @@
               :to="{
                 name: 'resultatsLieuxGeneriques',
               }"
-              class="fr-btn fr-icon-map-pin-2-line fr-btn--icon-right fr-btn--icon-center fr-px-2w"
+              class="fr-btn fr-icon-map-pin-2-line fr-btn--icon-right fr-btn--icon-center fr-px-3v fr-btn--multiline"
               data-testid="nearby-help"
             >
               Trouver de l'aide

--- a/src/components/trouver-interlocuteur.vue
+++ b/src/components/trouver-interlocuteur.vue
@@ -1,21 +1,23 @@
 <template>
   <div class="fr-container fr-px-0 fr-mb-0 fr-py-2w">
     <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-      <div class="fr-col">
-        <h2 class="fr-text--lead">Trouver de l'aide près de chez moi</h2>
+      <div class="fr-col-12 fr-col-lg-7">
+        <h2 class="fr-text--lead">Trouver de l'aide près de chez moi ?</h2>
         <p
           >Pour vous aider dans vos démarches, n'hésitez pas à consulter la
           liste des lieux où vous pourrez être accompagné.</p
         >
       </div>
-      <div class="fr-col-12 fr-col-md-3">
-        <ul class="fr-btns-group fr-btns-group--inline-md">
+      <div class="fr-col-12 fr-col-lg-5">
+        <ul
+          class="fr-btns-group fr-btns-group--inline-md fr-btns-group--center"
+        >
           <li>
             <router-link
               :to="{
                 name: 'resultatsLieuxGeneriques',
               }"
-              class="fr-btn"
+              class="fr-btn fr-icon-map-pin-2-line fr-btn--icon-right fr-btn--icon-center fr-px-2w"
               data-testid="nearby-help"
             >
               Trouver de l'aide

--- a/src/views/suivi.vue
+++ b/src/views/suivi.vue
@@ -30,6 +30,12 @@
                   minutes par une personne de notre équipe.</p
                 >
               </div>
+              <div
+                v-if="showFailedAnswerBlock"
+                class="fr-alert fr-alert--info fr-mt-4w fr-px-8w fr-py-3w"
+              >
+                <TrouverInterlocuteur />
+              </div>
             </div>
           </div>
         </div>
@@ -196,6 +202,7 @@ import StatisticsMixin from "@/mixins/statistics.js"
 import { EventAction, EventCategory } from "@lib/enums/event.js"
 import { useFollowupSurveyData } from "@/composables/use-followup-survey-data.js"
 import ABTestingService from "@/plugins/ab-testing-service"
+import TrouverInterlocuteur from "@/components/trouver-interlocuteur.vue"
 
 const choices = [
   { value: "already", label: "Rien, j'en bénéficiais déjà." },
@@ -243,6 +250,10 @@ const showAccompanimentBlock = computed(() => {
   // )
   return false
 })
+
+const showFailedAnswerBlock = computed(() =>
+  benefitsWithChoice.value.some((droit) => droit.choiceValue === "failed"),
+)
 
 const accompanimentClickEvent = computed(() => {
   return {

--- a/src/views/suivi.vue
+++ b/src/views/suivi.vue
@@ -30,10 +30,8 @@
                   minutes par une personne de notre équipe.</p
                 >
               </div>
-              <div
-                v-if="showFailedAnswerBlock"
-                class="fr-alert fr-alert--info fr-mt-4w fr-px-8w fr-py-3w"
-              >
+              <div v-if="showFailedAnswerBlock">
+                <hr class="fr-my-4w" />
                 <TrouverInterlocuteur />
               </div>
             </div>


### PR DESCRIPTION
Lorsqu'un utilisateur réponds au moins une fois comme ceci dans le sondage ⬇️ 

<img width="708" height="268" alt="image" src="https://github.com/user-attachments/assets/4e6bc16f-6b2b-49bd-9f08-48cd4b86a150" />

Alors on lui affiche le bouton des lieux proches de chez lui pour qu'il puisse être aidé ⬇️ 

<img width="1327" height="601" alt="image" src="https://github.com/user-attachments/assets/6a67d2ce-f75b-4a1c-9407-c5310612aa0e" />

---

J'ai amélioré un peu le composant [trouver-interlocuteur](https://github.com/betagouv/aides-jeunes/blob/dd437830365e8a2802534adf95043810bb8e398a/src/components/trouver-interlocuteur.vue) au passage
