### PR TITLE
Outil de contribution simplifié - supprime la contrainte de sélection d'une institution

### DIFF
--- a/backend/controllers/contributions.ts
+++ b/backend/controllers/contributions.ts
@@ -12,7 +12,6 @@ import {
   ContributionPullRequestStatus,
 } from "../../lib/enums/contribution.js"
 import {
-  checkInstitutionExists,
   commitBinaryFile,
   commitFile,
   createPullRequest,
@@ -24,7 +23,6 @@ import {
   buildBenefitPullRequestBody,
   buildInstitutionData,
   buildInstitutionPullRequestBody,
-  createDefaultInstitutionData,
   getImageExtension,
   isValidSlug,
   parseDataUrl,
@@ -120,38 +118,29 @@ export async function handleBenefitContribution(
       return res.status(400).json({ message: validationError })
     }
 
+    const institutionSlugToUse = institutionSlug || slugify(institutionName)
+    if (!isValidSlug(institutionSlugToUse)) {
+      return res.status(400).json({
+        message: "Le format de l'identifiant de l'institution est invalide",
+      })
+    }
+
+    const benefitBodyWithResolvedSlug: BenefitContributionBody = {
+      ...req.body,
+      institutionSlug: institutionSlugToUse,
+    }
+
     // Generate and validate benefit slug
-    const benefitSlug = `${institutionSlug}_${slugify(label)}`
+    const benefitSlug = `${institutionSlugToUse}_${slugify(label)}`
     if (!isValidSlug(benefitSlug)) {
       return res.status(400).json({ message: "Format benefitSlug invalide" })
     }
 
     // Build data
-    const benefitData = buildBenefitData(req.body)
+    const benefitData = buildBenefitData(benefitBodyWithResolvedSlug)
 
     const branchBase = `contribution/${benefitSlug}`
     const { githubApi, newBranch } = await initContributionBranch(branchBase)
-
-    // Check if institution exists
-    const institutionExists = await checkInstitutionExists(
-      institutionSlug,
-      githubApi,
-    )
-
-    // Commit files to new branch
-    if (!institutionExists) {
-      const institutionPath = `data/institutions/${institutionSlug}.yml`
-      const institutionFile = yamlDump(
-        createDefaultInstitutionData(institutionName, institutionSlug),
-      )
-      await commitFile(
-        githubApi,
-        institutionPath,
-        institutionFile,
-        newBranch,
-        `Contribution: ajout fichier ${institutionPath}`,
-      )
-    }
 
     const benefitPath = `data/benefits/javascript/${benefitSlug}.yml`
     await commitFile(

--- a/backend/controllers/contributions.ts
+++ b/backend/controllers/contributions.ts
@@ -26,6 +26,7 @@ import {
   getImageExtension,
   isValidSlug,
   parseDataUrl,
+  generateInstitutionSlug,
   slugify,
   validateRequiredBenefitFields,
   validateRequiredInstitutionFields,
@@ -110,7 +111,7 @@ export async function handleBenefitContribution(
   }
 
   try {
-    const { institutionName, institutionSlug, label } = req.body || {}
+    const { label } = req.body || {}
 
     // Validation
     const validationError = validateRequiredBenefitFields(req.body)
@@ -118,8 +119,9 @@ export async function handleBenefitContribution(
       return res.status(400).json({ message: validationError })
     }
 
-    const institutionSlugToUse = institutionSlug || slugify(institutionName)
-    if (!isValidSlug(institutionSlugToUse)) {
+    const institutionSlug = generateInstitutionSlug(req.body)
+
+    if (!isValidSlug(institutionSlug)) {
       return res.status(400).json({
         message: "Le format de l'identifiant de l'institution est invalide",
       })
@@ -127,11 +129,11 @@ export async function handleBenefitContribution(
 
     const benefitBodyWithResolvedSlug: BenefitContributionBody = {
       ...req.body,
-      institutionSlug: institutionSlugToUse,
+      institutionSlug,
     }
 
     // Generate and validate benefit slug
-    const benefitSlug = `${institutionSlugToUse}_${slugify(label)}`
+    const benefitSlug = `${institutionSlug}_${slugify(label)}`
     if (!isValidSlug(benefitSlug)) {
       return res.status(400).json({ message: "Format benefitSlug invalide" })
     }
@@ -155,7 +157,7 @@ export async function handleBenefitContribution(
       githubApi,
       title: `[Contribution] Ajout aide - ${label}`,
       branchName: newBranch,
-      body: buildBenefitPullRequestBody(req.body),
+      body: buildBenefitPullRequestBody(benefitBodyWithResolvedSlug),
       requestBody: req.body,
       category: ContributionCategory.BENEFIT,
       contributorName: req.body.contributorName,

--- a/backend/controllers/contributions.ts
+++ b/backend/controllers/contributions.ts
@@ -119,6 +119,7 @@ export async function handleBenefitContribution(
       return res.status(400).json({ message: validationError })
     }
 
+    const hasSelectedInstitution = Boolean(req.body.institutionSlug?.trim())
     const institutionSlug = generateInstitutionSlug(req.body)
 
     if (!isValidSlug(institutionSlug)) {
@@ -157,7 +158,10 @@ export async function handleBenefitContribution(
       githubApi,
       title: `[Contribution] Ajout aide - ${label}`,
       branchName: newBranch,
-      body: buildBenefitPullRequestBody(benefitBodyWithResolvedSlug),
+      body: buildBenefitPullRequestBody(
+        benefitBodyWithResolvedSlug,
+        hasSelectedInstitution,
+      ),
       requestBody: req.body,
       category: ContributionCategory.BENEFIT,
       contributorName: req.body.contributorName,

--- a/backend/controllers/contributions/contribution-data.ts
+++ b/backend/controllers/contributions/contribution-data.ts
@@ -68,16 +68,16 @@ export function validateRequiredBenefitFields(
     description,
   } = body
 
-  if (
-    !contributorEmail ||
-    !institutionName ||
-    !institutionSlug ||
-    !label ||
-    !description
-  ) {
-    return "Champs obligatoires manquants"
+  if (!contributorEmail || !label || !description) {
+    return "Les champs email, titre et description sont obligatoires"
   }
-  if (!isValidSlug(institutionSlug)) {
+
+  const institutionNameChars = (institutionName || "").replace(/\s/g, "")
+  if (institutionNameChars.length < 2) {
+    return "Le nom de l'institution doit contenir au moins 2 caractères"
+  }
+
+  if (institutionSlug && !isValidSlug(institutionSlug)) {
     return "Le format de l'identifiant de l'institution est invalide"
   }
   if (description.length > 5000) {
@@ -153,15 +153,19 @@ export function createDefaultInstitutionData(
 export function buildBenefitPullRequestBody(
   body: BenefitContributionBody,
 ): string {
-  const { label, institutionName, periodicite, description } = body
+  const { label, institutionName, institutionSlug, periodicite, description } =
+    body
 
   const sections = [
+    !institutionSlug &&
+      ":warning: L'institution associée à cette demande n'existe pas ou n'a pas été trouvée :warning:",
+    `Périodicité: ${periodicite}`,
     `Aide : **${label}**`,
     `Institution: ${institutionName}`,
-    `Périodicité: ${periodicite}`,
+
     `Description: ${description}`,
   ]
-  return sections.join("\n")
+  return sections.filter(Boolean).join("\n")
 }
 
 export function buildInstitutionPullRequestBody(params: {

--- a/backend/controllers/contributions/contribution-data.ts
+++ b/backend/controllers/contributions/contribution-data.ts
@@ -77,6 +77,11 @@ export function validateRequiredBenefitFields(
     return "Le nom de l'institution doit contenir au moins 2 caractères"
   }
 
+  const normalizedInstitutionSlug = slugify(institutionName || "")
+  if (!normalizedInstitutionSlug) {
+    return "Le nom de l'institution doit contenir au moins un caractère alphanumérique"
+  }
+
   if (institutionSlug && !isValidSlug(institutionSlug)) {
     return "Le format de l'identifiant de l'institution est invalide"
   }

--- a/backend/controllers/contributions/contribution-data.ts
+++ b/backend/controllers/contributions/contribution-data.ts
@@ -38,6 +38,7 @@ export function slugify(input: string) {
     .replace(/[^a-z0-9\s_-]/g, "")
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "")
     .slice(0, 80)
 }
 

--- a/backend/controllers/contributions/contribution-data.ts
+++ b/backend/controllers/contributions/contribution-data.ts
@@ -117,6 +117,11 @@ export function validateRequiredInstitutionFields(
   return null
 }
 
+export function generateInstitutionSlug(body: BenefitContributionBody): string {
+  const providedInstitutionSlug = body.institutionSlug?.trim()
+  return providedInstitutionSlug || slugify(body.institutionName)
+}
+
 export function buildBenefitData(body: BenefitContributionBody) {
   const {
     label,
@@ -158,12 +163,12 @@ export function createDefaultInstitutionData(
 export function buildBenefitPullRequestBody(
   body: BenefitContributionBody,
 ): string {
-  const { label, institutionName, institutionSlug, periodicite, description } =
-    body
+  const { label, institutionName, periodicite, description } = body
+  const hasSelectedInstitution = Boolean(body.institutionSlug?.trim())
 
   const sections = [
-    !institutionSlug &&
-      ":warning: L'institution associée à cette demande n'existe pas ou n'a pas été trouvée :warning:",
+    !hasSelectedInstitution &&
+      ":warning: Institution saisie manuellement à créer dans un second temps :warning:",
     `Périodicité: ${periodicite}`,
     `Aide : **${label}**`,
     `Institution: ${institutionName}`,

--- a/backend/controllers/contributions/contribution-data.ts
+++ b/backend/controllers/contributions/contribution-data.ts
@@ -66,10 +66,15 @@ export function validateRequiredBenefitFields(
     institutionSlug,
     label,
     description,
+    periodicite,
   } = body
 
   if (!contributorEmail || !label || !description) {
-    return "Les champs email, titre et description sont obligatoires"
+    return "Les champs email, titre et description sont requis"
+  }
+
+  if (!periodicite) {
+    return "La sélection d'une périodicité est requise"
   }
 
   const institutionNameChars = (institutionName || "").replace(/\s/g, "")
@@ -144,7 +149,7 @@ export function buildBenefitData(body: BenefitContributionBody) {
     instructions,
     form,
     teleservice,
-    periodicite: periodicite || "ponctuelle",
+    periodicite,
   }
 }
 

--- a/backend/controllers/contributions/contribution-data.ts
+++ b/backend/controllers/contributions/contribution-data.ts
@@ -162,9 +162,9 @@ export function createDefaultInstitutionData(
 
 export function buildBenefitPullRequestBody(
   body: BenefitContributionBody,
+  hasSelectedInstitution: boolean,
 ): string {
   const { label, institutionName, periodicite, description } = body
-  const hasSelectedInstitution = Boolean(body.institutionSlug?.trim())
 
   const sections = [
     !hasSelectedInstitution &&

--- a/lib/types/contributions.d.ts
+++ b/lib/types/contributions.d.ts
@@ -11,7 +11,7 @@ export interface BenefitContributionBody {
   contributorName?: string
   contributorEmail: string
   institutionName: string
-  institutionSlug: string
+  institutionSlug?: string | null
   label: string
   description: string
   criteres?: Record<string, string>

--- a/lib/types/contributions.d.ts
+++ b/lib/types/contributions.d.ts
@@ -21,7 +21,7 @@ export interface BenefitContributionBody {
   form?: string
   teleservice?: string
   type?: string
-  periodicite?: string
+  periodicite: string
   conditions?: string
 }
 

--- a/src/components/institution-select.vue
+++ b/src/components/institution-select.vue
@@ -12,7 +12,8 @@
         <span class="fr-text--error">*</span></label
       >
       <span class="fr-hint-text"
-        >Si votre institution n'apparaît pas dans la liste, vous pouvez
+        >Si votre institution n'apparaît pas dans la liste, vous pouvez écrire
+        son nom ou
         <router-link to="/contribuer/institution"
           ><b>l'ajouter en cliquant ici</b></router-link
         >.</span
@@ -61,19 +62,19 @@ interface Institution {
 }
 
 interface Props {
-  institutionSlug?: string
+  institutionSlug?: string | null
   institutionName?: string
   hasError?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   hasError: false,
-  institutionSlug: "",
+  institutionSlug: null,
   institutionName: "",
 })
 
 const emit = defineEmits<{
-  "update:institutionSlug": [value: string]
+  "update:institutionSlug": [value: string | null]
   "update:institutionName": [value: string]
   clearError: []
   selected: [value: Institution]
@@ -136,7 +137,7 @@ watch(filter, (value) => {
 })
 
 function handleInput() {
-  emit("update:institutionSlug", "")
+  emit("update:institutionSlug", null)
   emit("update:institutionName", filter.value)
   showDropdown.value = true
   emit("clearError")

--- a/src/lib/fetch-json.ts
+++ b/src/lib/fetch-json.ts
@@ -1,0 +1,10 @@
+export function postJson(url: string, payload: unknown) {
+  return fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  })
+}

--- a/src/views/contribuer/add-benefit.vue
+++ b/src/views/contribuer/add-benefit.vue
@@ -5,6 +5,7 @@ import InstitutionSelect from "@/components/institution-select.vue"
 import LoadingOverlay from "@/components/loading-overlay.vue"
 import InputTextareaMax from "@/components/input-textarea-max.vue"
 import ContributionNavigation from "@/components/contribution-navigation.vue"
+import { postJson } from "@/lib/fetch-json"
 
 const sending = ref(false)
 const sent = ref(false)
@@ -185,14 +186,7 @@ async function submit() {
       payload.conditions = conditionsText.value.trim()
     }
 
-    const response = await fetch("/api/contributions/benefit", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify(payload),
-    })
+    const response = await postJson("/api/contributions/benefit", payload)
 
     const data = await response.json().catch(() => null)
 

--- a/src/views/contribuer/add-benefit.vue
+++ b/src/views/contribuer/add-benefit.vue
@@ -33,7 +33,7 @@ const contributorName = ref("")
 const contributorOrganization = ref("")
 const contributorEmail = ref("")
 const institutionName = ref("")
-const institutionSlug = ref("")
+const institutionSlug = ref<string | null>(null)
 const label = ref("")
 const description = ref("")
 const descriptionMax = 5000
@@ -92,12 +92,9 @@ function validate(): boolean {
     e.push("L'email du contributeur n'est pas valide")
     ef.push("contributorEmail")
   }
-  if (!institutionName.value.trim()) {
-    e.push("Le nom de l'institution est requis")
-    ef.push("institutionName")
-  }
-  if (!institutionSlug.value) {
-    e.push("Vous devez sélectionner une institution dans la liste proposée")
+  const institutionNameChars = institutionName.value.replace(/\s/g, "")
+  if (institutionNameChars.length < 2) {
+    e.push("Une institution existante ou un nom d'institution est requis")
     ef.push("institutionName")
   }
   if (!label.value.trim()) {
@@ -167,6 +164,7 @@ async function submit() {
         contributorOrganization.value?.trim() || undefined,
       contributorEmail: contributorEmail.value.trim(),
       institutionName: institutionName.value.trim(),
+      institutionSlug: institutionSlug.value,
       label: label.value.trim(),
       description: description.value.trim(),
       periodicite: selectedPeriodicite.value,
@@ -174,11 +172,6 @@ async function submit() {
       teleservice: teleservice.value.trim() || undefined,
       form: form.value.trim() || undefined,
       instructions: instructions.value.trim() || undefined,
-    }
-
-    // Ajouter institutionSlug seulement s'il existe
-    if (institutionSlug.value) {
-      payload.institutionSlug = institutionSlug.value
     }
 
     // Ajouter conditions seulement si non vide
@@ -302,7 +295,7 @@ async function submit() {
                   :institution-name="institutionName"
                   :has-error="errorFields.includes('institutionName')"
                   @update:institution-slug="
-                    (val: string) => {
+                    (val: string | null) => {
                       institutionSlug = val
                     }
                   "

--- a/src/views/contribuer/add-benefit.vue
+++ b/src/views/contribuer/add-benefit.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref, nextTick } from "vue"
-import axios from "axios"
 import { EventAction, EventCategory } from "@lib/enums/event"
 import InstitutionSelect from "@/components/institution-select.vue"
 import LoadingOverlay from "@/components/loading-overlay.vue"
@@ -186,23 +185,45 @@ async function submit() {
       payload.conditions = conditionsText.value.trim()
     }
 
-    await axios.post("/api/contributions/benefit", payload)
+    const response = await fetch("/api/contributions/benefit", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    })
+
+    const data = await response.json().catch(() => null)
+
+    if (!response.ok) {
+      if (data?.missingFields) {
+        generalError.value = `Champs manquants : ${data.missingFields.join(", ")}`
+        errorFields.value = data.missingFields
+      } else if (data?.errors) {
+        generalError.value = `Erreurs : ${JSON.stringify(data.errors)}`
+      } else {
+        generalError.value =
+          data?.message || "Erreur lors de l'envoi de la contribution"
+      }
+
+      // Scroll vers le message d'erreur
+      await nextTick()
+      const alertElement = document.querySelector(".fr-alert--error")
+      if (alertElement) {
+        alertElement.scrollIntoView({ behavior: "smooth", block: "start" })
+      }
+      return
+    }
+
     sent.value = true
 
     // Scroll vers le message de succès
     await nextTick()
     window.scrollTo({ top: 0, behavior: "smooth" })
-  } catch (err: any) {
-    const data = err?.response?.data
-    if (data?.missingFields) {
-      generalError.value = `Champs manquants : ${data.missingFields.join(", ")}`
-      errorFields.value = data.missingFields
-    } else if (data?.errors) {
-      generalError.value = `Erreurs : ${JSON.stringify(data.errors)}`
-    } else {
-      generalError.value =
-        data?.message || "Erreur lors de l'envoi de la contribution"
-    }
+  } catch (err: unknown) {
+    console.error("Erreur lors de l'envoi:", err)
+    generalError.value = "Erreur réseau lors de l'envoi de la contribution"
 
     // Scroll vers le message d'erreur
     await nextTick()

--- a/src/views/contribuer/institution.vue
+++ b/src/views/contribuer/institution.vue
@@ -3,6 +3,7 @@ import { ref } from "vue"
 import InstitutionLogoUpload from "@/components/institution-logo-upload.vue"
 import LoadingOverlay from "@/components/loading-overlay.vue"
 import ContributionNavigation from "@/components/contribution-navigation.vue"
+import { postJson } from "@/lib/fetch-json"
 
 const sending = ref(false)
 const sent = ref(false)
@@ -112,14 +113,7 @@ async function submit() {
       payload.logoBase64 = logoBase64
     }
 
-    const response = await fetch("/api/contributions/institution", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify(payload),
-    })
+    const response = await postJson("/api/contributions/institution", payload)
 
     const data = await response.json().catch(() => null)
 

--- a/src/views/contribuer/institution.vue
+++ b/src/views/contribuer/institution.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref } from "vue"
-import axios from "axios"
 import InstitutionLogoUpload from "@/components/institution-logo-upload.vue"
 import LoadingOverlay from "@/components/loading-overlay.vue"
 import ContributionNavigation from "@/components/contribution-navigation.vue"
@@ -91,7 +90,6 @@ async function submit() {
     } catch {
       generalError.value =
         "Erreur lors du traitement de l'image du logo. Veuillez réessayer."
-      sending.value = false
       return
     }
 
@@ -114,23 +112,36 @@ async function submit() {
       payload.logoBase64 = logoBase64
     }
 
-    await axios.post("/api/contributions/institution", payload)
+    const response = await fetch("/api/contributions/institution", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    })
+
+    const data = await response.json().catch(() => null)
+
+    if (!response.ok) {
+      if (data?.missingFields) {
+        generalError.value = `Champs manquants : ${data.missingFields.join(", ")}`
+        errorFields.value = data.missingFields
+      } else if (data?.errors) {
+        generalError.value = `Erreurs : ${JSON.stringify(data.errors)}`
+      } else {
+        generalError.value =
+          data?.message || "Erreur lors de l'envoi de la demande d'institution"
+      }
+      return
+    }
 
     sent.value = true
     window.scrollTo({ top: 0, behavior: "smooth" })
-  } catch (err: any) {
-    console.error("Erreur lors de l'envoi:", err.response?.data || err)
-
-    const data = err?.response?.data
-    if (data?.missingFields) {
-      generalError.value = `Champs manquants : ${data.missingFields.join(", ")}`
-      errorFields.value = data.missingFields
-    } else if (data?.errors) {
-      generalError.value = `Erreurs : ${JSON.stringify(data.errors)}`
-    } else {
-      generalError.value =
-        data?.message || "Erreur lors de l'envoi de la demande d'institution"
-    }
+  } catch (err: unknown) {
+    console.error("Erreur lors de l'envoi:", err)
+    generalError.value =
+      "Erreur réseau lors de l'envoi de la demande d'institution"
   } finally {
     sending.value = false
   }


### PR DESCRIPTION
## Description

Cette PR modifie le formulaire d’ajout d’aide en supprimant la contrainte de devoir sélectionner une institution existante. Cela implique moins de friction pour le contributeur car il peut maintenant entrer un nom d'institution de son choix pour faire sa demande d'ajout d'aide.

## Changements clés

- Le formulaire “ajout d’aide” n’impose plus la sélection d’une institution existante.
- `institutionSlug` (correspondant au nom du fichier de l'institution) peut être nul si l'institution n'est pas existante (cas où l'utilisateur tape un nom d'institution qui ne correspond à aucune suggestion dans la liste des institutions)
- Si l'institution n'existe pas, le backend génère tout de même un slug (via le nom) pour pouvoir générer un nom de fichier pour la nouvelle aide 
- Le flux “ajout d’aide” ne crée plus de fichier institution (ce n'était pas un comportement souhaité).
- La création d’institution reste réservée au formulaire dédié `(/contribuer/institution`).
- Le corps de PR d’une aide affiche un message de warning en en-tête si aucune institution existante n’a été trouvée.