### PR TITLE
fix(sentry): évite Unhandled Axios network error sur le pré-chargement des paramètres OpenFisca

### DIFF
--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -545,6 +545,7 @@ export const useStore = defineStore("store", {
         .then((response) => {
           this.openFiscaParameters = response.data
         })
+        .catch(() => undefined) // Prevent unhandled promise rejection noise in Sentry on network hiccups.
     },
     verifyOpenfiscaBenefitVariables() {
       return axios


### PR DESCRIPTION
## Contexte
Sentry issue: https://github.com/betagouv/aides-jeunes/issues/5156

`store.setOpenFiscaParameters()` est appelé au démarrage de l'application. En cas d'échec réseau Axios, la promesse pouvait remonter en rejet non géré, ce qui générait un bruit Sentry (`onunhandledrejection`, `AxiosError: Network Error`).

## Changement
- ajout d'un `catch` dans `setOpenFiscaParameters()` pour absorber les erreurs réseau de préchargement.
- commentaire court pour documenter l'intention.

## Impact
- évite la remontée de cette erreur en unhandled promise rejection.
- n'impacte pas le parcours utilisateur: ce chargement reste best-effort.