### PR TITLE
veille: un Parrain, un Emploi — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/region-provence-alpes-cote-azur-un-parrain-un-emploi.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-un-parrain-un-emploi.yml
@@ -23,3 +23,4 @@ unit: €
 periodicite: autre
 link: https://www.maregionsud.fr/vos-aides/detail/un-parrain-un-emploi
 teleservice: https://www.pole-emploi.fr/region/provence-alpes-cote-d-azur/employeur/un-parrain-un-emploi.html
+private: true


### PR DESCRIPTION
## Dispositif : un Parrain, un Emploi
- Institution : region_provence_alpes_cote_azur

### Lien(s) cassé(s) détecté(s)

- [teleservice] https://www.pole-emploi.fr/region/provence-alpes-cote-d-azur/employeur/un-parrain-un-emploi.html → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.