### PR TITLE
fix(sentry): corrige l'erreur "Maximum call stack size exceeded" - page des ressources

### DIFF
--- a/src/components/ressource/types.vue
+++ b/src/components/ressource/types.vue
@@ -186,7 +186,7 @@ export default {
       this.$push()
     },
     sort(array) {
-      return array.sort(
+      return [...array].sort(
         (a, b) =>
           (a.positionInList || Infinity) - (b.positionInList || Infinity) ||
           a.label.localeCompare(b.label),


### PR DESCRIPTION
## Problème

Une erreur `RangeError: Maximum call stack size exceeded` était rapportée dans Sentry (AIDES-JEUNES-FRONT-30M https://sentry.incubateur.net/organizations/betagouv/issues/182130/?project=18&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream) sur la page `/simulation/individu/demandeur/ressources/types`.

### Cause

La méthode `sort()` dans `src/components/ressource/types.vue` appelait `array.sort()` directement sur le tableau passé en argument, ce qui **mutait le tableau d'origine**.

Ce tableau provient de `typesByCategories`, une propriété `data()` donc **réactive** dans Vue. La séquence d'événements était :

1. L'utilisateur clique sur une checkbox
2. Vue met à jour `selectedTypes` → re-rendu du template
3. Le template appelle `sort(typesByCategories[category.id])`
4. `array.sort()` mute `typesByCategories` → Vue détecte la mutation → re-rendu
5. Retour à l'étape 3 → boucle infinie → stack overflow

### Correction

Trier une **copie superficielle** du tableau avec `[...array].sort(...)` pour ne pas affecter les données réactives.

```diff
- return array.sort(...)
+ return [...array].sort(...)
```