### PR TITLE
veille: fonds d'aide à la mobilité vers l'emploi — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/region-nouvelle-aquitaine-fonds-aide-mobilite-emploi.yml
+++ b/data/benefits/javascript/region-nouvelle-aquitaine-fonds-aide-mobilite-emploi.yml
@@ -19,3 +19,4 @@ legend: maximum
 montant: 2000
 link: https://les-aides.nouvelle-aquitaine.fr/amenagement-du-territoire/fonds-daide-la-mobilite-vers-lemploi
 teleservice: https://mes-demarches.nouvelle-aquitaine.fr/craPortailFO/externe/creationDossier.do?codeDispositif=FPC11-20
+private: true


### PR DESCRIPTION
## Dispositif : fonds d'aide à la mobilité vers l'emploi
- Institution : region_nouvelle_aquitaine

### Lien(s) cassé(s) détecté(s)

- [link] https://les-aides.nouvelle-aquitaine.fr/amenagement-du-territoire/fonds-daide-la-mobilite-vers-lemploi → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.