### PR TITLE
veille: aide au BAFA pour une session de formation générale — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
@@ -1,12 +1,14 @@
 label: aide au BAFA pour une session de formation générale
 institution: caf_vaucluse
 description: L'aide à la formation du BAFA est une aide locale mise à
-  disposition par la CAF du Vaucluse pour vous aider à financer votre session générale en
-  complément de l'aide nationale apportée par la CAF.
+  disposition par la CAF du Vaucluse pour vous aider à financer votre session
+  générale en complément de l'aide nationale apportée par la CAF.
 conditions:
   - Être allocataire ou rattaché au dossier allocataire de vos parents.
   - Être sans emploi fixe rémunéré.
-  - 'Renvoyer le formulaire de demande dûment complété par email à <a href="transmettreundocument.caf84@info-caf.fr">transmettreundocument.caf84@info-caf.fr</a> ou par voie postale à lʼadresse suivante : Caf de Vaucluse - SIDP-BAFA - 218 boulevard Pierre BOULLE - 84049 AVIGNON Cedex 9.'
+  - 'Renvoyer le formulaire de demande dûment complété par email à <a href="transmettreundocument.caf84@info-caf.fr">transmettreundocument.caf84@info-caf.fr</a>
+    ou par voie postale à lʼadresse suivante : Caf de Vaucluse - SIDP-BAFA - 218 boulevard
+    Pierre BOULLE - 84049 AVIGNON Cedex 9.'
 conditions_generales:
   - type: age
     operator: ">="
@@ -27,3 +29,4 @@ unit: €
 periodicite: ponctuelle
 montant: 200
 interestFlag: _interetBafa
+private: true

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
@@ -21,7 +21,7 @@ conditions_generales:
       - "84"
 profils: []
 link: https://caf.fr/allocataires/caf-de-vaucluse/offre-de-service/vie-professionnelle/le-bafa
-instructions: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Plaquette_AFI_BAFA_BAFD.pdf
+instructions: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
 form: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
 prefix: l’
 type: float
@@ -29,4 +29,3 @@ unit: €
 periodicite: ponctuelle
 montant: 200
 interestFlag: _interetBafa
-private: true


### PR DESCRIPTION
## Dispositif : aide au BAFA pour une session de formation générale
- Institution : caf_vaucluse

### Lien(s) cassé(s) détecté(s)

- [instructions] https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Plaquette_AFI_BAFA_BAFD.pdf → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.