### PR TITLE
chore(cd) : upgrade version de node

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Cache NPM install files
         uses: actions/cache@v4
         id: restore-npm-install-packages


### PR DESCRIPTION
Suite à l'upgrade de Next dans le package contribuer, il faut monter node en v4 dans l'installation de la CD

Cf: https://github.com/betagouv/aides-jeunes/actions/runs/21447394581/job/61774231990