### PR TITLE
veille: mise à jour Dynastage - Apprenti (montant)

### DIFF
--- a/data/benefits/javascript/bourgogne-franche-comte-dynastage.yml
+++ b/data/benefits/javascript/bourgogne-franche-comte-dynastage.yml
@@ -21,5 +21,6 @@ type: float
 unit: €
 periodicite: autre
 legend: maximum
-montant: 2280
+montant: Variable entre 150 € et 2 280 € selon durée, quotient familial et
+  barème
 interestFlag: _interetEtudesEtranger


### PR DESCRIPTION
## Dispositif : Dynastage - Apprenti
- Institution : region_bourgogne_franche_comte
- Lien source : https://www.bourgognefranchecomte.fr/node/332

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| montant | 2280 | Variable entre 150 € et 2 280 € selon durée, quotient familial et barème |

### Extraits sources
- **montant** : > Il est compris entre 150 € et 2 280 €.

_Confiance LLM : 0.95_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.