### PR TITLE
veille: Bourse communale au permis de conduire — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/communaute-de-communes-sud-herault-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/communaute-de-communes-sud-herault-bourse-communale-au-permis-de-conduire.yml
@@ -25,6 +25,5 @@ unit: €
 periodicite: autre
 legend: maximum
 montant: 500
-link: https://www.cc-sud-herault.fr/actualite/permis-citoyen-2022/
-instructions: https://www.cc-sud-herault.fr/actualite/permis-citoyen-2022/
-private: true
+link: https://www.cc-sud-herault.fr/uploads/2020/07/flyer-A5-permis-citoyen.pdf
+instructions: https://www.cc-sud-herault.fr/uploads/2020/07/flyer-A5-permis-citoyen.pdf

--- a/data/benefits/javascript/communaute-de-communes-sud-herault-bourse-communale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/communaute-de-communes-sud-herault-bourse-communale-au-permis-de-conduire.yml
@@ -2,10 +2,10 @@ label: Bourse communale au permis de conduire
 institution: cc-sud-herault
 description: Afin de répondre aux difficultés de mobilité des jeunes, la
   communauté de communes Sud-Hérault propose une aide au financement du permis
-  de conduire de 150 à 500€. Le montant de l'aide varie selon les
-  ressources du jeune et de sa famille et est attribué en contrepartie d’un
-  engagement citoyen de 35 à 70h dans une association. L’instruction des
-  dossiers de candidature se fait auprès d’Info Jeunes Sud-Hérault.
+  de conduire de 150 à 500€. Le montant de l'aide varie selon les ressources du
+  jeune et de sa famille et est attribué en contrepartie d’un engagement citoyen
+  de 35 à 70h dans une association. L’instruction des dossiers de candidature se
+  fait auprès d’Info Jeunes Sud-Hérault.
 prefix: la
 conditions_generales:
   - type: attached_to_institution
@@ -27,3 +27,4 @@ legend: maximum
 montant: 500
 link: https://www.cc-sud-herault.fr/actualite/permis-citoyen-2022/
 instructions: https://www.cc-sud-herault.fr/actualite/permis-citoyen-2022/
+private: true


### PR DESCRIPTION
## Dispositif : Bourse communale au permis de conduire
- Institution : cc-sud-herault

### Lien(s) cassé(s) détecté(s)

- [link / instructions] https://www.cc-sud-herault.fr/actualite/permis-citoyen-2022/ → **503** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.