### PR TITLE
veille: Pass Pass mensuel pour les moins de 26 ans — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/pass-pass-mensuel-pour-les-moins-de-26-ans.yml
+++ b/data/benefits/javascript/pass-pass-mensuel-pour-les-moins-de-26-ans.yml
@@ -169,3 +169,4 @@ legend: à la place de 28
 montant: 5
 link: https://www.tadao.fr/707-Jeunes-28--de-26-ans29.html
 instructions: https://www.tadao.fr/707-Jeunes-28--de-26-ans29.html
+private: true


### PR DESCRIPTION
## Dispositif : Pass Pass mensuel pour les moins de 26 ans
- Institution : artois-mobilites

### Lien(s) cassé(s) détecté(s)

- [link / instructions] https://www.tadao.fr/707-Jeunes-28--de-26-ans29.html → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.