### PR TITLE
Update aide_permis_demandeur_emploi.yml

### DIFF
--- a/data/benefits/openfisca/aide_permis_demandeur_emploi.yml
+++ b/data/benefits/openfisca/aide_permis_demandeur_emploi.yml
@@ -15,3 +15,4 @@ legend: "maximum"
 entity: individus
 openfiscaPeriod: thisMonth
 interestFlag: _interetPermisDeConduire
+private: true


### PR DESCRIPTION
cette aide n'existe plus depuis le 1er avril 2026
source : https://www.service-public.gouv.fr/particuliers/vosdroits/F1719