### PR TITLE
veille: bourses pour les formations sanitaires et sociales — lien(s) cassé(s)

### DIFF
--- a/data/benefits/javascript/region_pays_de_la_loire-bourses-pour-les-élèves-et-étudiant-e-s-en-formation-sanitaire-et-sociale.yml
+++ b/data/benefits/javascript/region_pays_de_la_loire-bourses-pour-les-élèves-et-étudiant-e-s-en-formation-sanitaire-et-sociale.yml
@@ -1,8 +1,9 @@
 label: bourses pour les formations sanitaires et sociales
 institution: region_pays_de_la_loire
-description:
-  La Région finance des bourses pour les élèves, étudiants et étudiantes en formation initiale sociale, paramédicale ou de sages-femmes, dont
-  les revenus familiaux ou personnels sont reconnus insuffisants au regard de leurs charges.
+description: La Région finance des bourses pour les élèves, étudiants et
+  étudiantes en formation initiale sociale, paramédicale ou de sages-femmes,
+  dont les revenus familiaux ou personnels sont reconnus insuffisants au regard
+  de leurs charges.
 conditions:
   - Suivre une formation agréée ou autorisée par la Région Pays de la Loire.
 conditions_generales:
@@ -19,3 +20,4 @@ type: bool
 unit: €
 periodicite: ponctuelle
 interestFlag: _interetAidesSanitaireSocial
+private: true

--- a/data/benefits/javascript/region_pays_de_la_loire-bourses-pour-les-élèves-et-étudiant-e-s-en-formation-sanitaire-et-sociale.yml
+++ b/data/benefits/javascript/region_pays_de_la_loire-bourses-pour-les-élèves-et-étudiant-e-s-en-formation-sanitaire-et-sociale.yml
@@ -14,7 +14,7 @@ conditions_generales:
     operator: ">="
     value: 15
 link: https://www.paysdelaloire.fr/les-aides/bourses-regionales-pour-les-eleves-et-etudiants-en-formation-initiale-sociale-paramedicale-et-de?sous_thematique=215
-teleservice: https://maboursesanitaireetsociale.paysdelaloire.fr/Profil-public/public/paysdelaloire/bourse/accueil.do
+teleservice: https://messervices.etudiant.gouv.fr/
 prefix: les
 type: bool
 unit: €

--- a/data/benefits/javascript/region_pays_de_la_loire-bourses-pour-les-élèves-et-étudiant-e-s-en-formation-sanitaire-et-sociale.yml
+++ b/data/benefits/javascript/region_pays_de_la_loire-bourses-pour-les-élèves-et-étudiant-e-s-en-formation-sanitaire-et-sociale.yml
@@ -20,4 +20,3 @@ type: bool
 unit: €
 periodicite: ponctuelle
 interestFlag: _interetAidesSanitaireSocial
-private: true


### PR DESCRIPTION
## Dispositif : bourses pour les formations sanitaires et sociales
- Institution : region_pays_de_la_loire

### Lien(s) cassé(s) détecté(s)

- [teleservice] https://maboursesanitaireetsociale.paysdelaloire.fr/Profil-public/public/paysdelaloire/bourse/accueil.do → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.