### PR TITLE
veille: mutuelle communale de Chemillé-en-Anjou — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/chemille-en-anjou-mutuelle-communale.yml
+++ b/data/benefits/javascript/chemille-en-anjou-mutuelle-communale.yml
@@ -1,11 +1,10 @@
 label: mutuelle communale de Chemillé-en-Anjou
 institution: ville_chemille_en_anjou
-description:
-  La mutuelle communale prévoit une couverture de base complète (hospitalisation,
-  soins courants, auditifs, dentaires, optiques, bien-être et prévention). Elle
-  donne également la possibilité de choisir parmi une palette d’offres
-  complémentaires et facultatives (prévention santé, médecine douce, sport santé,
-  nutrition, etc.).
+description: La mutuelle communale prévoit une couverture de base complète
+  (hospitalisation, soins courants, auditifs, dentaires, optiques, bien-être et
+  prévention). Elle donne également la possibilité de choisir parmi une palette
+  d’offres complémentaires et facultatives (prévention santé, médecine douce,
+  sport santé, nutrition, etc.).
 conditions_generales:
   - type: communes
     values:
@@ -16,3 +15,4 @@ prefix: la
 type: bool
 periodicite: ponctuelle
 top: 2.3
+private: true

--- a/data/benefits/javascript/chemille-en-anjou-mutuelle-communale.yml
+++ b/data/benefits/javascript/chemille-en-anjou-mutuelle-communale.yml
@@ -9,10 +9,9 @@ conditions_generales:
   - type: communes
     values:
       - "49092"
-link: https://www.chemille-en-anjou.fr/actualites/lancement-dune-mutuelle-communale/
-instructions: https://www.chemille-en-anjou.fr/actualites/lancement-dune-mutuelle-communale/
+link: https://www.chemille-en-anjou.fr/chemille-en-anjou-mutuelle-communale/
+instructions: https://www.chemille-en-anjou.fr/chemille-en-anjou-mutuelle-communale/
 prefix: la
 type: bool
 periodicite: ponctuelle
 top: 2.3
-private: true


### PR DESCRIPTION
## Dispositif : mutuelle communale de Chemillé-en-Anjou
- Institution : ville_chemille_en_anjou

### Lien(s) cassé(s) détecté(s)

- [link / instructions] https://www.chemille-en-anjou.fr/actualites/lancement-dune-mutuelle-communale/ → **499** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.