### PR TITLE
Ajoute un bouton d'accompagnementà la fin du sondage

### DIFF
--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -91,12 +91,18 @@ export function getFollowupDataForSurvey(req: Request, res: Response) {
     usefullnessSurvey?.answers.find((answer) => answer.id === "wasUseful")
       ?.value ?? true // La simulation est utile par défaut
 
+  const depcomAnswer = req.followup.simulation?.answers?.all?.find(
+    (answer) => answer.entityName === "menage" && answer.fieldName === "depcom",
+  )
+  const simulationCommune = depcomAnswer?.value._nomCommune || ""
+
   res.send({
     createdAt: req.followup.createdAt,
     benefits: req.followup.benefits.filter(
       (benefit) => benefit.id in Benefits.benefitsMap,
     ),
     simulationWasUseful,
+    simulationCommune,
   } as FetchSurvey)
 }
 
@@ -151,7 +157,7 @@ export async function followupByAccessToken(
 ) {
   const followup: Followup | null = await Followups.findOne({
     accessToken,
-  })
+  }).populate("simulation")
   if (!followup) return res.sendStatus(ErrorStatus.NotFound)
   req.followup = followup
   next()

--- a/lib/types/survey.d.ts
+++ b/lib/types/survey.d.ts
@@ -34,4 +34,5 @@ interface FetchSurvey {
     amount: number | boolean
   }[]
   simulationWasUseful: boolean
+  simulationCommune?: string
 }

--- a/src/components/trouver-interlocuteur.vue
+++ b/src/components/trouver-interlocuteur.vue
@@ -17,7 +17,7 @@
               :to="{
                 name: 'resultatsLieuxGeneriques',
               }"
-              class="fr-btn fr-icon-map-pin-2-line fr-btn--icon-right fr-btn--icon-center fr-px-3v fr-btn--multiline"
+              class="fr-btn fr-icon-map-pin-2-line fr-btn--icon-right fr-btn--icon-center fr-px-2w fr-btn--multiline"
               data-testid="nearby-help"
             >
               Trouver de l'aide

--- a/src/composables/use-followup-survey-data.ts
+++ b/src/composables/use-followup-survey-data.ts
@@ -14,6 +14,7 @@ export function useFollowupSurveyData(token: string) {
   const benefitsWithChoice = ref<BenefitWithChoice[]>([])
   const simulationWasUseful = ref<boolean>(false)
   const loading = ref<boolean>(true)
+  const simulationCommune = ref<string>("")
   const store = useStore()
   const router = useRouter()
 
@@ -26,6 +27,7 @@ export function useFollowupSurveyData(token: string) {
       "DD MMMM YYYY",
     )
     simulationWasUseful.value = followupSurveyData.simulationWasUseful
+    simulationCommune.value = followupSurveyData.simulationCommune || ""
     const benefits: StandardBenefit[] = followupSurveyData.benefits.map(
       (benefit) => ({
         ...getBenefit(benefit.id),
@@ -57,5 +59,6 @@ export function useFollowupSurveyData(token: string) {
     benefitsWithChoice,
     simulationWasUseful,
     loading,
+    simulationCommune,
   }
 }

--- a/src/views/suivi.vue
+++ b/src/views/suivi.vue
@@ -33,6 +33,22 @@
               <div v-if="showFailedAnswerBlock">
                 <hr class="fr-my-4w" />
                 <TrouverInterlocuteur />
+                <div v-if="showCityAccompanimentBlock">
+                  <hr class="fr-my-4w" />
+                  <p>
+                    {{ currentAccompanimentLink?.title }} peut aussi vous
+                    accompagner gratuitement dans vos démarches. N'hésitez pas à
+                    prendre rendez-vous :
+                  </p>
+                  <a
+                    class="fr-btn fr-btn--secondary fr-btn--lg"
+                    :href="currentAccompanimentLink?.link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Je prends rendez-vous pour me faire aider dans mes démarches
+                  </a>
+                </div>
               </div>
             </div>
           </div>
@@ -224,8 +240,13 @@ function showReasonQuestion(droit) {
 
 const route = useRoute()
 const submitted = ref(false)
-const { followupCreatedAt, benefitsWithChoice, simulationWasUseful, loading } =
-  useFollowupSurveyData(route.query.token as string)
+const {
+  followupCreatedAt,
+  benefitsWithChoice,
+  simulationWasUseful,
+  loading,
+  simulationCommune,
+} = useFollowupSurveyData(route.query.token as string)
 
 const isComplete = computed(() => {
   const choiceValues = benefitsWithChoice.value.map(
@@ -240,6 +261,29 @@ const isComplete = computed(() => {
 const showPlansToAskQuestion = (choiceValue) =>
   choiceValue === "nothing" &&
   ABTestingService.getValues().plans_to_ask_question === "show"
+
+const accompanimentLinks: Record<string, { title: string; link: string }> = {
+  Montpellier: {
+    title: "Le CCAS de Montpellier",
+    link: "https://rdv.anct.gouv.fr/org/259/ccas-montpellier",
+  },
+  Strasbourg: {
+    title: "La ville de Strasbourg",
+    link: "https://demarches.strasbourg.eu/rdv-tel-1jeune1solution/",
+  },
+  Aubervilliers: {
+    title: "Le CCAS d'Aubervilliers",
+    link: "https://rdv.anct.gouv.fr/org/166/ccas-aubervilliers",
+  },
+}
+
+const showCityAccompanimentBlock = computed(() => {
+  return simulationCommune.value in accompanimentLinks
+})
+
+const currentAccompanimentLink = computed(() => {
+  return accompanimentLinks[simulationCommune.value]
+})
 
 const showAccompanimentBlock = computed(() => {
   // To restore when the budget will be back


### PR DESCRIPTION
Suit la PR #5043.

Pour les utilisateurs en difficulté, affiché uniquement pour les CCAS/villes qui le propose :

- Aubervilliers
- Strasbourg
- Montpellier
---

Exemple pour un sondage issu d'une simulation à Montpellier (le CCAS de Montpellier propose un accompagnement) : 

<img width="923" height="1245" alt="image" src="https://github.com/user-attachments/assets/47d8b873-8f4c-438f-9bfc-ab6ae5a0601b" />
