### PR TITLE
Pass Pass annuel pour les moins de 26 ans (artois-mobilites) + aide à la restauration des lycéens (région nouvelle aquitaine) — aides désactivées

### DIFF
--- a/data/benefits/javascript/pass-pass-annuel-pour-les-moins-de-26-ans.yml
+++ b/data/benefits/javascript/pass-pass-annuel-pour-les-moins-de-26-ans.yml
@@ -169,3 +169,4 @@ legend: à la place de 308
 montant: 50
 link: https://www.tadao.fr/707-Jeunes-28--de-26-ans29.html
 instructions: https://www.tadao.fr/707-Jeunes-28--de-26-ans29.html
+private: true

--- a/data/benefits/javascript/region-nouvelle-aquitaine-aide-à-la-restauration-des-lycéen·ne·s.yml
+++ b/data/benefits/javascript/region-nouvelle-aquitaine-aide-à-la-restauration-des-lycéen·ne·s.yml
@@ -1,8 +1,8 @@
 label: aide à la restauration des lycéens et lycéennes
 institution: region_nouvelle_aquitaine
-description: La Région propose un tarif réduit pour la restauration des
-  lycéens et lycéennes demi-pensionnaires ou internes inscrits ou inscrites dans un lycée public ou
-  EREA.
+description: La Région propose un tarif réduit pour la restauration des lycéens
+  et lycéennes demi-pensionnaires ou internes inscrits ou inscrites dans un
+  lycée public ou EREA.
 prefix: l’
 conditions_generales:
   - type: regions
@@ -18,3 +18,4 @@ unit: €
 periodicite: annuelle
 link: https://les-aides.nouvelle-aquitaine.fr/jeunesse/aide-la-restauration-pour-les-lyceens
 instructions: https://les-aides.nouvelle-aquitaine.fr/jeunesse/aide-la-restauration-pour-les-lyceens
+private: true


### PR DESCRIPTION
## Dispositif : Pass Pass annuel pour les moins de 26 ans
- Institution : artois-mobilites

### Lien(s) cassé(s) détecté(s)

- [link / instructions] https://www.tadao.fr/707-Jeunes-28--de-26-ans29.html → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.