### PR TITLE
veille: carte jeunes 01 pour le sport, la culture et les loisirs — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/departement_ain_carte_jeunes.yml
+++ b/data/benefits/javascript/departement_ain_carte_jeunes.yml
@@ -1,10 +1,10 @@
 label: carte jeunes 01 pour le sport, la culture et les loisirs
 institution: departement_ain
-description:
-  La Carte Jeunes 01 est un porte-monnaie en ligne offert à tous les collégiens
-  par le département de l'Ain, avec 25 euros pour les activités culturelles, 25 euros pour
-  les activités sportives et de loisirs, plus de 170 euros d'offres promotionnelles, ainsi
-  que des bons plans chez les partenaires du département de l'Ain.
+description: La Carte Jeunes 01 est un porte-monnaie en ligne offert à tous les
+  collégiens par le département de l'Ain, avec 25 euros pour les activités
+  culturelles, 25 euros pour les activités sportives et de loisirs, plus de 170
+  euros d'offres promotionnelles, ainsi que des bons plans chez les partenaires
+  du département de l'Ain.
 prefix: la
 profils:
   - type: collegien
@@ -14,15 +14,17 @@ conditions_generales:
     values:
       - "01"
 conditions:
-  - Commander la Carte Jeunes 01 <a target="_blank"
-    rel="noopener" title="Téléservice demande Carte Jeunes 01 - Nouvelle fenêtre" href="
+  - Commander la Carte Jeunes 01 <a target="_blank" rel="noopener"
+    title="Téléservice demande Carte Jeunes 01 - Nouvelle fenêtre" href="
     https://cartejeunes01.ain.fr/my/dashboard">via le téléservice</a>.
   - Utiliser la Carte Jeunes 01 chez les partenaires listés sur <a target="_blank"
-    rel="noopener" title="Partenaires de la Carte Jeunes 01 - Nouvelle fenêtre" href="
-    https://cartejeunes01.ain.fr/iframe/searchengine">ce site du département de l'Ain</a>.
+    rel="noopener" title="Partenaires de la Carte Jeunes 01 - Nouvelle fenêtre"
+    href=" https://cartejeunes01.ain.fr/iframe/searchengine">ce site du
+    département de l'Ain</a>.
 type: float
 unit: €
 periodicite: ponctuelle
 montant: 50
 link: https://www.ain.fr/solutions/carte-jeunes-01/
 teleservice: https://cartejeunes01.ain.fr/my/dashboard
+private: true


### PR DESCRIPTION
## Dispositif : carte jeunes 01 pour le sport, la culture et les loisirs
- Institution : departement_ain

### Lien(s) cassé(s) détecté(s)

- [link] https://www.ain.fr/solutions/carte-jeunes-01/ → **499** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.