### PR TITLE
veille: aide au BAFA pour une session de formation d'approfondissement — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
@@ -19,7 +19,9 @@ profils: []
 conditions:
   - Être allocataire ou rattaché au dossier allocataire de vos parents.
   - Être sans emploi fixe rémunéré.
-  - 'Renvoyer le formulaire de demande dûment complété par email à <a href="mailto:transmettreundocument.caf84@info-caf.fr">transmettreundocument.caf84@info-caf.fr</a> ou par voie postale à lʼadresse suivante : Caf de Vaucluse - SIDP-BAFA - 218 boulevard Pierre BOULLE - 84049 AVIGNON Cedex 9.'
+  - 'Renvoyer le formulaire de demande dûment complété par email à <a href="mailto:transmettreundocument.caf84@info-caf.fr">transmettreundocument.caf84@info-caf.fr</a>
+    ou par voie postale à lʼadresse suivante : Caf de Vaucluse - SIDP-BAFA - 218 boulevard
+    Pierre BOULLE - 84049 AVIGNON Cedex 9.'
 interestFlag: _interetBafa
 type: float
 unit: €
@@ -28,3 +30,4 @@ montant: 200
 link: https://caf.fr/allocataires/caf-de-vaucluse/offre-de-service/vie-professionnelle/le-bafa
 form: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
 instructions: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Plaquette_AFI_BAFA_BAFD.pdf
+private: true

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
@@ -28,6 +28,6 @@ unit: €
 periodicite: ponctuelle
 montant: 200
 link: https://caf.fr/allocataires/caf-de-vaucluse/offre-de-service/vie-professionnelle/le-bafa
-form: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
-instructions: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Plaquette_AFI_BAFA_BAFD.pdf
+form: https://www.caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
+instructions: https://www.caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
 private: true


### PR DESCRIPTION
## Dispositif : aide au BAFA pour une session de formation d'approfondissement
- Institution : caf_vaucluse

### Lien(s) cassé(s) détecté(s)

- [instructions] https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Plaquette_AFI_BAFA_BAFD.pdf → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.