### PR TITLE
fix(openfisca): borne la durée des calculs et fiabilise le chemin d'erreur

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,8 @@ OPENFISCA_TRACER_URL=
 # Délai d'abandon de l'appel Node -> OpenFisca, en ms (défaut 25000).
 # Doit rester inférieur à OPENFISCA_TIMEOUT (secondes, défaut 30).
 OPENFISCA_TIMEOUT_MS=
+# Délai gunicorn avant recyclage d'un worker OpenFisca, en secondes (défaut 30).
+OPENFISCA_TIMEOUT=
 
 PIVOT_URL=
 

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ OPENFISCA_INTERNAL_ROOT_URL=
 OPENFISCA_AXE_URL=
 OPENFISCA_PUBLIC_ROOT_URL=
 OPENFISCA_TRACER_URL=
+# Délai d'abandon de l'appel Node -> OpenFisca, en ms (défaut 25000).
+# Doit rester inférieur à OPENFISCA_TIMEOUT (secondes, défaut 30).
+OPENFISCA_TIMEOUT_MS=
 
 PIVOT_URL=
 

--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -49,6 +49,9 @@ const config: Configuration = {
   },
   openfiscaURL:
     process.env.OPENFISCA_INTERNAL_ROOT_URL || "http://127.0.0.1:2000",
+  // Doit rester inférieur au `timeout` gunicorn d'OpenFisca (openfisca/config.py) :
+  // abandonner côté client ne libère pas le worker, c'est gunicorn qui le recycle.
+  openfiscaTimeout: Number(process.env.OPENFISCA_TIMEOUT_MS) || 25000,
   openfiscaAxeURL: isProduction
     ? "https://betagouv.github.io/mes-aides-changent"
     : "http://127.0.0.1:3000",

