### PR TITLE
veille: Sas jeunes : orientation active vers l'emploi — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/region-nouvelle-aquitaine-sas-jeunes-orientation-active-vers-emploi.yml
+++ b/data/benefits/javascript/region-nouvelle-aquitaine-sas-jeunes-orientation-active-vers-emploi.yml
@@ -17,10 +17,11 @@ profils:
   - type: chomeur
     conditions: []
 conditions:
-  - Être accompagné ou accompagnée par une Mission Locale du Limousin et effectuer votre
-    demande auprès d'eux.
+  - Être accompagné ou accompagnée par une Mission Locale du Limousin et effectuer
+    votre demande auprès d'eux.
 type: bool
 unit: €
 periodicite: ponctuelle
 link: https://les-aides.nouvelle-aquitaine.fr/economie-et-emploi/sas-jeunes-orientation-active-vers-lemploi
 instructions: https://les-aides.nouvelle-aquitaine.fr/economie-et-emploi/sas-jeunes-orientation-active-vers-lemploi
+private: true


### PR DESCRIPTION
## Dispositif : Sas jeunes : orientation active vers l'emploi
- Institution : region_nouvelle_aquitaine

### Lien(s) cassé(s) détecté(s)

- [link / instructions] https://les-aides.nouvelle-aquitaine.fr/economie-et-emploi/sas-jeunes-orientation-active-vers-lemploi → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.