### PR TITLE
veille: Service Transport Plus Handicap — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/ccas-de-redon-service-transport-plus-handicap.yml
+++ b/data/benefits/javascript/ccas-de-redon-service-transport-plus-handicap.yml
@@ -22,3 +22,4 @@ type: bool
 periodicite: autre
 link: https://www.redon.fr/transport-plus/
 instructions: https://www.redon.fr/transport-plus/
+private: true


### PR DESCRIPTION
## Dispositif : Service Transport Plus Handicap
- Institution : ccas-de-redon

### Lien(s) cassé(s) détecté(s)

- [link / instructions] https://www.redon.fr/transport-plus/ → **499** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.