### PR TITLE
veille: Aide départementale au Permis de conduire — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
+++ b/data/benefits/javascript/departement-gironde-aide-departementale-au-permis-de-conduire.yml
@@ -23,9 +23,11 @@ profils:
   - type: inactif
 conditions:
   - Etre éligible aux critères du Fonds d'Aide au Jeunes.
-  - Résider dans une commune de la Gironde qui ne se situe pas au sein de la Métropole.
+  - Résider dans une commune de la Gironde qui ne se situe pas au sein de la
+    Métropole.
 voluntary_conditions:
-  - Réaliser 70 heures de bénévolat auprès d’une association ou d'une collectivité locale.
+  - Réaliser 70 heures de bénévolat auprès d’une association ou d'une collectivité
+    locale.
 interestFlag: _interetPermisDeConduire
 type: float
 montant: 75
@@ -34,3 +36,4 @@ legend: "du prix du permis"
 periodicite: ponctuelle
 link: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire
 instructions: https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire
+private: true


### PR DESCRIPTION
## Dispositif : Aide départementale au Permis de conduire
- Institution : departement_gironde

### Lien(s) cassé(s) détecté(s)

- [link / instructions] https://www.gironde.fr/acteurs-jeunesse/les-actions/aide-departementale-au-permis-de-conduire → **499** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.