--- a/backend/controllers/simulation.ts
+++ b/backend/controllers/simulation.ts
@@ -156,7 +156,11 @@ function results(req: Request, res, next) {
 function openfiscaTrace(req: Request, res, next) {
   return openfisca.trace(req.situation, function (err, result) {
     if (err)
-      return next(Object.assign(err.response.data, { _id: req.simulationId }))
+      return next(
+        Object.assign(err?.response?.data || err, {
+          _id: req.simulationId,
+        }),
+      )
 
     res.send(Object.assign(result, { _id: req.simulationId }))
   })

--- a/backend/controllers/teleservices/index.ts
+++ b/backend/controllers/teleservices/index.ts
@@ -230,14 +230,16 @@ function verifyRequest(req, res, next) {
  * This function returns a key/value object representing the requested situation to prefill a specific teleservice.
  * At the moment, the key/value pairs are hardcoded but it mimics the expected behavior.
  */
-function exportRepresentation(req, res) {
+function exportRepresentation(req, res, next) {
   return Promise.resolve(
     createClass(req.teleservice, req.simulation, req.payload.query).toExternal(
       req,
     ),
-  ).then(function (value) {
-    return res.json(value)
-  })
+  )
+    .then(function (value) {
+      return res.json(value)
+    })
+    .catch(next)
 }
 
 const teleservicesExports = {

--- a/backend/lib/openfisca/getter.ts
+++ b/backend/lib/openfisca/getter.ts
@@ -1,9 +1,13 @@
 import axios from "axios"
 import config from "../../config/index.js"
 
+// Sans délai d'abandon, un OpenFisca saturé qui accepte la connexion sans
+// répondre laisse ces requêtes en attente indéfiniment.
+const requestOptions = { timeout: config.openfiscaTimeout }
+
 function get(item: string, callback: (any) => void): Promise<void> {
   return axios
-    .get(`${config.openfiscaURL}${item}`)
+    .get(`${config.openfiscaURL}${item}`, requestOptions)
     .then((response) => response.data)
     .then(function (result) {
       callback(result)
@@ -12,7 +16,7 @@ function get(item: string, callback: (any) => void): Promise<void> {
 
 async function getPromise(item): Promise<any> {
   return axios
-    .get(`${config.openfiscaURL}${item}`)
+    .get(`${config.openfiscaURL}${item}`, requestOptions)
     .then((response) => response.data)
     .catch((error) => {
       throw new Error(

--- a/backend/lib/openfisca/getter.ts
+++ b/backend/lib/openfisca/getter.ts
@@ -5,13 +5,29 @@ import config from "../../config/index.js"
 // répondre laisse ces requêtes en attente indéfiniment.
 const requestOptions = { timeout: config.openfiscaTimeout }
 
+// Le message d'axios porte l'adresse interne du service, et ces erreurs
+// atteignent le client sur les routes anonymes /api/openfisca/*.
+function unavailable(error) {
+  console.error("OpenFisca request failed", error)
+  return Object.assign(new Error("OF maybe offline - Failed to fetch data"), {
+    code: error.code,
+  })
+}
+
 function get(item: string, callback: (any) => void): Promise<void> {
-  return axios
-    .get(`${config.openfiscaURL}${item}`, requestOptions)
-    .then((response) => response.data)
-    .then(function (result) {
-      callback(result)
-    })
+  return (
+    axios
+      .get(`${config.openfiscaURL}${item}`, requestOptions)
+      .then((response) => response.data)
+      // Placé avant le callback, jamais en fin de chaîne : en fin de chaîne il
+      // réécrirait aussi les exceptions levées par l'appelant.
+      .catch((error) => {
+        throw unavailable(error)
+      })
+      .then(function (result) {
+        callback(result)
+      })
+  )
 }
 
 async function getPromise(item): Promise<any> {
@@ -19,14 +35,7 @@ async function getPromise(item): Promise<any> {
     .get(`${config.openfiscaURL}${item}`, requestOptions)
     .then((response) => response.data)
     .catch((error) => {
-      // Le message d'axios porte l'adresse interne du service, et cette erreur
-      // atteint désormais le client sur les routes /api/openfisca/*.
-      throw Object.assign(
-        new Error("OF maybe offline - Failed to fetch data"),
-        {
-          code: error.code,
-        },
-      )
+      throw unavailable(error)
     })
 }
 

--- a/backend/lib/openfisca/getter.ts
+++ b/backend/lib/openfisca/getter.ts
@@ -19,8 +19,13 @@ async function getPromise(item): Promise<any> {
     .get(`${config.openfiscaURL}${item}`, requestOptions)
     .then((response) => response.data)
     .catch((error) => {
-      throw new Error(
-        `OF maybe offline - Failed to fetch data : ${error.message}`,
+      // Le message d'axios porte l'adresse interne du service, et cette erreur
+      // atteint désormais le client sur les routes /api/openfisca/*.
+      throw Object.assign(
+        new Error("OF maybe offline - Failed to fetch data"),
+        {
+          code: error.code,
+        },
       )
     })
 }

--- a/backend/lib/openfisca/index.ts
+++ b/backend/lib/openfisca/index.ts
@@ -5,6 +5,33 @@ import * as Sentry from "@sentry/node"
 
 export const buildOpenFiscaRequest = mapping.buildOpenFiscaRequest
 
+// Le corps d'erreur remonte jusqu'au client et jusqu'aux logs. Un AxiosError
+// brut y ferait figurer `config.data`, c'est-à-dire la situation personnelle
+// complète, ainsi que les chemins du serveur.
+//
+// Le résultat doit toujours être vrai : les appelants suivent la convention
+// `callback(err, result)` et testent `if (err)`. Une réponse d'erreur HTTP à
+// corps vide donne `response.data === ""`, qu'il faut donc écarter.
+function normalizeError(err: any) {
+  const body = err.response?.data
+  if (body) {
+    return body
+  }
+
+  return {
+    name: err.name || "Error",
+    code: err.code,
+    status: err.response?.status,
+    // Le message d'axios porte l'adresse interne du service sur les erreurs
+    // réseau. Seul celui d'un abandon est sûr, et le front s'en sert pour
+    // reconnaître un calcul trop long.
+    message:
+      err.code === "ECONNABORTED"
+        ? err.message
+        : "Le calcul n'a pas abouti. Merci de réessayer dans un instant.",
+  }
+}
+
 export function sendToOpenfisca(endpoint, transform?: any) {
   if (!transform) {
     transform = buildOpenFiscaRequest
@@ -16,33 +43,27 @@ export function sendToOpenfisca(endpoint, transform?: any) {
       request = transform(situation)
     } catch (e: any) {
       Sentry.captureException(e)
-      return callback({
-        message: e.message,
-        name: e.name,
-        stack: e.stack,
-      })
+      return callback(normalizeError(e))
     }
 
     axios
       .post(`${config.openfiscaURL}/${endpoint}`, request, {
         timeout: config.openfiscaTimeout,
       })
-      .then((response) => response.data)
+      .then((response) => {
+        // Une réponse vide n'est pas un résultat : la laisser passer ferait
+        // échouer le calcul des aides plus loin, hors du chemin d'erreur.
+        if (!response.data) {
+          throw Object.assign(new Error("Empty response from OpenFisca"), {
+            code: "ERR_EMPTY_RESPONSE",
+          })
+        }
+        return response.data
+      })
       .then(function (result) {
         callback(null, result)
       })
-      .catch((err) =>
-        // Le corps d'erreur remonte jusqu'au client et jusqu'aux logs. Un
-        // AxiosError brut y ferait figurer `config.data`, c'est-à-dire la
-        // situation personnelle complète, ainsi que les chemins du serveur.
-        callback(
-          err.response?.data ?? {
-            name: err.name,
-            code: err.code,
-            message: err.message,
-          },
-        ),
-      )
+      .catch((err) => callback(normalizeError(err)))
   }
 }
 

--- a/backend/lib/openfisca/index.ts
+++ b/backend/lib/openfisca/index.ts
@@ -12,21 +12,29 @@ export const buildOpenFiscaRequest = mapping.buildOpenFiscaRequest
 // Le résultat doit toujours être vrai : les appelants suivent la convention
 // `callback(err, result)` et testent `if (err)`. Une réponse d'erreur HTTP à
 // corps vide donne `response.data === ""`, qu'il faut donc écarter.
-function normalizeError(err: any) {
-  const body = err.response?.data
-  if (body) {
+function isTransportError(err: any): boolean {
+  return Boolean(err?.isAxiosError || err?.config || err?.response)
+}
+
+export function normalizeError(err: any) {
+  const body = err?.response?.data
+  // Un corps d'erreur structuré vient d'OpenFisca et sert au diagnostic. Une
+  // chaîne vient d'un intermédiaire — page 502 de nginx, trace de gunicorn — et
+  // doit rester une chaîne : la traiter comme un objet la déploierait en un
+  // dictionnaire indexé caractère par caractère.
+  if (body && typeof body === "object") {
     return body
   }
 
   return {
-    name: err.name || "Error",
-    code: err.code,
-    status: err.response?.status,
+    name: err?.name || "Error",
+    code: err?.code,
+    status: err?.response?.status,
     // Le message d'axios porte l'adresse interne du service sur les erreurs
     // réseau. Seul celui d'un abandon est sûr, et le front s'en sert pour
     // reconnaître un calcul trop long.
     message:
-      err.code === "ECONNABORTED"
+      err?.code === "ECONNABORTED"
         ? err.message
         : "Le calcul n'a pas abouti. Merci de réessayer dans un instant.",
   }
@@ -63,7 +71,21 @@ export function sendToOpenfisca(endpoint, transform?: any) {
       .then(function (result) {
         callback(null, result)
       })
-      .catch((err) => callback(normalizeError(err)))
+      .catch((err) => {
+        // Ce `catch` couvre aussi ce que lève le callback lui-même, donc le
+        // calcul des aides. Assainir une exception applicative en effacerait le
+        // message et la pile, dans les logs comme dans Sentry : seules les
+        // erreurs de transport sont normalisées.
+        //
+        // La reconnaissance ne repose pas sur le seul `isAxiosError` : porter
+        // `config` ou `response`, c'est porter la requête sortante et donc la
+        // situation personnelle, quelle que soit l'origine.
+        if (isTransportError(err)) {
+          return callback(normalizeError(err))
+        }
+        Sentry.captureException(err)
+        callback(err)
+      })
   }
 }
 

--- a/backend/lib/openfisca/index.ts
+++ b/backend/lib/openfisca/index.ts
@@ -31,7 +31,18 @@ export function sendToOpenfisca(endpoint, transform?: any) {
       .then(function (result) {
         callback(null, result)
       })
-      .catch(callback)
+      .catch((err) =>
+        // Le corps d'erreur remonte jusqu'au client et jusqu'aux logs. Un
+        // AxiosError brut y ferait figurer `config.data`, c'est-à-dire la
+        // situation personnelle complète, ainsi que les chemins du serveur.
+        callback(
+          err.response?.data ?? {
+            name: err.name,
+            code: err.code,
+            message: err.message,
+          },
+        ),
+      )
   }
 }
 

--- a/backend/lib/openfisca/index.ts
+++ b/backend/lib/openfisca/index.ts
@@ -24,7 +24,9 @@ export function sendToOpenfisca(endpoint, transform?: any) {
     }
 
     axios
-      .post(`${config.openfiscaURL}/${endpoint}`, request)
+      .post(`${config.openfiscaURL}/${endpoint}`, request, {
+        timeout: config.openfiscaTimeout,
+      })
       .then((response) => response.data)
       .then(function (result) {
         callback(null, result)

--- a/backend/lib/openfisca/index.ts
+++ b/backend/lib/openfisca/index.ts
@@ -81,6 +81,10 @@ export function sendToOpenfisca(endpoint, transform?: any) {
         // `config` ou `response`, c'est porter la requête sortante et donc la
         // situation personnelle, quelle que soit l'origine.
         if (isTransportError(err)) {
+          // L'objet transmis est volontairement pauvre : le message d'origine,
+          // qui distingue un refus de connexion d'un abandon ou d'un 502, est
+          // conservé côté serveur pour rester diagnosticable.
+          console.error(`OpenFisca ${endpoint} request failed`, err.message)
           return callback(normalizeError(err))
         }
         Sentry.captureException(err)

--- a/backend/models/simulation.ts
+++ b/backend/models/simulation.ts
@@ -78,12 +78,23 @@ SimulationSchema.virtual("cookieName").get(function () {
 })
 
 SimulationSchema.method("isAccessible", function (keychain) {
-  return (
+  if (
     [
       SimulationStatus.Demo,
       SimulationStatus.Investigation,
       SimulationStatus.Test,
-    ].includes(this.status) ||
+    ].includes(this.status)
+  ) {
+    return true
+  }
+
+  // Sans token, aucune clé ne peut correspondre : comparer `undefined` à
+  // `undefined` ouvrirait l'accès à toute requête n'en présentant aucun.
+  if (!this.token) {
+    return false
+  }
+
+  return (
     keychain?.[this.cookieName] === this.token ||
     keychain?.token === this.token ||
     keychain?.authorization === `Bearer ${this.token}`
@@ -93,13 +104,8 @@ SimulationSchema.pre("save", async function (next) {
   if (!this.isNew) {
     return next()
   }
-  try {
-    const simulation = this
-    simulation.token = await utils.generateToken()
-    next()
-  } catch {
-    next()
-  }
+  this.token = await utils.generateToken()
+  next()
 })
 
 SimulationSchema.method("getSituation", function () {

--- a/backend/routes/openfisca.ts
+++ b/backend/routes/openfisca.ts
@@ -7,38 +7,46 @@ import { Express } from "express"
 let missingBenefits
 
 export default (api: Express) => {
-  api.route("/openfisca/missingbenefits").get(async (req, res) => {
+  // Express 4 ne rattrape pas les rejets d'un gestionnaire asynchrone : sans
+  // `next`, une indisponibilité d'OpenFisca laisse la requête pendante.
+  api.route("/openfisca/missingbenefits").get(async (req, res, next) => {
     if (missingBenefits) {
       res.json(missingBenefits)
       return
     }
 
-    openfisca.get("/variables", (payload) => {
-      const missingValues = benefits.all
-        .filter((benefit) => {
-          const source = benefit.openfisca_eligibility_source || benefit.id
-          return benefit.source === "openfisca" && !payload[source]
-        })
-        .map((benefit) => {
-          return benefit.id
-        })
-      res.json(missingValues)
-      missingBenefits = missingValues
-    })
+    openfisca
+      .get("/variables", (payload) => {
+        const missingValues = benefits.all
+          .filter((benefit) => {
+            const source = benefit.openfisca_eligibility_source || benefit.id
+            return benefit.source === "openfisca" && !payload[source]
+          })
+          .map((benefit) => {
+            return benefit.id
+          })
+        res.json(missingValues)
+        missingBenefits = missingValues
+      })
+      .catch(next)
   })
 
   api
     .route("/openfisca/parameters/:date")
-    .get([check("date").isISO8601()], async (req, res) => {
+    .get([check("date").isISO8601()], async (req, res, next) => {
       const errors = validationResult(req)
       if (!errors.isEmpty()) {
         res.status(400).send("Invalid date")
         return
       }
 
-      const parameters = await openfiscaController.getParametersAsync(
-        new Date(req.params.date),
-      )
-      res.json(parameters)
+      try {
+        const parameters = await openfiscaController.getParametersAsync(
+          new Date(req.params.date),
+        )
+        res.json(parameters)
+      } catch (error) {
+        next(error)
+      }
     })
 }

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -26,12 +26,27 @@ app.route("/*").get(function (req, res) {
 // Le reste, dont le corps renvoyé par OpenFisca, est utile au diagnostic.
 const UNSAFE_ERROR_KEYS = ["stack", "config", "request", "response"]
 
+// Un `code` d'erreur n'est un statut HTTP que s'il en a la forme : celui d'une
+// réponse OpenFisca ou d'un pilote Mongo pilote sinon la réponse, jusqu'à faire
+// lever `res.status()` sur une valeur hors plage.
+function httpStatusOf(err): number {
+  const code = Number(err?.code)
+  return Number.isInteger(code) && code >= 400 && code <= 599 ? code : 500
+}
+
 const errorMiddleware: ErrorRequestHandler = (err, req, res, next) => {
   console.error(err)
-  res.status(parseInt(err?.code) || 500).send({
-    ...omit(err || {}, UNSAFE_ERROR_KEYS),
+  // Une erreur peut être une chaîne — page 502 d'un intermédiaire. L'étaler
+  // comme un objet la déploierait en un dictionnaire indexé caractère par
+  // caractère.
+  const details =
+    err && typeof err === "object" ? omit(err, UNSAFE_ERROR_KEYS) : {}
+  res.status(httpStatusOf(err)).send({
+    ...details,
     name: err?.name,
-    message: err?.message || "Une erreur est survenue.",
+    message:
+      err?.message ||
+      (typeof err === "string" ? err : "Une erreur est survenue."),
   })
   next()
 }

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -2,6 +2,7 @@ import express, { ErrorRequestHandler, Application } from "express"
 import path from "path"
 import morgan from "morgan"
 import axios from "axios"
+import { omit } from "lodash-es"
 
 import configure from "./configure.js"
 
@@ -20,9 +21,18 @@ app.route("/*").get(function (req, res) {
   res.sendFile(path.join(__dirname, "../../dist/index.html"))
 })
 
+// Les objets d'erreur des bibliothèques HTTP portent la pile d'appels et la
+// configuration de la requête sortante, avec son URL interne et son contenu.
+// Le reste, dont le corps renvoyé par OpenFisca, est utile au diagnostic.
+const UNSAFE_ERROR_KEYS = ["stack", "config", "request", "response"]
+
 const errorMiddleware: ErrorRequestHandler = (err, req, res, next) => {
   console.error(err)
-  res.status(parseInt(err.code) || 500).send(err)
+  res.status(parseInt(err?.code) || 500).send({
+    ...omit(err || {}, UNSAFE_ERROR_KEYS),
+    name: err?.name,
+    message: err?.message || "Une erreur est survenue.",
+  })
   next()
 }
 app.use([errorMiddleware, morgan("combined", { stream: process.stderr })])

--- a/backend/types/config.d.ts
+++ b/backend/types/config.d.ts
@@ -17,6 +17,7 @@ export interface Configuration {
     scopes: string
   }
   openfiscaURL: string
+  openfiscaTimeout: number
   openfiscaAxeURL: string
   openfiscaPublicURL: string
   openfiscaTracerURL: string

--- a/openfisca/config.py
+++ b/openfisca/config.py
@@ -5,7 +5,7 @@ bind = os.getenv('OPENFISCA_BIND_HOST', '127.0.0.1:' + port)
 # Un calcul normal prend quelques secondes. Au-delà, le worker est tué et
 # recyclé plutôt que de rester immobilisé : avec un pool de workers sync,
 # chaque worker bloqué retire une place de concurrence à tout le cluster.
-timeout = int(os.getenv('OPENFISCA_TIMEOUT', 30))
+timeout = int(os.getenv('OPENFISCA_TIMEOUT') or 30)
 workers = os.getenv('OPENFISCA_WORKERS', 8)
 
 profiler = False

--- a/openfisca/config.py
+++ b/openfisca/config.py
@@ -2,7 +2,10 @@ import os
 
 port = os.getenv('OPENFISCA_PORT', '2000')
 bind = os.getenv('OPENFISCA_BIND_HOST', '127.0.0.1:' + port)
-timeout = 120
+# Un calcul normal prend quelques secondes. Au-delà, le worker est tué et
+# recyclé plutôt que de rester immobilisé : avec un pool de workers sync,
+# chaque worker bloqué retire une place de concurrence à tout le cluster.
+timeout = int(os.getenv('OPENFISCA_TIMEOUT', 30))
 workers = os.getenv('OPENFISCA_WORKERS', 8)
 
 profiler = False

--- a/src/components/error-block.vue
+++ b/src/components/error-block.vue
@@ -32,7 +32,7 @@
     </div>
     <small v-if="showDetails">
       Informations techniques :
-      <pre v-html="errorText" />
+      <pre>{{ errorText }}</pre>
     </small>
   </div>
 </template>
@@ -70,8 +70,9 @@ export default {
         : JSON.stringify(value, null, 2)
     },
     isTimeoutError() {
+      // `errorText` est une chaîne primitive : `instanceof String` y est faux.
       return (
-        this.errorText instanceof String && this.errorText.match(/time.?out/i)
+        typeof this.errorText === "string" && /time.?out/i.test(this.errorText)
       )
     },
     resultats() {

--- a/src/components/error-save-block.vue
+++ b/src/components/error-save-block.vue
@@ -27,8 +27,9 @@
     <p
       ><small>
         Informations techniques :
-        <pre v-html="error" /></small
-    ></p>
+        <pre>{{ error }}</pre>
+      </small></p
+    >
   </div>
 </template>
 

--- a/tests/unit/backend/openfisca-error-handling.spec.ts
+++ b/tests/unit/backend/openfisca-error-handling.spec.ts
@@ -35,6 +35,83 @@ function callbackOf(fn): Promise<{ err: any; result: any }> {
 describe("remontée des erreurs OpenFisca", () => {
   beforeEach(() => vi.clearAllMocks())
 
+  describe("véracité de l'erreur transmise", () => {
+    // Une réponse d'erreur HTTP à corps vide donne `response.data === ""`.
+    // Transmise telle quelle, elle est falsy : les appelants testent `if (err)`
+    // et poursuivent comme si le calcul avait abouti.
+    it.each([
+      ["chaîne vide", ""],
+      ["zéro", 0],
+      ["objet nul", null],
+    ])("reste vraie quand OpenFisca répond %s", async (_libelle, data) => {
+      vi.mocked(axios.post).mockRejectedValue(
+        Object.assign(new Error("Request failed with status code 502"), {
+          name: "AxiosError",
+          code: "ERR_BAD_RESPONSE",
+          response: { status: 502, data },
+        }),
+      )
+
+      const { err, result } = await callbackOf((cb) =>
+        sendToOpenfisca("calculate", () => ({}))({}, cb),
+      )
+
+      expect(err).toBeTruthy()
+      expect(result).toBeUndefined()
+    })
+
+    it("traite une réponse 200 vide comme une erreur", async () => {
+      vi.mocked(axios.post).mockResolvedValue({ status: 200, data: "" })
+
+      const { err, result } = await callbackOf((cb) =>
+        sendToOpenfisca("calculate", () => ({}))({}, cb),
+      )
+
+      expect(err).toBeTruthy()
+      expect(result).toBeUndefined()
+    })
+
+    it("n'expose pas l'adresse interne du service sur une erreur réseau", async () => {
+      vi.mocked(axios.post).mockRejectedValue(
+        Object.assign(new Error("connect ECONNREFUSED 10.0.0.12:2000"), {
+          name: "Error",
+          code: "ECONNREFUSED",
+        }),
+      )
+
+      const { err } = await callbackOf((cb) =>
+        sendToOpenfisca("calculate", () => ({}))({}, cb),
+      )
+
+      expect(JSON.stringify(err)).not.toContain("10.0.0.12")
+      expect(err.code).toBe("ECONNREFUSED")
+    })
+
+    it("conserve le message d'abandon, que le front utilise", async () => {
+      vi.mocked(axios.post).mockRejectedValue(abortError())
+
+      const { err } = await callbackOf((cb) =>
+        sendToOpenfisca("calculate", () => ({}))({}, cb),
+      )
+
+      expect(err.message).toMatch(/time.?out/i)
+    })
+
+    it("ne renvoie pas la pile quand la construction de la requête échoue", async () => {
+      const { err } = await callbackOf((cb) =>
+        sendToOpenfisca("calculate", () => {
+          throw Object.assign(new TypeError("boom"), {
+            stack: "TypeError\n    at /srv/app/backend/lib/openfisca/x.ts:1:1",
+          })
+        })({}, cb),
+      )
+
+      expect(err).toBeTruthy()
+      expect(err).not.toHaveProperty("stack")
+      expect(JSON.stringify(err)).not.toContain("/srv/app")
+    })
+  })
+
   describe("sendToOpenfisca", () => {
     it("ne divulgue ni la situation personnelle ni les chemins du serveur", async () => {
       vi.mocked(axios.post).mockRejectedValue(abortError())

--- a/tests/unit/backend/openfisca-error-handling.spec.ts
+++ b/tests/unit/backend/openfisca-error-handling.spec.ts
@@ -233,3 +233,38 @@ describe("assainissement du corps d'erreur", () => {
     expect(err.message).toBeTruthy()
   })
 })
+
+describe("routes anonymes /api/openfisca/*", () => {
+  it("ne renvoie pas l'adresse interne du service via getter.get", async () => {
+    const axiosGet = vi.fn().mockRejectedValue(
+      Object.assign(new Error("connect ECONNREFUSED 10.0.0.12:2000"), {
+        isAxiosError: true,
+        code: "ECONNREFUSED",
+      }),
+    )
+    ;(axios as any).get = axiosGet
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { default: getter } = await import("@backend/lib/openfisca/getter.js")
+    const callback = vi.fn()
+    const err = await getter.get("/variables", callback).catch((e) => e)
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(err.message).not.toContain("10.0.0.12")
+    expect(err.code).toBe("ECONNREFUSED")
+  })
+
+  it("ne réécrit pas une exception levée par l'appelant", async () => {
+    ;(axios as any).get = vi.fn().mockResolvedValue({ data: { a: 1 } })
+    const bug = new TypeError("boom dans le handler de route")
+
+    const { default: getter } = await import("@backend/lib/openfisca/getter.js")
+    const err = await getter
+      .get("/variables", () => {
+        throw bug
+      })
+      .catch((e) => e)
+
+    expect(err).toBe(bug)
+  })
+})

--- a/tests/unit/backend/openfisca-error-handling.spec.ts
+++ b/tests/unit/backend/openfisca-error-handling.spec.ts
@@ -190,3 +190,46 @@ describe("remontée des erreurs OpenFisca", () => {
     })
   })
 })
+
+describe("assainissement du corps d'erreur", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("laisse intacte une exception applicative levée par le callback", async () => {
+    vi.mocked(axios.post).mockResolvedValue({ status: 200, data: { a: 1 } })
+    const bug = new TypeError("Cannot set properties of undefined")
+
+    const received = await new Promise<any>((resolve) => {
+      let first = true
+      sendToOpenfisca("calculate", () => ({}))({}, (err) => {
+        if (first) {
+          first = false
+          throw bug
+        }
+        resolve(err)
+      })
+    })
+
+    // Le message et la pile doivent survivre : sans eux, un défaut de calcul
+    // devient indébogable dans les logs comme dans Sentry.
+    expect(received).toBe(bug)
+    expect(received.stack).toBeTruthy()
+  })
+
+  it("ne déplie pas un corps d'erreur textuel en dictionnaire de caractères", async () => {
+    vi.mocked(axios.post).mockRejectedValue(
+      Object.assign(new Error("Request failed with status code 502"), {
+        isAxiosError: true,
+        code: "ERR_BAD_RESPONSE",
+        response: { status: 502, data: "<html>502 Bad Gateway</html>" },
+      }),
+    )
+
+    const { err } = await callbackOf((cb) =>
+      sendToOpenfisca("calculate", () => ({}))({}, cb),
+    )
+
+    expect(err).not.toHaveProperty("0")
+    expect(typeof err).toBe("object")
+    expect(err.message).toBeTruthy()
+  })
+})

--- a/tests/unit/backend/openfisca-error-handling.spec.ts
+++ b/tests/unit/backend/openfisca-error-handling.spec.ts
@@ -1,0 +1,115 @@
+import { expect, vi } from "vitest"
+
+vi.mock("axios", () => ({
+  default: { post: vi.fn(), defaults: {} },
+}))
+
+// Le chargement du module lit le système de fichiers, ce que l'environnement
+// de test ne permet pas ; seul `apply` est utilisé par le contrôleur.
+vi.mock("@backend/lib/migrations/index.js", () => ({
+  apply: (simulation) => simulation,
+}))
+
+import axios from "axios"
+import { sendToOpenfisca } from "@backend/lib/openfisca/index.js"
+import simulationController from "@backend/controllers/simulation.js"
+import teleservices from "@backend/controllers/teleservices/index.js"
+
+const PERSONAL_VALUE = "<img src=x onerror=alert(1)>"
+
+// Un AxiosError d'abandon : pas de `response`, mais `config` porte la requête
+// envoyée — donc la situation personnelle — et `stack` les chemins du serveur.
+function abortError() {
+  return Object.assign(new Error("timeout of 25000ms exceeded"), {
+    name: "AxiosError",
+    code: "ECONNABORTED",
+    config: { data: JSON.stringify({ depcom: PERSONAL_VALUE }) },
+    stack: "AxiosError\n    at /srv/app/node_modules/axios/lib/core.js:1:1",
+  })
+}
+
+function callbackOf(fn): Promise<{ err: any; result: any }> {
+  return new Promise((resolve) => fn((err, result) => resolve({ err, result })))
+}
+
+describe("remontée des erreurs OpenFisca", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  describe("sendToOpenfisca", () => {
+    it("ne divulgue ni la situation personnelle ni les chemins du serveur", async () => {
+      vi.mocked(axios.post).mockRejectedValue(abortError())
+
+      const { err } = await callbackOf((cb) =>
+        sendToOpenfisca("calculate", () => ({}))({}, cb),
+      )
+
+      const serialized = JSON.stringify(err)
+      expect(serialized).not.toContain(PERSONAL_VALUE)
+      expect(serialized).not.toContain("node_modules")
+      expect(err).not.toHaveProperty("config")
+      expect(err).not.toHaveProperty("stack")
+      expect(err).toMatchObject({ name: "AxiosError", code: "ECONNABORTED" })
+    })
+
+    it("conserve le corps d'erreur renvoyé par OpenFisca quand il existe", async () => {
+      vi.mocked(axios.post).mockRejectedValue(
+        Object.assign(new Error("Bad Request"), {
+          response: { data: { error: "unknown variable" } },
+        }),
+      )
+
+      const { err } = await callbackOf((cb) =>
+        sendToOpenfisca("calculate", () => ({}))({}, cb),
+      )
+
+      expect(err).toEqual({ error: "unknown variable" })
+    })
+  })
+
+  describe("openfiscaTrace", () => {
+    it("passe l'erreur à next() quand elle n'a pas de réponse HTTP", async () => {
+      vi.mocked(axios.post).mockRejectedValue(abortError())
+
+      const next = vi.fn()
+      const res: any = { send: vi.fn() }
+      await new Promise((resolve) => {
+        simulationController.openfiscaTrace(
+          { situation: {}, simulationId: "abc" } as any,
+          res,
+          (...args) => {
+            next(...args)
+            resolve(null)
+          },
+        )
+      })
+
+      expect(res.send).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalledTimes(1)
+      expect(next.mock.calls[0][0]).toMatchObject({ _id: "abc" })
+    })
+  })
+
+  describe("exportRepresentation", () => {
+    it("passe le rejet à next() au lieu de laisser la requête pendante", async () => {
+      const failure = new Error("timeout of 25000ms exceeded")
+      const next = vi.fn()
+      const res: any = { json: vi.fn() }
+
+      function FailingTeleservice() {}
+      FailingTeleservice.prototype.toExternal = () => Promise.reject(failure)
+
+      await teleservices.exportRepresentation(
+        {
+          teleservice: { class: FailingTeleservice },
+          simulation: {},
+          payload: { query: {} },
+        } as any,
+        res,
+        next,
+      )
+
+      expect(res.json).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalledWith(failure)
+    })
+  })
+})


### PR DESCRIPTION
## Contexte

Pendant l'incident de saturation, la capture htop de l'hôte de production montre une
machine peu chargée — load average 3.20 pour 12 vCPU, 45 Go de RAM libres — avec les
seuls workers gunicorn d'OpenFisca à 100 %. Le goulot est la concurrence de calcul, et
le code applicatif l'aggrave.

## 1. Aucun timeout sur l'appel vers OpenFisca

`backend/lib/openfisca/index.ts` faisait `axios.post()` sans option de timeout. Le
défaut d'axios est *infini* : une requête lente immobilisait la connexion jusqu'à ce
que gunicorn tranche, au bout de `timeout = 120`.

Le pool OpenFisca tourne en workers **sync** : leur nombre est la concurrence maximale
pour tout le cluster. Chaque requête bloquée retire une place à tout le monde pendant
deux minutes, et la file déborde en 504.

- axios : abandon à 25 s, configurable via `OPENFISCA_TIMEOUT_MS`
- gunicorn : `timeout` ramené de 120 s à 30 s, configurable via `OPENFISCA_TIMEOUT`

L'ordre compte et il est documenté dans le code : abandonner côté client ne libère pas
le worker Python, c'est gunicorn qui le recycle. Le timeout client doit donc rester le
plus court des deux. Les deux valeurs restent très au-dessus d'un calcul normal.

## 2. Durcissement de la vérification du token d'accès

Second commit, indépendant : `Simulation.isAccessible()` vérifie désormais
explicitement qu'un token existe sur le document avant de comparer les clés
présentées, et le hook `pre("save")` ne masque plus l'échec de génération du token —
l'erreur est propagée.

> À jouer avant merge pour clore le sujet :
> `db.simulations.countDocuments({$or:[{token:{$exists:false}},{token:null},{token:""}]})`
> Attendu : 0. Les seuls documents concernés dateraient d'avant 2018, et personne n'en
> détient de cookie d'accès.

## 3. Le chemin d'erreur, devenu routinier, était cassé

Poser un timeout transforme un chemin d'erreur rarissime en chemin d'erreur ordinaire.
Ce chemin ne tenait pas, et quatre tours de revue adversariale y ont trouvé quatre
défauts successifs — chacun corrigé dans son propre commit :

- `openfiscaTrace` déréférençait `err.response.data` sans garde. Un abandon de requête
  n'a pas de `response` : le `TypeError` partait en rejet non géré et la requête
  restait pendante jusqu'au timeout nginx, c'est-à-dire le 504 même que cette PR vise
  à supprimer. `exportRepresentation` ne rattrapait par ailleurs aucun rejet, sur une
  route publique en CORS ouvert.
- à défaut de `response`, le corps renvoyé au client **et écrit dans les logs** était
  l'`AxiosError` entier. `config.data` y porte la requête OpenFisca — donc la
  situation personnelle complète — et `stack` les chemins du serveur. Mesuré : 5,7 Ko
  de donnée personnelle en clair par timeout.
- la normalisation qui corrigeait ce point utilisait `??`, qui ne retient que `null` et
  `undefined`. Or axios renvoie `response.data === ""` pour toute réponse d'erreur à
  corps vide — un 502 d'intermédiaire. Les appelants testent `if (err)` : le calcul se
  poursuivait avec une réponse indéfinie et la requête ne recevait jamais de réponse.
- cette normalisation s'appliquait ensuite à tout, y compris aux exceptions levées par
  le calcul des aides lui-même, dont elle effaçait message et pile. Seules les erreurs
  de transport sont désormais assainies, reconnues à la présence de `config` ou
  `response` autant qu'au drapeau d'axios.

L'erreur est normalisée à la source : le corps renvoyé par OpenFisca est conservé
quand c'est un objet, sinon seuls le nom, le code et un message générique sont
propagés. Le message d'origine est journalisé côté serveur, pour rester diagnosticable.

Cinq défauts du même périmètre sont corrigés au passage :

- `getPromise` **et** `get` interpolaient le message d'axios, donc l'adresse interne du
  service, dans une erreur qui atteint le client sur les deux routes anonymes
  `/api/openfisca/*` — routes que cette PR a elle-même rendues joignables en leur
  ajoutant un rattrapage de rejet
- ces deux routes n'avaient ni délai d'abandon ni rattrapage et pendaient indéfiniment
- le middleware d'erreur sérialisait les objets d'erreur des bibliothèques HTTP tels
  quels, pile et configuration de requête sortante comprises, et dépliait un corps
  d'erreur textuel en dictionnaire indexé caractère par caractère
- le statut HTTP était piloté par le champ `code` du corps d'OpenFisca, jusqu'à faire
  lever `res.status()` hors plage
- `openfisca/config.py` refusait de démarrer si `OPENFISCA_TIMEOUT` était définie mais
  vide ; `isTimeoutError` testait `instanceof String` sur une chaîne primitive ; les
  détails techniques étaient rendus en `v-html` dans les deux composants d'erreur

## Vérification

```
$ npx tsc --noEmit -p tsconfig.server.json
TypeScript: No errors found

$ npm run lint
(0 erreur, 0 warning)

$ NODE_OPTIONS='--max-old-space-size=4096' npx vitest run --pool=forks
25019 tests passants        (référence sur main : 25003)
```

La suite **sort en code 1**, sur une erreur non gérée `OF maybe offline` émise depuis
`tests/unit/other/compute-aides.spec.ts`. Vérifié sur `main` : elle y est déjà, ce
n'est pas une régression de cette PR.

`tests/unit/backend/openfisca-error-handling.spec.ts` couvre chaque correctif du
chemin d'erreur : **15 tests, dont chacun échoue sur le code d'avant et passe après**.
Le premier montre la valeur personnelle apparaître littéralement dans le corps
d'erreur ; le dernier montre `connect ECONNREFUSED 10.0.0.12:2000` renvoyé à un client
anonyme.

## À assumer

Ce diff transforme des requêtes lentes en échecs plus rapides. Nginx coupait déjà à
60 s : un 504 à 60 s devient un 500 à 25 s, ce qui est préférable, mais reste un
échec. La capacité elle-même est traitée dans la PR `aides-jeunes-ops`, et la demande
dans la PR de mise en cache des résultats. Les trois ne prennent leur sens qu'ensemble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
