### PR TITLE
veille: Aides au BAFA ou BAFD — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
@@ -30,4 +30,3 @@ montant: 200
 link: https://caf.fr/allocataires/caf-de-vaucluse/offre-de-service/vie-professionnelle/le-bafa
 form: https://www.caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
 instructions: https://www.caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
-private: true

--- a/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
+++ b/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
@@ -23,5 +23,4 @@ interestFlag: _interetBafa
 type: bool
 periodicite: autre
 link: https://caf.fr/allocataires/caf-d-ille-et-vilaine/offre-de-service/vie-professionnelle/je-passe-le-bafa-ou-le-bafd
-form: https://caf.fr/sites/default/files/medias/351/Offre-de-service/vie-professionnelle/aide-au-bafa-bafd/Formulaire%20BAFA-2025_mod%C3%A8le.pdf
-private: true
+form: https://caf.fr/sites/default/files/medias/351/Offre-de-service/vie-professionnelle/aide-au-bafa-bafd/Imprime_1138102.pdf

--- a/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
+++ b/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
@@ -1,11 +1,11 @@
 label: Aides au BAFA ou BAFD
 institution: caf_ille_et_vilaine
-description:
-  Le brevet d’aptitude aux fonctions d’animateur (BAFA) et le brevet d’aptitude
-  aux fonctions de directeur (BAFD) sont des diplômes qui permettent d’encadrer
-  des enfants et des adolescents en accueil collectif de mineurs. La Caf d'Ille-et-Vilaine
-  vous aide à financer ces formations, sous conditions de ressources. Cette aide est cumulable
-  avec celle de la CNAF et son montant dépend de votre quotient familial.
+description: Le brevet d’aptitude aux fonctions d’animateur (BAFA) et le brevet
+  d’aptitude aux fonctions de directeur (BAFD) sont des diplômes qui permettent
+  d’encadrer des enfants et des adolescents en accueil collectif de mineurs. La
+  Caf d'Ille-et-Vilaine vous aide à financer ces formations, sous conditions de
+  ressources. Cette aide est cumulable avec celle de la CNAF et son montant
+  dépend de votre quotient familial.
 prefix: les
 conditions_generales:
   - type: age
@@ -24,3 +24,4 @@ type: bool
 periodicite: autre
 link: https://caf.fr/allocataires/caf-d-ille-et-vilaine/offre-de-service/vie-professionnelle/je-passe-le-bafa-ou-le-bafd
 form: https://caf.fr/sites/default/files/medias/351/Offre-de-service/vie-professionnelle/aide-au-bafa-bafd/Formulaire%20BAFA-2025_mod%C3%A8le.pdf
+private: true


### PR DESCRIPTION
## Dispositif : Aides au BAFA ou BAFD
- Institution : caf_ille_et_vilaine

### Lien(s) cassé(s) détecté(s)

- [form] https://caf.fr/sites/default/files/medias/351/Offre-de-service/vie-professionnelle/aide-au-bafa-bafd/Formulaire%20BAFA-2025_mod%C3%A8le.pdf → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.