### PR TITLE
veille: aide au BAFA — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/caf-eure-et-loir-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-eure-et-loir-aide-bafa-approfondissement.yml
@@ -1,8 +1,9 @@
 label: aide au BAFA
 institution: caf_eure_et_loir
-description: La Caf d'Eure-et-Loir vous aide à financer votre formation BAFA,
-  à condition que vous suiviez un parcours complet de formation (formation générale,
-  stage pratique, puis stage d'approfondissement ou de qualification). L'aide est versée directement au stagiaire.
+description: La Caf d'Eure-et-Loir vous aide à financer votre formation BAFA, à
+  condition que vous suiviez un parcours complet de formation (formation
+  générale, stage pratique, puis stage d'approfondissement ou de qualification).
+  L'aide est versée directement au stagiaire.
 prefix: l’
 conditions_generales:
   - type: age
@@ -16,7 +17,8 @@ conditions:
   - Envoyer le <a target="_blank" title="Formulaire - Nouvelle fenêtre"
     rel="noopener"
     href="https://caf.fr/sites/default/files/medias/281/Documents/Action-sociale/Bafa/Cerfa_bafa.pdf">formulaire</a>
-    dans un délai de 3 mois maximum suivant l'inscription au stage d'approfondissement ou de qualification.
+    dans un délai de 3 mois maximum suivant l'inscription au stage
+    d'approfondissement ou de qualification.
 interestFlag: _interetBafa
 type: float
 unit: €
@@ -25,3 +27,4 @@ legend: maximum
 montant: 600
 link: https://caf.fr/allocataires/caf-d-eure-et-loir/offre-de-service/vie-personnelle/bafa
 form: https://caf.fr/sites/default/files/medias/281/Documents/Action-sociale/Bafa/Cerfa_bafa.pdf
+private: true

--- a/data/benefits/javascript/caf-eure-et-loir-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-eure-et-loir-aide-bafa-approfondissement.yml
@@ -16,7 +16,7 @@ profils: []
 conditions:
   - Envoyer le <a target="_blank" title="Formulaire - Nouvelle fenêtre"
     rel="noopener"
-    href="https://caf.fr/sites/default/files/medias/281/Documents/Action-sociale/Bafa/Cerfa_bafa.pdf">formulaire</a>
+    href="https://www.calameo.com/caf-d-eure-et-loir/read/006004434a4b66221cb45">formulaire</a>
     dans un délai de 3 mois maximum suivant l'inscription au stage
     d'approfondissement ou de qualification.
 interestFlag: _interetBafa
@@ -26,5 +26,5 @@ periodicite: ponctuelle
 legend: maximum
 montant: 600
 link: https://caf.fr/allocataires/caf-d-eure-et-loir/offre-de-service/vie-personnelle/bafa
-form: https://caf.fr/sites/default/files/medias/281/Documents/Action-sociale/Bafa/Cerfa_bafa.pdf
+form: https://www.calameo.com/caf-d-eure-et-loir/read/006004434a4b66221cb45
 private: true


### PR DESCRIPTION
## Dispositif : aide au BAFA
- Institution : caf_eure_et_loir

### Lien(s) cassé(s) détecté(s)

- [form] https://caf.fr/sites/default/files/medias/281/Documents/Action-sociale/Bafa/Cerfa_bafa.pdf → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.