### PR TITLE
veille: Bourse Projets Jeunes — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/communaute-de-communes-adour-madiran-bourse-projets-jeunes.yml
+++ b/data/benefits/javascript/communaute-de-communes-adour-madiran-bourse-projets-jeunes.yml
@@ -16,9 +16,9 @@ conditions_generales:
 profils: []
 conditions:
   - Habiter dans l’une des 72 communes du territoire Adour Madiran.
-  - Présenter un projet ayant un caractère d’intérêt général et sʼinscrivant
-    dans une des thématiques suivantes ":" l’environnement, la culture, la santé,
-    la solidarité, la mobilité, l’inclusion, l’éducation, l’orientation, la
+  - Présenter un projet ayant un caractère d’intérêt général et sʼinscrivant dans
+    une des thématiques suivantes ":" l’environnement, la culture, la santé, la
+    solidarité, la mobilité, l’inclusion, l’éducation, l’orientation, la
     citoyenneté, la participation, l’intergénérationnel, l’animation sociale,
     l’aménagement du territoire.
 type: bool
@@ -27,3 +27,4 @@ periodicite: autre
 link: https://www.adour-madiran.fr/bourse-projets-jeunes/
 form: https://www.adour-madiran.fr/wp-content/uploads/2024/07/BPJ-Dossier-de-candidature-VF.pdf
 instructions: https://www.adour-madiran.fr/wp-content/uploads/2024/07/BPJ-Cahier-des-charges-VF-1.pdf
+private: true


### PR DESCRIPTION
## Dispositif : Bourse Projets Jeunes
- Institution : communaute-de-communes-adour-madiran

### Lien(s) cassé(s) détecté(s)

- [link] https://www.adour-madiran.fr/bourse-projets-jeunes/ → **499** — à vérifier
- [instructions] https://www.adour-madiran.fr/wp-content/uploads/2024/07/BPJ-Cahier-des-charges-VF-1.pdf → **499** — à vérifier
- [form] https://www.adour-madiran.fr/wp-content/uploads/2024/07/BPJ-Dossier-de-candidature-VF.pdf → **499** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.