### PR TITLE
feat(simulation): met en cache les résultats de calcul OpenFisca

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,11 @@ VITE_STATS_VERSION=
 
 MONGODB_URL=
 
+# Durée de validité d'un résultat de simulation mis en cache, en heures.
+# Elle borne la dérive que la signature de calcul ne peut pas détecter.
+# Par défaut : 24. Une valeur nulle désactive le cache.
+COMPUTED_RESULTS_TTL_HOURS=
+
 SENTRY_ORG=
 SENTRY_URL=
 

--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -17,6 +17,20 @@ const isProduction = process.env.NODE_ENV == "production"
 
 const contextName = process.env.CONTEXT_NAME || "1jeune1solution"
 
+function readNonNegativeNumber(name: string, defaultValue: number): number {
+  const raw = process.env[name]
+  if (raw === undefined || raw === "") {
+    return defaultValue
+  }
+
+  const value = Number(raw)
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative number, got "${raw}"`)
+  }
+
+  return value
+}
+
 const config: Configuration = {
   env: process.env.NODE_ENV || "development",
   baseURL:
@@ -108,6 +122,12 @@ const config: Configuration = {
     url: process.env.VITE_STATS_URL || "http://localhost:4000/benefits",
     version: Number(process.env.VITE_STATS_VERSION) || 2,
   },
+  // Durée de validité d'un résultat de simulation mis en cache. Elle borne la
+  // dérive que la signature de calcul ne peut pas détecter, par exemple une
+  // modification de la logique JavaScript sans changement de version. Une durée
+  // nulle désactive le cache.
+  computedResultsTtlMs:
+    readNonNegativeNumber("COMPUTED_RESULTS_TTL_HOURS", 24) * 60 * 60 * 1000,
   mongodb_url:
     process.env.MONGODB_URL || "mongodb://127.0.0.1:27017/dev-aides-jeunes",
   sentry: {

--- a/backend/controllers/simulation.ts
+++ b/backend/controllers/simulation.ts
@@ -81,7 +81,12 @@ function validateAccess(req: Request, res, next) {
 }
 
 function show(req: Request, res) {
-  res.send(req.simulation)
+  // `computedResults` est un état interne de cache : ni le front ni les
+  // téléservices ne le consomment, et il alourdit une route chaude.
+  const simulation = req.simulation?.toObject
+    ? req.simulation.toObject()
+    : req.simulation
+  res.send(omit(simulation, "computedResults"))
 }
 
 function clearCookies(req: Request, res) {

--- a/backend/controllers/simulation.ts
+++ b/backend/controllers/simulation.ts
@@ -83,8 +83,10 @@ function validateAccess(req: Request, res, next) {
 function show(req: Request, res) {
   // `computedResults` est un état interne de cache : ni le front ni les
   // téléservices ne le consomment, et il alourdit une route chaude.
-  const simulation = req.simulation?.toObject
-    ? req.simulation.toObject()
+  // `toJSON` et non `toObject` : c'est lui qu'Express appellerait, et lui seul
+  // aplatit les Map du schéma. `toObject` rendrait `abtesting` vide.
+  const simulation = req.simulation?.toJSON
+    ? req.simulation.toJSON()
     : req.simulation
   res.send(omit(simulation, "computedResults"))
 }

--- a/backend/controllers/simulation.ts
+++ b/backend/controllers/simulation.ts
@@ -114,7 +114,7 @@ async function create(req: Request, res, next) {
 
   try {
     const persistedSimulation = await Simulations.create(
-      omit(req.body, "createdAt", "status", "token"),
+      omit(req.body, "computedResults", "createdAt", "status", "token"),
     )
 
     clearCookies(req, res)

--- a/backend/lib/computed-results.ts
+++ b/backend/lib/computed-results.ts
@@ -1,0 +1,146 @@
+import { isEqual } from "lodash-es"
+
+import benefits from "../../data/all.js"
+
+const GROUPS = ["droitsEligibles", "droitsInjectes"] as const
+
+type Group = (typeof GROUPS)[number]
+
+type SerializedDroit = {
+  id: string
+  overlay?: Record<string, unknown>
+  undefinedKeys?: string[]
+}
+
+// Une entrée sérialisée sous un autre format ne décrit pas les mêmes données :
+// elle est refusée plutôt que relue de travers.
+const SERIALIZATION_FORMAT = 1
+
+export type SerializedResults = Record<Group, SerializedDroit[]> & {
+  format: number
+}
+
+let catalogById: Map<string, Record<string, unknown>> | undefined
+
+function getCatalogBenefit(id: string): Record<string, unknown> {
+  if (!catalogById) {
+    catalogById = new Map(
+      (benefits.all as unknown as Record<string, unknown>[]).map((benefit) => [
+        benefit.id as string,
+        benefit,
+      ]),
+    )
+  }
+
+  const benefit = catalogById.get(id)
+  if (!benefit) {
+    throw new Error(`Benefit "${id}" is missing from the catalog`)
+  }
+
+  return benefit
+}
+
+function containsFunction(value: unknown): boolean {
+  if (typeof value === "function") {
+    return true
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(containsFunction)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some(containsFunction)
+  }
+
+  return false
+}
+
+/**
+ * Un droit calculé est une aide du catalogue à laquelle le calcul a ajouté sa
+ * part volatile (montant, légende, instructions, personnalisation locale). Seul
+ * cet écart est persisté : les propriétés fonction (`labelFunction`,
+ * `legend`, `compute`…) et les `undefined` ne survivent pas à un aller-retour
+ * BSON, et le catalogue les restitue intacts à la relecture.
+ */
+function serializeDroit(droit: Record<string, unknown>): SerializedDroit {
+  const id = droit.id as string
+  const base = getCatalogBenefit(id)
+  const overlay: Record<string, unknown> = {}
+  const undefinedKeys: string[] = []
+
+  for (const key of Object.keys(droit)) {
+    const value = droit[key]
+
+    if (value === undefined) {
+      undefinedKeys.push(key)
+      continue
+    }
+
+    if (isEqual(value, base[key])) {
+      continue
+    }
+
+    if (containsFunction(value)) {
+      throw new Error(
+        `Benefit "${id}" holds a function in its computed field "${key}", which cannot be persisted`,
+      )
+    }
+
+    overlay[key] = value
+  }
+
+  const serialized: SerializedDroit = { id }
+  if (Object.keys(overlay).length) {
+    serialized.overlay = overlay
+  }
+  if (undefinedKeys.length) {
+    serialized.undefinedKeys = undefinedKeys
+  }
+
+  return serialized
+}
+
+function deserializeDroit(
+  serialized: SerializedDroit,
+): Record<string, unknown> {
+  const droit = { ...getCatalogBenefit(serialized.id), ...serialized.overlay }
+
+  for (const key of serialized.undefinedKeys ?? []) {
+    droit[key] = undefined
+  }
+
+  return droit
+}
+
+export function serializeResults(results): SerializedResults {
+  return {
+    format: SERIALIZATION_FORMAT,
+    ...Object.fromEntries(
+      GROUPS.map((group) => [group, results[group].map(serializeDroit)]),
+    ),
+  } as SerializedResults
+}
+
+export function deserializeResults(
+  serialized: SerializedResults,
+  id: string,
+): Record<string, unknown> {
+  if (serialized?.format !== SERIALIZATION_FORMAT) {
+    throw new Error(
+      `Unsupported computed results format "${serialized?.format}", expected ${SERIALIZATION_FORMAT}`,
+    )
+  }
+
+  const results = Object.fromEntries(
+    GROUPS.map((group) => {
+      if (!Array.isArray(serialized[group])) {
+        throw new Error(`Computed results are missing the "${group}" group`)
+      }
+
+      return [group, serialized[group].map(deserializeDroit)]
+    }),
+  )
+
+  return { ...results, _id: id }
+}

--- a/backend/lib/computed-results.ts
+++ b/backend/lib/computed-results.ts
@@ -9,12 +9,14 @@ type Group = (typeof GROUPS)[number]
 type SerializedDroit = {
   id: string
   overlay?: Record<string, unknown>
-  undefinedKeys?: string[]
+  // Chemins, et non simples clés : BSON écrit `null` pour un `undefined`, à
+  // n'importe quelle profondeur.
+  undefinedPaths?: string[][]
 }
 
 // Une entrée sérialisée sous un autre format ne décrit pas les mêmes données :
 // elle est refusée plutôt que relue de travers.
-const SERIALIZATION_FORMAT = 1
+const SERIALIZATION_FORMAT = 2
 
 export type SerializedResults = Record<Group, SerializedDroit[]> & {
   format: number
@@ -63,17 +65,47 @@ function containsFunction(value: unknown): boolean {
  * `legend`, `compute`…) et les `undefined` ne survivent pas à un aller-retour
  * BSON, et le catalogue les restitue intacts à la relecture.
  */
+// Un `undefined` imbriqué ne se distingue plus d'un `null` après un aller-retour
+// BSON : son emplacement est relevé pour être rétabli à la relecture.
+function collectUndefinedPaths(
+  value: unknown,
+  path: string[],
+  paths: string[][],
+): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      if (item === undefined) {
+        paths.push([...path, String(index)])
+        return
+      }
+      collectUndefinedPaths(item, [...path, String(index)], paths)
+    })
+    return
+  }
+
+  if (value && typeof value === "object" && !(value instanceof Date)) {
+    for (const key of Object.keys(value)) {
+      const child = (value as Record<string, unknown>)[key]
+      if (child === undefined) {
+        paths.push([...path, key])
+        continue
+      }
+      collectUndefinedPaths(child, [...path, key], paths)
+    }
+  }
+}
+
 function serializeDroit(droit: Record<string, unknown>): SerializedDroit {
   const id = droit.id as string
   const base = getCatalogBenefit(id)
   const overlay: Record<string, unknown> = {}
-  const undefinedKeys: string[] = []
+  const undefinedPaths: string[][] = []
 
   for (const key of Object.keys(droit)) {
     const value = droit[key]
 
     if (value === undefined) {
-      undefinedKeys.push(key)
+      undefinedPaths.push([key])
       continue
     }
 
@@ -88,14 +120,15 @@ function serializeDroit(droit: Record<string, unknown>): SerializedDroit {
     }
 
     overlay[key] = value
+    collectUndefinedPaths(value, [key], undefinedPaths)
   }
 
   const serialized: SerializedDroit = { id }
   if (Object.keys(overlay).length) {
     serialized.overlay = overlay
   }
-  if (undefinedKeys.length) {
-    serialized.undefinedKeys = undefinedKeys
+  if (undefinedPaths.length) {
+    serialized.undefinedPaths = undefinedPaths
   }
 
   return serialized
@@ -106,8 +139,14 @@ function deserializeDroit(
 ): Record<string, unknown> {
   const droit = { ...getCatalogBenefit(serialized.id), ...serialized.overlay }
 
-  for (const key of serialized.undefinedKeys ?? []) {
-    droit[key] = undefined
+  for (const path of serialized.undefinedPaths ?? []) {
+    let target: any = droit
+    for (const segment of path.slice(0, -1)) {
+      target = target?.[segment]
+    }
+    if (target && typeof target === "object") {
+      target[path[path.length - 1]] = undefined
+    }
   }
 
   return droit

--- a/backend/lib/openfisca/compute-signature.ts
+++ b/backend/lib/openfisca/compute-signature.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto"
+import * as Sentry from "@sentry/node"
+
+import getter from "./getter.js"
+import benefits from "../../../data/all.js"
+import { version as simulationVersion } from "../../../lib/simulation.js"
+
+const REFRESH_INTERVAL_MS = 10 * 60 * 1000
+const RETRY_INTERVAL_MS = 30 * 1000
+
+type SignatureCache = {
+  value: string | null
+  expiresAt: number
+}
+
+let cache: SignatureCache | undefined
+let inFlight: Promise<string | null> | undefined
+let benefitsDigest: string | undefined
+
+// Sérialisation déterministe : clés triées pour ne pas dépendre de l'ordre de
+// lecture du référentiel, fonctions rendues par leur source pour couvrir les
+// aides dont le montant est calculé en JavaScript.
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, current) => {
+    if (typeof current === "function") {
+      return current.toString()
+    }
+
+    if (current && typeof current === "object" && !Array.isArray(current)) {
+      return Object.keys(current)
+        .sort()
+        .reduce((sorted, key) => {
+          sorted[key] = current[key]
+          return sorted
+        }, {})
+    }
+
+    return current
+  })
+}
+
+/**
+ * Empreinte de la situation soumise au calcul, complément local de la
+ * signature globale : elle identifie les données d'entrée du résultat mis en
+ * cache.
+ */
+export function getSituationSignature(situation: unknown): string {
+  const digest = createHash("sha256")
+    .update(stableStringify(situation))
+    .digest("hex")
+    .slice(0, 16)
+
+  return `situation:${digest}`
+}
+
+function getBenefitsDigest(): string {
+  if (!benefitsDigest) {
+    benefitsDigest = createHash("sha256")
+      .update(stableStringify(benefits))
+      .digest("hex")
+      .slice(0, 12)
+  }
+
+  return benefitsDigest
+}
+
+async function buildSignature(): Promise<string | null> {
+  try {
+    const { name, version } = await getter.getCountryPackageMetadata()
+    const signature = [
+      `openfisca:${name}@${version}`,
+      `benefits:${getBenefitsDigest()}`,
+      `simulation:${simulationVersion}`,
+    ].join("|")
+
+    cache = { value: signature, expiresAt: Date.now() + REFRESH_INTERVAL_MS }
+    return signature
+  } catch (error) {
+    console.error("Unable to build the OpenFisca compute signature", error)
+    Sentry.captureException(error)
+
+    // Aucune signature de repli : servir un résultat sous une signature
+    // approximative exposerait des montants périmés. L'absence de signature
+    // désactive le cache, en lecture comme en écriture.
+    cache = { value: null, expiresAt: Date.now() + RETRY_INTERVAL_MS }
+    return null
+  }
+}
+
+/**
+ * Signature du contexte de calcul : version du paquet pays OpenFisca,
+ * empreinte du référentiel d'aides et version du format de simulation.
+ * Mémoïsée, rafraîchie périodiquement, et `null` quand elle est indéterminable.
+ */
+export async function getComputeSignature(): Promise<string | null> {
+  if (cache && Date.now() < cache.expiresAt) {
+    return cache.value
+  }
+
+  if (!inFlight) {
+    inFlight = buildSignature().finally(() => {
+      inFlight = undefined
+    })
+  }
+
+  return inFlight
+}

--- a/backend/lib/openfisca/compute-signature.ts
+++ b/backend/lib/openfisca/compute-signature.ts
@@ -1,4 +1,7 @@
 import { createHash } from "node:crypto"
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
 import * as Sentry from "@sentry/node"
 
 import getter from "./getter.js"
@@ -8,14 +11,12 @@ import { version as simulationVersion } from "../../../lib/simulation.js"
 const REFRESH_INTERVAL_MS = 10 * 60 * 1000
 const RETRY_INTERVAL_MS = 30 * 1000
 
-type SignatureCache = {
-  value: string | null
-  expiresAt: number
-}
-
-let cache: SignatureCache | undefined
-let inFlight: Promise<string | null> | undefined
+let lastKnownSignature: string | undefined
+let refreshedAt = 0
+let attemptedAt = 0
+let inFlight: Promise<void> | undefined
 let benefitsDigest: string | undefined
+let environmentDigest: string | null | undefined
 
 // Sérialisation déterministe : clés triées pour ne pas dépendre de l'ordre de
 // lecture du référentiel, fonctions rendues par leur source pour couvrir les
@@ -39,69 +40,137 @@ function stableStringify(value: unknown): string {
   })
 }
 
+function digest(value: unknown, length: number): string {
+  return createHash("sha256")
+    .update(stableStringify(value))
+    .digest("hex")
+    .slice(0, length)
+}
+
 /**
  * Empreinte de la situation soumise au calcul, complément local de la
  * signature globale : elle identifie les données d'entrée du résultat mis en
  * cache.
  */
 export function getSituationSignature(situation: unknown): string {
-  const digest = createHash("sha256")
-    .update(stableStringify(situation))
-    .digest("hex")
-    .slice(0, 16)
-
-  return `situation:${digest}`
+  return `situation:${digest(situation, 16)}`
 }
 
 function getBenefitsDigest(): string {
   if (!benefitsDigest) {
-    benefitsDigest = createHash("sha256")
-      .update(stableStringify(benefits))
-      .digest("hex")
-      .slice(0, 12)
+    benefitsDigest = digest(benefits, 12)
   }
 
   return benefitsDigest
 }
 
-async function buildSignature(): Promise<string | null> {
-  try {
-    const { name, version } = await getter.getCountryPackageMetadata()
-    const signature = [
-      `openfisca:${name}@${version}`,
-      `benefits:${getBenefitsDigest()}`,
-      `simulation:${simulationVersion}`,
-    ].join("|")
+// La racine du dépôt porte `openfisca/requirements.txt` et `package.json` :
+// elle se trouve trois niveaux au-dessus de ce module dans l'arborescence des
+// sources, quatre une fois compilé sous `dist-server`.
+function findRepositoryRoot(): string {
+  const moduleDirectory = path.dirname(fileURLToPath(import.meta.url))
+  let directory = moduleDirectory
 
-    cache = { value: signature, expiresAt: Date.now() + REFRESH_INTERVAL_MS }
-    return signature
-  } catch (error) {
-    console.error("Unable to build the OpenFisca compute signature", error)
-    Sentry.captureException(error)
+  for (;;) {
+    if (existsSync(path.join(directory, "package.json"))) {
+      return directory
+    }
 
-    // Aucune signature de repli : servir un résultat sous une signature
-    // approximative exposerait des montants périmés. L'absence de signature
-    // désactive le cache, en lecture comme en écriture.
-    cache = { value: null, expiresAt: Date.now() + RETRY_INTERVAL_MS }
-    return null
+    const parent = path.dirname(directory)
+    if (parent === directory) {
+      throw new Error(`No package.json found above ${moduleDirectory}`)
+    }
+
+    directory = parent
   }
 }
 
 /**
- * Signature du contexte de calcul : version du paquet pays OpenFisca,
- * empreinte du référentiel d'aides et version du format de simulation.
- * Mémoïsée, rafraîchie périodiquement, et `null` quand elle est indéterminable.
+ * Empreinte des sources de calcul que l'API OpenFisca n'expose pas :
+ * `get_package_metadata()` ne décrit que le paquet pays, sans les extensions
+ * (`OpenFisca-France-Local`, `Openfisca-Paris`) ni la réforme EPCI, toutes
+ * épinglées par `openfisca/requirements.txt`. `package.json` couvre la version
+ * applicative et les dépendances de calcul côté Node, dont `@betagouv/aides-velo`.
  */
-export async function getComputeSignature(): Promise<string | null> {
-  if (cache && Date.now() < cache.expiresAt) {
-    return cache.value
+function getEnvironmentDigest(): string | null {
+  if (environmentDigest === undefined) {
+    try {
+      const root = findRepositoryRoot()
+      const requirements = readFileSync(
+        path.join(root, "openfisca", "requirements.txt"),
+        "utf8",
+      )
+      const { version, dependencies } = JSON.parse(
+        readFileSync(path.join(root, "package.json"), "utf8"),
+      )
+
+      environmentDigest = digest({ requirements, version, dependencies }, 12)
+    } catch (error) {
+      console.error("Unable to digest the compute environment sources", error)
+      Sentry.captureException(error)
+
+      // Sans cette empreinte, une signature resterait aveugle aux extensions
+      // OpenFisca et au code applicatif : le cache est désactivé plutôt que
+      // signé sur un périmètre incomplet.
+      environmentDigest = null
+    }
   }
 
-  if (!inFlight) {
-    inFlight = buildSignature().finally(() => {
+  return environmentDigest
+}
+
+async function buildSignature(): Promise<string> {
+  const environment = getEnvironmentDigest()
+  if (!environment) {
+    throw new Error("The compute environment digest is unavailable")
+  }
+
+  const { name, version } = await getter.getCountryPackageMetadata()
+
+  return [
+    `openfisca:${name}@${version}`,
+    `environment:${environment}`,
+    `benefits:${getBenefitsDigest()}`,
+    `simulation:${simulationVersion}`,
+  ].join("|")
+}
+
+function refresh(): void {
+  if (inFlight || Date.now() - attemptedAt < RETRY_INTERVAL_MS) {
+    return
+  }
+
+  attemptedAt = Date.now()
+  inFlight = buildSignature()
+    .then((signature) => {
+      lastKnownSignature = signature
+      refreshedAt = Date.now()
+    })
+    .catch((error) => {
+      console.error("Unable to build the OpenFisca compute signature", error)
+      Sentry.captureException(error)
+    })
+    .finally(() => {
       inFlight = undefined
     })
+}
+
+/**
+ * Signature du contexte de calcul : version du paquet pays OpenFisca, empreinte
+ * des sources de calcul, empreinte du référentiel d'aides et version du format
+ * de simulation.
+ *
+ * L'appel ne bloque jamais : il sert la dernière signature obtenue et déclenche
+ * le rafraîchissement en arrière-plan. Un échec ne remplace jamais cette
+ * signature — la version d'un paquet ne change pas sans redémarrage du
+ * processus, alors que la jeter relancerait un calcul complet pour tout le
+ * monde au pire moment. Tant qu'aucune signature n'a été obtenue, son absence
+ * désactive le cache en lecture comme en écriture.
+ */
+export function getComputeSignature(): string | null {
+  if (!lastKnownSignature || Date.now() - refreshedAt >= REFRESH_INTERVAL_MS) {
+    refresh()
   }
 
-  return inFlight
+  return lastKnownSignature ?? null
 }

--- a/backend/lib/openfisca/getter.ts
+++ b/backend/lib/openfisca/getter.ts
@@ -21,7 +21,36 @@ async function getPromise(item): Promise<any> {
     })
 }
 
+const COUNTRY_PACKAGE_METADATA_TIMEOUT_MS = 5000
+
+export interface CountryPackageMetadata {
+  name: string
+  version: string
+}
+
+// La racine de la Web API OpenFisca répond 300 avec un simple message de
+// bienvenue : les métadonnées du paquet pays ne sont exposées que par les
+// en-têtes `Country-Package` et `Country-Package-Version`.
+async function getCountryPackageMetadata(): Promise<CountryPackageMetadata> {
+  const response = await axios.get(`${config.openfiscaURL}/`, {
+    timeout: COUNTRY_PACKAGE_METADATA_TIMEOUT_MS,
+    validateStatus: (status) => status >= 200 && status < 400,
+  })
+
+  const name = response.headers["country-package"]
+  const version = response.headers["country-package-version"]
+
+  if (!name || !version) {
+    throw new Error(
+      `Country package metadata missing from ${config.openfiscaURL}/ response headers (status ${response.status})`,
+    )
+  }
+
+  return { name, version }
+}
+
 export default {
   get,
   getPromise,
+  getCountryPackageMetadata,
 }

--- a/backend/lib/openfisca/parameters.ts
+++ b/backend/lib/openfisca/parameters.ts
@@ -52,6 +52,10 @@ function requestParameters() {
         throw error
       },
     )
+    // `getParameters` est synchrone et jette cette promesse sans la traiter.
+    // Chaque fenêtre de réessai produirait sinon un rejet non géré, qui termine
+    // le process quand Sentry est désactivé faute de DSN.
+    parameterPromise.catch(() => {})
   }
   return parameterPromise
 }

--- a/backend/lib/openfisca/parameters.ts
+++ b/backend/lib/openfisca/parameters.ts
@@ -11,7 +11,14 @@ export const parametersList: OpenfiscaParameters = {
   "marche_travail.salaire_minimum.smic.nb_heures_travail_mensuel": 151.67,
 }
 
+// Une tentative infructueuse n'est mémoïsée que le temps de ce délai : sans
+// lui, un OpenFisca indisponible au démarrage du processus laisserait
+// `parameters` indéfini pour toute sa durée de vie, et les légendes
+// retomberaient sur les constantes de `parametersList`.
+const RETRY_DELAY_MS = 60 * 1000
+
 let parameterPromise
+let parameterFailedAt = 0
 let parameters
 
 async function fetchParameters() {
@@ -29,13 +36,34 @@ async function fetchParameters() {
 }
 
 function requestParameters() {
+  if (parameterFailedAt && Date.now() - parameterFailedAt >= RETRY_DELAY_MS) {
+    parameterPromise = undefined
+  }
+
   if (!parameterPromise) {
-    parameterPromise = fetchParameters().then((values) => {
-      parameters = values
-      return values
-    })
+    parameterFailedAt = 0
+    parameterPromise = fetchParameters().then(
+      (values) => {
+        parameters = values
+        return values
+      },
+      (error) => {
+        parameterFailedAt = Date.now()
+        throw error
+      },
+    )
   }
   return parameterPromise
+}
+
+/**
+ * Les paramètres alimentent les légendes des aides (« au lieu de 0,5 % ») :
+ * tant qu'ils ne sont pas chargés, `computeParameter` retombe sur les
+ * constantes de `parametersList`, dont la valeur ne correspond plus au barème
+ * courant. Un résultat calculé dans cet état ne doit pas être persisté.
+ */
+export function areParametersLoaded(): boolean {
+  return parameters !== undefined
 }
 
 function computeParameter(parameter, date) {
@@ -82,6 +110,7 @@ export async function getParametersAsync(date): Promise<OpenfiscaParameters> {
 
 export default {
   parametersList,
+  areParametersLoaded,
   getParameter,
   getParameters,
   getParametersAsync,

--- a/backend/lib/teleservices/aides-jeunes-preremplissage.ts
+++ b/backend/lib/teleservices/aides-jeunes-preremplissage.ts
@@ -8,10 +8,8 @@ AidesJeunesPreremplissage.prototype.toInternal = function () {
 
 AidesJeunesPreremplissage.prototype.toExternal = function () {
   try {
-    // Calcul mené pour un tiers sur un document que l'appelant a pu modifier en
-    // mémoire : il reste hors du cache de l'usager.
     const p = this.simulation
-      .compute({ cache: false })
+      .compute()
       .then((results) => {
         return results
       })

--- a/backend/lib/teleservices/aides-jeunes-preremplissage.ts
+++ b/backend/lib/teleservices/aides-jeunes-preremplissage.ts
@@ -8,8 +8,10 @@ AidesJeunesPreremplissage.prototype.toInternal = function () {
 
 AidesJeunesPreremplissage.prototype.toExternal = function () {
   try {
+    // Calcul mené pour un tiers sur un document que l'appelant a pu modifier en
+    // mémoire : il reste hors du cache de l'usager.
     const p = this.simulation
-      .compute()
+      .compute({ cache: false })
       .then((results) => {
         return results
       })

--- a/backend/lib/teleservices/aides-jeunes-service-logement.ts
+++ b/backend/lib/teleservices/aides-jeunes-service-logement.ts
@@ -57,8 +57,11 @@ AidesJeunesServiceLogement.prototype.toExternal = function ({ query }) {
     }
   })
 
+  // Les réponses du document viennent d'être remplacées par le scénario
+  // demandé : ce calcul décrit une situation hypothétique et ne doit pas
+  // prendre la place du résultat de l'usager dans le cache.
   return this.simulation
-    .compute()
+    .compute({ cache: false })
     .then((r) => {
       return {
         value:

--- a/backend/models/simulation.ts
+++ b/backend/models/simulation.ts
@@ -1,6 +1,11 @@
 import mongoose from "mongoose"
+import * as Sentry from "@sentry/node"
 import utils from "../lib/utils.js"
 import openfisca from "../lib/openfisca/index.js"
+import {
+  getComputeSignature,
+  getSituationSignature,
+} from "../lib/openfisca/compute-signature.js"
 import benefits from "../../data/all.js"
 import { computeAides } from "../../lib/benefits/compute.js"
 import { generateSituation } from "../../lib/situations.js"
@@ -66,6 +71,11 @@ const SimulationSchema = new mongoose.Schema<Simulation, SimulationModel>(
     },
     teleservice: String,
     token: String,
+    computedResults: {
+      signature: String,
+      computedAt: Date,
+      results: Object,
+    },
   },
   { minimize: false },
 )
@@ -106,24 +116,68 @@ SimulationSchema.method("getSituation", function () {
   return generateSituation(this)
 })
 
-SimulationSchema.method("compute", function (showPrivate) {
-  const situation = this.getSituation()
-  const id = String(this._id)
+function calculate(situation): Promise<any> {
   return new Promise(function (resolve, reject) {
     openfisca.calculate(situation, function (err, openfiscaResponse) {
       if (err) {
         return reject(err)
       }
-
-      const aides = computeBenefits(
-        situation,
-        id,
-        openfiscaResponse,
-        showPrivate,
-      )
-      resolve(aides)
+      resolve(openfiscaResponse)
     })
   })
+}
+
+SimulationSchema.method("compute", async function (showPrivate) {
+  const situation = this.getSituation()
+  const id = String(this._id)
+
+  // `showPrivate` produit un résultat enrichi réservé aux outils internes : il
+  // ne doit ni être servi depuis le cache ni l'alimenter.
+  const context = showPrivate ? null : await getComputeSignature()
+  // La situation entre dans la clé de cache : certains appelants modifient le
+  // document en mémoire avant de calculer (scénarios du téléservice logement,
+  // migrations appliquées à la volée) et ne décrivent alors plus le document
+  // persisté.
+  const signature = context
+    ? `${context}|${getSituationSignature(situation)}`
+    : null
+
+  if (signature && this.computedResults?.signature === signature) {
+    return this.computedResults.results
+  }
+
+  const openfiscaResponse = await calculate(situation)
+  const aides = computeBenefits(situation, id, openfiscaResponse, showPrivate)
+
+  if (signature) {
+    try {
+      // `updateOne` plutôt que `save` : le hook `pre("save")` régénère le token
+      // et une écriture complète du document exposerait à des conflits de
+      // version sur une simple lecture des résultats.
+      await (this.constructor as SimulationModel).updateOne(
+        { _id: this._id },
+        {
+          $set: {
+            computedResults: {
+              signature,
+              computedAt: new Date(),
+              results: aides,
+            },
+          },
+        },
+      )
+    } catch (error) {
+      // Le calcul a abouti : l'échec de mise en cache est signalé mais ne prive
+      // pas l'appelant de son résultat.
+      console.error(
+        `Unable to cache the computed results of simulation ${id}`,
+        error,
+      )
+      Sentry.captureException(error)
+    }
+  }
+
+  return aides
 })
 
 export default mongoose.model<Simulation, SimulationModel>(

--- a/backend/models/simulation.ts
+++ b/backend/models/simulation.ts
@@ -233,9 +233,11 @@ SimulationSchema.method("compute", async function (options = {}) {
 
   // `showPrivate` produit un résultat enrichi réservé aux outils internes ;
   // `cache: false` sert les appelants qui modifient le document en mémoire
-  // avant de calculer et dont le résultat ne décrit pas le document persisté.
-  // Ni l'un ni l'autre ne lit ou n'alimente le cache.
-  const context = showPrivate || !cache ? null : getComputeSignature()
+  // avant de calculer et dont le résultat ne décrit pas le document persisté ;
+  // un TTL nul est l'interrupteur d'arrêt du cache. Aucun des trois ne lit ni
+  // n'alimente le cache.
+  const cacheEnabled = cache && !showPrivate && config.computedResultsTtlMs > 0
+  const context = cacheEnabled ? getComputeSignature() : null
   // La situation entre dans la clé de cache : une migration appliquée à la
   // volée peut modifier le document en mémoire sans être persistée.
   const signature = context

--- a/backend/models/simulation.ts
+++ b/backend/models/simulation.ts
@@ -139,7 +139,14 @@ function calculate(situation): Promise<any> {
 // Rafales de requêtes sur un même document — restauration d'onglet, iframes
 // rechargées — : un seul calcul est mené, les appelants concurrents partagent
 // son résultat. La clé porte la signature, donc la situation calculée.
-const inFlightComputations = new Map<string, Promise<any>>()
+const inFlightComputations = new Map<
+  string,
+  { promise: Promise<any>; startedAt: number }
+>()
+
+// Au-delà, un calcul en cours n'est plus partagé : une requête qui ne se règle
+// jamais ne doit pas condamner le document pour la vie du process.
+const IN_FLIGHT_MAX_SHARE_MS = 60000
 
 function readCachedResults(simulation, signature: string, id: string) {
   const cached = simulation.computedResults
@@ -219,18 +226,6 @@ SimulationSchema.method("compute", async function (options = {}) {
   const situation = this.getSituation()
   const id = String(this._id)
 
-  // Les paramètres alimentent les légendes des aides : les charger avant le
-  // calcul évite d'y inscrire les constantes de repli.
-  try {
-    await getParametersAsync(situation.dateDeValeur)
-  } catch (error) {
-    console.error(
-      `Unable to load the OpenFisca parameters before computing simulation ${id}`,
-      error,
-    )
-    Sentry.captureException(error)
-  }
-
   // `showPrivate` produit un résultat enrichi réservé aux outils internes ;
   // `cache: false` sert les appelants qui modifient le document en mémoire
   // avant de calculer et dont le résultat ne décrit pas le document persisté ;
@@ -244,33 +239,55 @@ SimulationSchema.method("compute", async function (options = {}) {
     ? `${context}|${getSituationSignature(situation)}`
     : null
 
+  // Le cache est lu avant toute attente réseau : les paramètres ne servent
+  // qu'aux légendes produites par le calcul, et les attendre ici rendrait un
+  // OpenFisca saturé capable de bloquer jusqu'aux lectures de cache.
+  if (signature) {
+    const cached = readCachedResults(this, signature, id)
+    if (cached) {
+      return cached
+    }
+  }
+
+  // Les paramètres alimentent les légendes des aides : les charger avant le
+  // calcul évite d'y inscrire les constantes de repli.
+  try {
+    await getParametersAsync(situation.dateDeValeur)
+  } catch (error) {
+    console.error(
+      `Unable to load the OpenFisca parameters before computing simulation ${id}`,
+      error,
+    )
+    Sentry.captureException(error)
+  }
+
   if (!signature) {
     return computeAndCache(this, situation, id, showPrivate, null)
   }
 
-  const cached = readCachedResults(this, signature, id)
-  if (cached) {
-    return cached
-  }
-
   const key = `${id}|${signature}`
   const pending = inFlightComputations.get(key)
-  if (pending) {
-    return pending
+  // Un calcul qui ne se règle jamais — OpenFisca qui accepte la connexion sans
+  // répondre — laisserait sinon toutes les requêtes suivantes du document
+  // rejoindre une promesse morte, bien après le rétablissement du service.
+  if (pending && Date.now() - pending.startedAt < IN_FLIGHT_MAX_SHARE_MS) {
+    return pending.promise
   }
 
-  const computation = computeAndCache(
+  const promise = computeAndCache(
     this,
     situation,
     id,
     showPrivate,
     signature,
   ).finally(() => {
-    inFlightComputations.delete(key)
+    if (inFlightComputations.get(key)?.promise === promise) {
+      inFlightComputations.delete(key)
+    }
   })
-  inFlightComputations.set(key, computation)
+  inFlightComputations.set(key, { promise, startedAt: Date.now() })
 
-  return computation
+  return promise
 })
 
 export default mongoose.model<Simulation, SimulationModel>(

--- a/backend/models/simulation.ts
+++ b/backend/models/simulation.ts
@@ -181,13 +181,20 @@ async function computeAndCache(
   showPrivate,
   signature,
 ) {
+  // L'état est relevé AVANT tout appel réseau : la requête envoyée à OpenFisca
+  // dépend elle-même des paramètres — l'abattement `salaire_imposable` des
+  // alternants lit le SMIC — et des paramètres arrivés pendant que `/calculate`
+  // est en vol rendraient le garde-fou vrai pour une requête bâtie sur les
+  // constantes de repli.
+  const parametersWereLoaded = areParametersLoaded()
+
   const openfiscaResponse = await calculate(situation)
   const aides = computeBenefits(situation, id, openfiscaResponse, showPrivate)
 
   // Sans paramètres OpenFisca, `getParameters` retombe sur des constantes
-  // figées et les légendes produites sont fausses : le résultat est servi, mais
-  // il ne doit pas être gravé en base.
-  if (signature && areParametersLoaded()) {
+  // figées et les montants comme les légendes sont faux : le résultat est
+  // servi, mais il ne doit pas être gravé en base.
+  if (signature && parametersWereLoaded && areParametersLoaded()) {
     try {
       // `updateOne` plutôt que `save` : le hook `pre("save")` régénère le token
       // et une écriture complète du document exposerait à des conflits de

--- a/backend/models/simulation.ts
+++ b/backend/models/simulation.ts
@@ -1,11 +1,20 @@
 import mongoose from "mongoose"
 import * as Sentry from "@sentry/node"
+import config from "../config/index.js"
 import utils from "../lib/utils.js"
 import openfisca from "../lib/openfisca/index.js"
 import {
   getComputeSignature,
   getSituationSignature,
 } from "../lib/openfisca/compute-signature.js"
+import {
+  areParametersLoaded,
+  getParametersAsync,
+} from "../lib/openfisca/parameters.js"
+import {
+  serializeResults,
+  deserializeResults,
+} from "../lib/computed-results.js"
 import benefits from "../../data/all.js"
 import { computeAides } from "../../lib/benefits/compute.js"
 import { generateSituation } from "../../lib/situations.js"
@@ -127,41 +136,66 @@ function calculate(situation): Promise<any> {
   })
 }
 
-SimulationSchema.method("compute", async function (showPrivate) {
-  const situation = this.getSituation()
-  const id = String(this._id)
+// Rafales de requêtes sur un même document — restauration d'onglet, iframes
+// rechargées — : un seul calcul est mené, les appelants concurrents partagent
+// son résultat. La clé porte la signature, donc la situation calculée.
+const inFlightComputations = new Map<string, Promise<any>>()
 
-  // `showPrivate` produit un résultat enrichi réservé aux outils internes : il
-  // ne doit ni être servi depuis le cache ni l'alimenter.
-  const context = showPrivate ? null : await getComputeSignature()
-  // La situation entre dans la clé de cache : certains appelants modifient le
-  // document en mémoire avant de calculer (scénarios du téléservice logement,
-  // migrations appliquées à la volée) et ne décrivent alors plus le document
-  // persisté.
-  const signature = context
-    ? `${context}|${getSituationSignature(situation)}`
-    : null
+function readCachedResults(simulation, signature: string, id: string) {
+  const cached = simulation.computedResults
 
-  if (signature && this.computedResults?.signature === signature) {
-    return this.computedResults.results
+  if (!cached || cached.signature !== signature) {
+    return null
   }
 
+  // Le TTL borne la dérive que la signature ne voit pas : une correction de la
+  // logique JavaScript ne s'accompagne pas toujours d'un changement de version.
+  const computedAt = cached.computedAt?.getTime?.()
+  if (!computedAt || Date.now() - computedAt >= config.computedResultsTtlMs) {
+    return null
+  }
+
+  try {
+    return deserializeResults(cached.results, id)
+  } catch (error) {
+    console.error(
+      `Unable to read the cached computed results of simulation ${id}`,
+      error,
+    )
+    Sentry.captureException(error)
+    return null
+  }
+}
+
+async function computeAndCache(
+  simulation,
+  situation,
+  id,
+  showPrivate,
+  signature,
+) {
   const openfiscaResponse = await calculate(situation)
   const aides = computeBenefits(situation, id, openfiscaResponse, showPrivate)
 
-  if (signature) {
+  // Sans paramètres OpenFisca, `getParameters` retombe sur des constantes
+  // figées et les légendes produites sont fausses : le résultat est servi, mais
+  // il ne doit pas être gravé en base.
+  if (signature && areParametersLoaded()) {
     try {
       // `updateOne` plutôt que `save` : le hook `pre("save")` régénère le token
       // et une écriture complète du document exposerait à des conflits de
       // version sur une simple lecture des résultats.
-      await (this.constructor as SimulationModel).updateOne(
-        { _id: this._id },
+      await (simulation.constructor as SimulationModel).updateOne(
+        // Un document anonymisé ne repasse jamais par le nettoyage : la
+        // condition de statut vit dans le filtre pour que l'écriture ne puisse
+        // pas y réinjecter des montants dérivés de réponses personnelles.
+        { _id: simulation._id, status: { $ne: SimulationStatus.Anonymized } },
         {
           $set: {
             computedResults: {
               signature,
               computedAt: new Date(),
-              results: aides,
+              results: serializeResults(aides),
             },
           },
         },
@@ -178,6 +212,63 @@ SimulationSchema.method("compute", async function (showPrivate) {
   }
 
   return aides
+}
+
+SimulationSchema.method("compute", async function (options = {}) {
+  const { showPrivate = false, cache = true } = options
+  const situation = this.getSituation()
+  const id = String(this._id)
+
+  // Les paramètres alimentent les légendes des aides : les charger avant le
+  // calcul évite d'y inscrire les constantes de repli.
+  try {
+    await getParametersAsync(situation.dateDeValeur)
+  } catch (error) {
+    console.error(
+      `Unable to load the OpenFisca parameters before computing simulation ${id}`,
+      error,
+    )
+    Sentry.captureException(error)
+  }
+
+  // `showPrivate` produit un résultat enrichi réservé aux outils internes ;
+  // `cache: false` sert les appelants qui modifient le document en mémoire
+  // avant de calculer et dont le résultat ne décrit pas le document persisté.
+  // Ni l'un ni l'autre ne lit ou n'alimente le cache.
+  const context = showPrivate || !cache ? null : getComputeSignature()
+  // La situation entre dans la clé de cache : une migration appliquée à la
+  // volée peut modifier le document en mémoire sans être persistée.
+  const signature = context
+    ? `${context}|${getSituationSignature(situation)}`
+    : null
+
+  if (!signature) {
+    return computeAndCache(this, situation, id, showPrivate, null)
+  }
+
+  const cached = readCachedResults(this, signature, id)
+  if (cached) {
+    return cached
+  }
+
+  const key = `${id}|${signature}`
+  const pending = inFlightComputations.get(key)
+  if (pending) {
+    return pending
+  }
+
+  const computation = computeAndCache(
+    this,
+    situation,
+    id,
+    showPrivate,
+    signature,
+  ).finally(() => {
+    inFlightComputations.delete(key)
+  })
+  inFlightComputations.set(key, computation)
+
+  return computation
 })
 
 export default mongoose.model<Simulation, SimulationModel>(

--- a/backend/types/config.d.ts
+++ b/backend/types/config.d.ts
@@ -53,6 +53,7 @@ export interface Configuration {
     url: string
     version: number
   }
+  computedResultsTtlMs: number
   mongodb_url: string
   sessionSecret: string
   mattermost_post_url: string

--- a/lib/cleaner-functions.ts
+++ b/lib/cleaner-functions.ts
@@ -84,6 +84,8 @@ export function anonymizeSimulation(simulation) {
     all: answersAnonymized,
     current: [],
   }
+  // Montants d'aides dérivés des réponses : donnée personnelle à purger.
+  simulation.computedResults = undefined
   simulation.status = SimulationStatus.Anonymized
 
   return simulation

--- a/lib/types/simulation.d.ts
+++ b/lib/types/simulation.d.ts
@@ -21,12 +21,19 @@ interface SimulationAttributes {
   status: SimulationStatus
   teleservice?: string
   token: string
+  computedResults?: ComputedResults
+}
+
+interface ComputedResults {
+  signature?: string
+  computedAt?: Date
+  results?: any
 }
 
 interface SimulationMethods {
   isAccessible(keychain: Record<string, string>): boolean
   getSituation(): any
-  compute(): Promise<any>
+  compute(showPrivate?: boolean): Promise<any>
 }
 
 interface SimulationVirtuals {

--- a/lib/types/simulation.d.ts
+++ b/lib/types/simulation.d.ts
@@ -30,10 +30,21 @@ interface ComputedResults {
   results?: any
 }
 
+interface ComputeOptions {
+  /** Résultat enrichi réservé aux outils internes, jamais mis en cache. */
+  showPrivate?: boolean
+  /**
+   * `false` pour les appelants qui modifient le document en mémoire avant de
+   * calculer : leur résultat ne décrit pas le document persisté et ne doit ni
+   * être lu ni évincer l'entrée de cache de l'usager.
+   */
+  cache?: boolean
+}
+
 interface SimulationMethods {
   isAccessible(keychain: Record<string, string>): boolean
   getSituation(): any
-  compute(showPrivate?: boolean): Promise<any>
+  compute(options?: ComputeOptions): Promise<any>
 }
 
 interface SimulationVirtuals {

--- a/tests/unit/backend/compute-signature.spec.ts
+++ b/tests/unit/backend/compute-signature.spec.ts
@@ -1,0 +1,140 @@
+import { expect, vi } from "vitest"
+
+const { catalog, getCountryPackageMetadata, captureException } = vi.hoisted(
+  () => ({
+    catalog: { value: { all: [{ id: "aide-a", montant: 100 }] } as any },
+    getCountryPackageMetadata: vi.fn(),
+    captureException: vi.fn(),
+  }),
+)
+
+vi.mock("@root/data/all.js", () => ({
+  get default() {
+    return catalog.value
+  },
+}))
+
+vi.mock("@backend/lib/openfisca/getter.js", () => ({
+  default: { getCountryPackageMetadata },
+}))
+
+vi.mock("@sentry/node", () => ({ captureException }))
+
+async function loadComputeSignature() {
+  vi.resetModules()
+  return (await import("@backend/lib/openfisca/compute-signature.js"))
+    .getComputeSignature
+}
+
+describe("getSituationSignature", () => {
+  it("ignores the key order but not the values", async () => {
+    const { getSituationSignature } = await import(
+      "@backend/lib/openfisca/compute-signature.js"
+    )
+
+    const reference = getSituationSignature({
+      dateDeValeur: new Date("2024-01-01"),
+      menage: { loyer: 500, depcom: "75056" },
+    })
+
+    expect(
+      getSituationSignature({
+        menage: { depcom: "75056", loyer: 500 },
+        dateDeValeur: new Date("2024-01-01"),
+      }),
+    ).toEqual(reference)
+    expect(
+      getSituationSignature({
+        dateDeValeur: new Date("2024-01-01"),
+        menage: { loyer: 600, depcom: "75056" },
+      }),
+    ).not.toEqual(reference)
+  })
+})
+
+describe("getComputeSignature", () => {
+  let consoleSpy
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    catalog.value = { all: [{ id: "aide-a", montant: 100 }] }
+    getCountryPackageMetadata.mockResolvedValue({
+      name: "openfisca-france",
+      version: "175.1.7",
+    })
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("combines the country package version, the benefits digest and the simulation version", async () => {
+    const getComputeSignature = await loadComputeSignature()
+
+    const signature = await getComputeSignature()
+
+    expect(signature).toMatch(
+      /^openfisca:openfisca-france@175\.1\.7\|benefits:[0-9a-f]{12}\|simulation:\d+$/,
+    )
+  })
+
+  it("changes when the benefits catalog changes", async () => {
+    const firstSignature = await (await loadComputeSignature())()
+
+    catalog.value = { all: [{ id: "aide-a", montant: 200 }] }
+    const secondSignature = await (await loadComputeSignature())()
+
+    expect(secondSignature).not.toEqual(firstSignature)
+  })
+
+  it("changes when OpenFisca is redeployed", async () => {
+    const firstSignature = await (await loadComputeSignature())()
+
+    getCountryPackageMetadata.mockResolvedValue({
+      name: "openfisca-france",
+      version: "176.0.7",
+    })
+    const secondSignature = await (await loadComputeSignature())()
+
+    expect(secondSignature).not.toEqual(firstSignature)
+  })
+
+  it("queries OpenFisca once for repeated calls", async () => {
+    const getComputeSignature = await loadComputeSignature()
+
+    const signatures = await Promise.all([
+      getComputeSignature(),
+      getComputeSignature(),
+    ])
+    await getComputeSignature()
+
+    expect(getCountryPackageMetadata).toHaveBeenCalledTimes(1)
+    expect(signatures[0]).toEqual(signatures[1])
+  })
+
+  it("queries OpenFisca again once the memoized signature expires", async () => {
+    vi.useFakeTimers()
+    const getComputeSignature = await loadComputeSignature()
+
+    await getComputeSignature()
+    vi.advanceTimersByTime(11 * 60 * 1000)
+    await getComputeSignature()
+
+    expect(getCountryPackageMetadata).toHaveBeenCalledTimes(2)
+  })
+
+  it("reports the failure and returns no signature when OpenFisca is unreachable", async () => {
+    const error = new Error("OF offline")
+    getCountryPackageMetadata.mockRejectedValue(error)
+    const getComputeSignature = await loadComputeSignature()
+
+    expect(await getComputeSignature()).toBeNull()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Unable to build the OpenFisca compute signature",
+      error,
+    )
+    expect(captureException).toHaveBeenCalledWith(error)
+  })
+})

--- a/tests/unit/backend/compute-signature.spec.ts
+++ b/tests/unit/backend/compute-signature.spec.ts
@@ -1,12 +1,16 @@
 import { expect, vi } from "vitest"
 
-const { catalog, getCountryPackageMetadata, captureException } = vi.hoisted(
-  () => ({
+const { catalog, sources, getCountryPackageMetadata, captureException } =
+  vi.hoisted(() => ({
     catalog: { value: { all: [{ id: "aide-a", montant: 100 }] } as any },
+    sources: {
+      requirements: "",
+      packageJson: "",
+      readError: undefined as Error | undefined,
+    },
     getCountryPackageMetadata: vi.fn(),
     captureException: vi.fn(),
-  }),
-)
+  }))
 
 vi.mock("@root/data/all.js", () => ({
   get default() {
@@ -14,16 +18,63 @@ vi.mock("@root/data/all.js", () => ({
   },
 }))
 
+vi.mock("node:fs", async (importOriginal) => {
+  const original = (await importOriginal()) as any
+  const existsSync = (target: string) => String(target).endsWith("package.json")
+  const readFileSync = (target: string) => {
+    if (sources.readError) {
+      throw sources.readError
+    }
+
+    return String(target).endsWith("requirements.txt")
+      ? sources.requirements
+      : sources.packageJson
+  }
+
+  return {
+    ...original,
+    default: { ...original.default, existsSync, readFileSync },
+    existsSync,
+    readFileSync,
+  }
+})
+
 vi.mock("@backend/lib/openfisca/getter.js", () => ({
   default: { getCountryPackageMetadata },
 }))
 
 vi.mock("@sentry/node", () => ({ captureException }))
 
+const A_REQUIREMENTS_FILE =
+  "Openfisca-France==175.1.7\nOpenFisca-France-Local[excel-reader]==6.17.10\nOpenfisca-Paris==5.5.14\n"
+
+function aPackageJson(overrides = {}) {
+  return JSON.stringify({
+    version: "12.1.3",
+    dependencies: { "@betagouv/aides-velo": "1.11.0" },
+    ...overrides,
+  })
+}
+
 async function loadComputeSignature() {
   vi.resetModules()
   return (await import("@backend/lib/openfisca/compute-signature.js"))
     .getComputeSignature
+}
+
+// Le rafraîchissement est déclenché en arrière-plan : vider la file de
+// microtâches suffit à le laisser aboutir, les dépendances étant simulées.
+async function flushMicrotasks() {
+  for (let index = 0; index < 5; index++) {
+    await Promise.resolve()
+  }
+}
+
+async function loadSettledSignature() {
+  const getComputeSignature = await loadComputeSignature()
+  getComputeSignature()
+  await flushMicrotasks()
+  return getComputeSignature
 }
 
 describe("getSituationSignature", () => {
@@ -58,6 +109,9 @@ describe("getComputeSignature", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     catalog.value = { all: [{ id: "aide-a", montant: 100 }] }
+    sources.requirements = A_REQUIREMENTS_FILE
+    sources.packageJson = aPackageJson()
+    sources.readError = undefined
     getCountryPackageMetadata.mockResolvedValue({
       name: "openfisca-france",
       version: "175.1.7",
@@ -70,69 +124,140 @@ describe("getComputeSignature", () => {
     vi.restoreAllMocks()
   })
 
-  it("combines the country package version, the benefits digest and the simulation version", async () => {
-    const getComputeSignature = await loadComputeSignature()
+  it("combines the country package version, the compute environment, the benefits digest and the simulation version", async () => {
+    const getComputeSignature = await loadSettledSignature()
 
-    const signature = await getComputeSignature()
-
-    expect(signature).toMatch(
-      /^openfisca:openfisca-france@175\.1\.7\|benefits:[0-9a-f]{12}\|simulation:\d+$/,
+    expect(getComputeSignature()).toMatch(
+      /^openfisca:openfisca-france@175\.1\.7\|environment:[0-9a-f]{12}\|benefits:[0-9a-f]{12}\|simulation:\d+$/,
     )
   })
 
   it("changes when the benefits catalog changes", async () => {
-    const firstSignature = await (await loadComputeSignature())()
+    const firstSignature = (await loadSettledSignature())()
 
     catalog.value = { all: [{ id: "aide-a", montant: 200 }] }
-    const secondSignature = await (await loadComputeSignature())()
 
-    expect(secondSignature).not.toEqual(firstSignature)
+    expect((await loadSettledSignature())()).not.toEqual(firstSignature)
   })
 
   it("changes when OpenFisca is redeployed", async () => {
-    const firstSignature = await (await loadComputeSignature())()
+    const firstSignature = (await loadSettledSignature())()
 
     getCountryPackageMetadata.mockResolvedValue({
       name: "openfisca-france",
       version: "176.0.7",
     })
-    const secondSignature = await (await loadComputeSignature())()
 
-    expect(secondSignature).not.toEqual(firstSignature)
+    expect((await loadSettledSignature())()).not.toEqual(firstSignature)
+  })
+
+  // `get_package_metadata()` ne décrit que le paquet pays : les extensions
+  // (`OpenFisca-France-Local`, `Openfisca-Paris`) et la réforme EPCI ne sont
+  // visibles que par `openfisca/requirements.txt`.
+  it("changes when an OpenFisca extension is upgraded", async () => {
+    const firstSignature = (await loadSettledSignature())()
+
+    sources.requirements = A_REQUIREMENTS_FILE.replace("6.17.10", "6.18.0")
+
+    expect((await loadSettledSignature())()).not.toEqual(firstSignature)
+  })
+
+  it("changes when the application version changes", async () => {
+    const firstSignature = (await loadSettledSignature())()
+
+    sources.packageJson = aPackageJson({ version: "12.2.0" })
+
+    expect((await loadSettledSignature())()).not.toEqual(firstSignature)
+  })
+
+  it("changes when a compute dependency is upgraded", async () => {
+    const firstSignature = (await loadSettledSignature())()
+
+    sources.packageJson = aPackageJson({
+      dependencies: { "@betagouv/aides-velo": "1.12.0" },
+    })
+
+    expect((await loadSettledSignature())()).not.toEqual(firstSignature)
   })
 
   it("queries OpenFisca once for repeated calls", async () => {
-    const getComputeSignature = await loadComputeSignature()
+    const getComputeSignature = await loadSettledSignature()
 
-    const signatures = await Promise.all([
-      getComputeSignature(),
-      getComputeSignature(),
-    ])
-    await getComputeSignature()
-
+    expect(getComputeSignature()).toEqual(getComputeSignature())
     expect(getCountryPackageMetadata).toHaveBeenCalledTimes(1)
-    expect(signatures[0]).toEqual(signatures[1])
   })
 
-  it("queries OpenFisca again once the memoized signature expires", async () => {
+  it("queries OpenFisca again once the signature expires", async () => {
     vi.useFakeTimers()
-    const getComputeSignature = await loadComputeSignature()
+    const getComputeSignature = await loadSettledSignature()
 
-    await getComputeSignature()
     vi.advanceTimersByTime(11 * 60 * 1000)
-    await getComputeSignature()
+    getComputeSignature()
+    await flushMicrotasks()
 
     expect(getCountryPackageMetadata).toHaveBeenCalledTimes(2)
   })
 
-  it("reports the failure and returns no signature when OpenFisca is unreachable", async () => {
-    const error = new Error("OF offline")
-    getCountryPackageMetadata.mockRejectedValue(error)
+  // Attendre la racine OpenFisca, c'est ajouter son temps de réponse à chaque
+  // lecture du cache et se river au service que la mise en cache soulage.
+  it("never waits for OpenFisca", async () => {
+    let resolveMetadata
+    getCountryPackageMetadata.mockReturnValue(
+      new Promise((resolve) => {
+        resolveMetadata = resolve
+      }),
+    )
     const getComputeSignature = await loadComputeSignature()
 
-    expect(await getComputeSignature()).toBeNull()
+    expect(getComputeSignature()).toBeNull()
+
+    resolveMetadata({ name: "openfisca-france", version: "175.1.7" })
+    await flushMicrotasks()
+
+    expect(getComputeSignature()).not.toBeNull()
+  })
+
+  // Une racine OpenFisca en échec ne doit pas éteindre les caches : la version
+  // d'un paquet ne change pas sans redémarrage du processus.
+  it("keeps serving the last known signature when the refresh fails", async () => {
+    vi.useFakeTimers()
+    const getComputeSignature = await loadSettledSignature()
+    const signature = getComputeSignature()
+
+    getCountryPackageMetadata.mockRejectedValue(new Error("OF offline"))
+    vi.advanceTimersByTime(11 * 60 * 1000)
+    getComputeSignature()
+    await flushMicrotasks()
+
+    expect(getCountryPackageMetadata).toHaveBeenCalledTimes(2)
+    expect(getComputeSignature()).toEqual(signature)
+  })
+
+  it("reports the failure and returns no signature when none was ever obtained", async () => {
+    const error = new Error("OF offline")
+    getCountryPackageMetadata.mockRejectedValue(error)
+    const getComputeSignature = await loadSettledSignature()
+
+    expect(getComputeSignature()).toBeNull()
     expect(consoleSpy).toHaveBeenCalledWith(
       "Unable to build the OpenFisca compute signature",
+      error,
+    )
+    expect(captureException).toHaveBeenCalledWith(error)
+  })
+
+  // Une empreinte des sources illisible laisserait la signature aveugle aux
+  // extensions OpenFisca et au code applicatif.
+  it("reports the failure and returns no signature when the sources cannot be read", async () => {
+    const error = new Error("ENOENT: openfisca/requirements.txt")
+    sources.readError = error
+
+    const getComputeSignature = await loadSettledSignature()
+
+    expect(getComputeSignature()).toBeNull()
+    expect(getCountryPackageMetadata).not.toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Unable to digest the compute environment sources",
       error,
     )
     expect(captureException).toHaveBeenCalledWith(error)

--- a/tests/unit/backend/computed-results.spec.ts
+++ b/tests/unit/backend/computed-results.spec.ts
@@ -267,4 +267,24 @@ describe("email rendered from cached results", () => {
       basicBenefitText(lep, openfiscaParameters),
     )
   })
+
+  it("restitue les undefined imbriqués, que BSON écrit en null", () => {
+    const droit = {
+      id: "rsa",
+      montant: 600,
+      institution: { slug: "caf", code_insee: undefined, label: "CAF" },
+      tags: ["a", undefined],
+    }
+
+    const relu = deserializeResults(
+      BSON.deserialize(
+        BSON.serialize(serializeResults({ droitsEligibles: [droit], droitsInjectes: [] })),
+      ) as any,
+    )
+
+    const servi: any = relu.droitsEligibles[0]
+    expect(servi.institution.code_insee).toBeUndefined()
+    expect("code_insee" in servi.institution).toBe(true)
+    expect(servi.tags[1]).toBeUndefined()
+  })
 })

--- a/tests/unit/backend/computed-results.spec.ts
+++ b/tests/unit/backend/computed-results.spec.ts
@@ -1,0 +1,270 @@
+import { expect, vi } from "vitest"
+
+const { openfiscaParameters } = vi.hoisted(() => ({
+  openfiscaParameters: {
+    "prestations_sociales.education.carte_des_metiers.age_maximal": 26,
+    "prestations_sociales.prestations_etat_de_sante.invalidite.aah.taux_capacite.taux_incapacite": 0.8,
+    "taxation_capital.epargne.livret_a.taux": 0.017,
+    "marche_travail.salaire_minimum.smic.smic_b_horaire": 11.88,
+    "marche_travail.salaire_minimum.smic.nb_heures_travail_mensuel": 151.67,
+  },
+}))
+
+// Les paramètres sont ceux d'un OpenFisca joignable : c'est le seul état dans
+// lequel un résultat a le droit d'être mis en cache.
+vi.mock("@backend/lib/openfisca/parameters.js", () => ({
+  getParameters: () => openfiscaParameters,
+}))
+
+import { BSON } from "mongodb"
+import { computeAides } from "@lib/benefits/compute.js"
+import benefits from "@root/data/all.js"
+import { datesGenerator } from "@lib/dates.js"
+import {
+  serializeResults,
+  deserializeResults,
+} from "@backend/lib/computed-results.js"
+import {
+  basicBenefitText,
+  formatBenefits,
+} from "@backend/lib/mes-aides/emails/simulation-results.js"
+
+const compute = computeAides.bind(benefits as any)
+const A_SIMULATION_ID = "6555555555555555555555ff"
+
+function aSituation(): any {
+  return {
+    dateDeValeur: "2025-04-01",
+    demandeur: {
+      // Deux droits déclarés par l'usager alimentent `droitsInjectes`.
+      aah: { "2025-04": 100 },
+      aide_logement: { "2025-04": 250 },
+      activite: "salarie",
+      date_naissance: "2003-04-01",
+      _interetsAidesVelo: [],
+    },
+    famille: {},
+    menage: {
+      depcom: "75056",
+      _departement: "75",
+      _region: "11",
+      statut_occupation_logement: "locataire_vide",
+      loyer: 700,
+    },
+  }
+}
+
+// Chaque aide du catalogue reçoit une valeur pour la période qu'elle interroge :
+// le résultat couvre alors l'ensemble du référentiel, pas un échantillon.
+function anOpenfiscaResponse(situation): any {
+  const periods = datesGenerator(situation.dateDeValeur)
+  const demandeur: any = {}
+  const familles: any = {}
+
+  for (const benefit of benefits.all as any[]) {
+    const period = benefit.openfiscaPeriod
+      ? periods[benefit.openfiscaPeriod].id
+      : periods.thisMonth.id
+    const source = benefit.openfisca_eligibility_source || benefit.id
+
+    demandeur[source] = { ...demandeur[source], [period]: 123.45 }
+    familles[source] = { ...familles[source], [period]: 123.45 }
+  }
+
+  return {
+    familles: { _: familles },
+    menages: {
+      _: {
+        personne_de_reference: ["demandeur"],
+        depcom: { [periods.thisMonth.id]: "75056" },
+      },
+    },
+    individus: { demandeur },
+    foyers_fiscaux: {
+      _: {
+        rfr: { [periods.fiscalYear.id]: 12000 },
+        nbptr: { [periods.fiscalYear.id]: 1 },
+      },
+    },
+  }
+}
+
+function computeFreshResults() {
+  const situation = aSituation()
+  return compute(situation, A_SIMULATION_ID, anOpenfiscaResponse(situation))
+}
+
+// Aller-retour BSON réel : c'est le format dans lequel Mongo range le document.
+function throughMongo<T>(value: T): T {
+  return BSON.deserialize(BSON.serialize({ value })).value
+}
+
+function roundTrip(results) {
+  return deserializeResults(
+    throughMongo(serializeResults(results)),
+    A_SIMULATION_ID,
+  )
+}
+
+describe("computed results serialization", () => {
+  let fresh, restored
+
+  beforeEach(() => {
+    fresh = computeFreshResults()
+    restored = roundTrip(fresh)
+  })
+
+  it("covers the whole catalog", () => {
+    expect(fresh.droitsEligibles.length).toBeGreaterThan(20)
+    expect(fresh.droitsInjectes.length).toBeGreaterThan(0)
+  })
+
+  it("restores a result strictly identical to the computed one", () => {
+    expect(restored).toStrictEqual(fresh)
+  })
+
+  // Les propriétés fonction ne survivent pas au BSON : elles reviennent du
+  // catalogue, à l'identique.
+  it("restores the function properties", () => {
+    const droits = [...fresh.droitsEligibles, ...fresh.droitsInjectes]
+    const functionProperties = droits.flatMap((droit) =>
+      Object.keys(droit).filter((key) => typeof droit[key] === "function"),
+    )
+    expect(functionProperties.length).toBeGreaterThan(0)
+
+    for (const [index, droit] of droits.entries()) {
+      const target = [...restored.droitsEligibles, ...restored.droitsInjectes][
+        index
+      ]
+      for (const key of Object.keys(droit)) {
+        if (typeof droit[key] === "function") {
+          expect(target[key]).toBe(droit[key])
+        }
+      }
+    }
+  })
+
+  // `undefined` devient `null` en BSON : la distinction est rétablie plutôt que
+  // laissée diverger.
+  it("keeps undefined properties undefined", () => {
+    const undefinedProperties = fresh.droitsEligibles.flatMap((droit) =>
+      Object.keys(droit).filter((key) => droit[key] === undefined),
+    )
+    expect(undefinedProperties.length).toBeGreaterThan(0)
+
+    for (const [index, droit] of fresh.droitsEligibles.entries()) {
+      for (const key of Object.keys(droit)) {
+        if (droit[key] === undefined) {
+          expect(restored.droitsEligibles[index][key]).toBeUndefined()
+          expect(key in restored.droitsEligibles[index]).toBe(true)
+        }
+      }
+    }
+  })
+
+  it("stores a fraction of the computed payload", () => {
+    const stored = BSON.serialize({ value: serializeResults(fresh) }).length
+    const full = BSON.serialize({
+      value: JSON.parse(JSON.stringify(fresh)),
+    }).length
+
+    expect(stored).toBeLessThan(full / 5)
+  })
+
+  it("refuses a payload serialized under another format", () => {
+    const serialized = serializeResults(fresh)
+
+    expect(() =>
+      deserializeResults({ ...serialized, format: 99 } as any, A_SIMULATION_ID),
+    ).toThrow(/Unsupported computed results format/)
+  })
+
+  it("refuses a benefit that has left the catalog", () => {
+    const serialized = serializeResults(fresh)
+    serialized.droitsEligibles[0].id = "aide_disparue"
+
+    expect(() => deserializeResults(serialized, A_SIMULATION_ID)).toThrow(
+      /is missing from the catalog/,
+    )
+  })
+
+  // Les aides vélo sont produites à partir du moteur `@betagouv/aides-velo` :
+  // leur écart au catalogue porte des clés qui lui sont étrangères.
+  it("restores an aides-velo benefit", () => {
+    const veloBenefit = (benefits.all as any[]).find(
+      (benefit) => benefit.source === "aides-velo",
+    )
+    const droit = {
+      ...veloBenefit,
+      title: "Prime vélo",
+      amount: 300,
+      montant: 300,
+      link: "https://example.org/prime",
+      id: veloBenefit.id,
+    }
+
+    const restoredVelo = roundTrip({
+      droitsEligibles: [droit],
+      droitsInjectes: [],
+    })
+
+    expect(restoredVelo.droitsEligibles[0]).toStrictEqual(droit)
+  })
+})
+
+describe("email rendered from cached results", () => {
+  let fresh, restored
+
+  beforeEach(() => {
+    fresh = computeFreshResults()
+    restored = roundTrip(fresh)
+  })
+
+  it("serves the same benefit texts", () => {
+    const freshTexts = fresh.droitsEligibles.map((droit) =>
+      basicBenefitText(droit, openfiscaParameters),
+    )
+    const restoredTexts = restored.droitsEligibles.map((droit) =>
+      basicBenefitText(droit, openfiscaParameters),
+    )
+
+    expect(restoredTexts).toEqual(freshTexts)
+  })
+
+  it("serves the same formatted benefits", () => {
+    expect(
+      formatBenefits(restored.droitsEligibles, openfiscaParameters),
+    ).toStrictEqual(formatBenefits(fresh.droitsEligibles, openfiscaParameters))
+  })
+
+  // Le texte du LEP vient de `labelFunction` et sa légende d'un paramètre
+  // OpenFisca : c'est la phrase que le finding voit se dégrader.
+  it("keeps the label produced by labelFunction", () => {
+    const findLep = (results) =>
+      results.droitsEligibles.find(
+        (droit) => droit.id === "livret_epargne_populaire_taux",
+      )
+    const lep = findLep(fresh)
+    expect(lep).toBeDefined()
+
+    const text = basicBenefitText(lep, openfiscaParameters)
+    expect(text).toMatch(/taux de .+ ?% \/ an au lieu de 1\.7 %/)
+    expect(basicBenefitText(findLep(restored), openfiscaParameters)).toEqual(
+      text,
+    )
+  })
+
+  // Persister le résultat tel quel perd `labelFunction` : la phrase retombe sur
+  // le gabarit générique et le montant change de sens.
+  it("degrades when the whole result is persisted as is", () => {
+    const lep = fresh.droitsEligibles.find(
+      (droit) => droit.id === "livret_epargne_populaire_taux",
+    )
+    const naivelyStored = throughMongo(lep)
+
+    expect(naivelyStored.labelFunction).toBeUndefined()
+    expect(basicBenefitText(naivelyStored, openfiscaParameters)).not.toEqual(
+      basicBenefitText(lep, openfiscaParameters),
+    )
+  })
+})

--- a/tests/unit/backend/computed-results.spec.ts
+++ b/tests/unit/backend/computed-results.spec.ts
@@ -278,7 +278,9 @@ describe("email rendered from cached results", () => {
 
     const relu = deserializeResults(
       BSON.deserialize(
-        BSON.serialize(serializeResults({ droitsEligibles: [droit], droitsInjectes: [] })),
+        BSON.serialize(
+          serializeResults({ droitsEligibles: [droit], droitsInjectes: [] }),
+        ),
       ) as any,
     )
 

--- a/tests/unit/backend/simulation-compute.spec.ts
+++ b/tests/unit/backend/simulation-compute.spec.ts
@@ -470,4 +470,48 @@ describe("Simulation.compute", () => {
       expect(updateOneSpy).not.toHaveBeenCalled()
     })
   })
+  describe("resilience when OpenFisca is unresponsive", () => {
+    it("serves a cache hit without waiting for the OpenFisca parameters", async () => {
+      // Un `/parameter` qui pend ne doit pas bloquer une lecture de cache :
+      // les paramètres ne servent qu'aux légendes produites par le calcul.
+      getParametersAsync.mockImplementation(() => new Promise(() => {}))
+      const simulation = buildSimulation(aCacheEntry(cachedResults))
+
+      const results = await simulation.compute()
+
+      expect(results.droitsEligibles[0].montant).toBe(200)
+      expect(calculateSpy).not.toHaveBeenCalled()
+      expect(getParametersAsync).not.toHaveBeenCalled()
+    })
+
+    it("stops sharing a computation that never settles", async () => {
+      // OpenFisca accepte la connexion et ne répond jamais : la promesse
+      // partagée ne se règle pas.
+      calculateSpy.mockImplementation(() => {})
+      const simulation = buildSimulation()
+
+      const abandoned = simulation.compute()
+      abandoned.catch(() => {})
+      await new Promise((resolve) => setImmediate(resolve))
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+
+      // Tant que la borne n'est pas dépassée, le calcul en cours est partagé.
+      let pending: any = "unresolved"
+      simulation.compute().then((value) => (pending = value))
+      await new Promise((resolve) => setImmediate(resolve))
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+      expect(pending).toBe("unresolved")
+
+      // Au-delà, un nouvel appel repart sur son propre calcul.
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 120000)
+      calculateSpy.mockImplementation((_situation, callback) =>
+        callback(null, openfiscaResponse),
+      )
+      const results = await simulation.compute()
+      nowSpy.mockRestore()
+
+      expect(results.droitsEligibles[0].montant).toBe(100)
+      expect(calculateSpy).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/tests/unit/backend/simulation-compute.spec.ts
+++ b/tests/unit/backend/simulation-compute.spec.ts
@@ -6,13 +6,27 @@ const {
   areParametersLoaded,
   getParametersAsync,
   captureException,
+  ttl,
 } = vi.hoisted(() => ({
   getComputeSignature: vi.fn(),
   computeAides: vi.fn(),
   areParametersLoaded: vi.fn(),
   getParametersAsync: vi.fn(),
   captureException: vi.fn(),
+  ttl: { value: 24 * 60 * 60 * 1000 },
 }))
+
+vi.mock("@backend/config/index.js", async (importOriginal) => {
+  const original = ((await importOriginal()) as any).default
+  return {
+    default: {
+      ...original,
+      get computedResultsTtlMs() {
+        return ttl.value
+      },
+    },
+  }
+})
 
 // Seule la signature globale est simulée : l'empreinte de situation, qui
 // complète la clé de cache, reste celle du code de production, tout comme la
@@ -104,6 +118,7 @@ describe("Simulation.compute", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    ttl.value = 24 * 60 * 60 * 1000
     computeAides.mockReturnValue(freshResults)
     getComputeSignature.mockReturnValue(A_CONTEXT)
     areParametersLoaded.mockReturnValue(true)
@@ -292,6 +307,20 @@ describe("Simulation.compute", () => {
 
       expect(results).toEqual(freshResults)
       expect(getComputeSignature).not.toHaveBeenCalled()
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+      expect(updateOneSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  // L'interrupteur d'arrêt doit couper l'écriture autant que la lecture.
+  describe("when the TTL is set to zero", () => {
+    it("neither reads nor writes the cache", async () => {
+      ttl.value = 0
+      const simulation = buildSimulation(aCacheEntry(cachedResults))
+
+      const results = await simulation.compute()
+
+      expect(results).toEqual(freshResults)
       expect(calculateSpy).toHaveBeenCalledTimes(1)
       expect(updateOneSpy).not.toHaveBeenCalled()
     })

--- a/tests/unit/backend/simulation-compute.spec.ts
+++ b/tests/unit/backend/simulation-compute.spec.ts
@@ -1,15 +1,22 @@
 import { expect, vi } from "vitest"
 
-const { getComputeSignature, computeAides, captureException } = vi.hoisted(
-  () => ({
-    getComputeSignature: vi.fn(),
-    computeAides: vi.fn(),
-    captureException: vi.fn(),
-  }),
-)
+const {
+  getComputeSignature,
+  computeAides,
+  areParametersLoaded,
+  getParametersAsync,
+  captureException,
+} = vi.hoisted(() => ({
+  getComputeSignature: vi.fn(),
+  computeAides: vi.fn(),
+  areParametersLoaded: vi.fn(),
+  getParametersAsync: vi.fn(),
+  captureException: vi.fn(),
+}))
 
 // Seule la signature globale est simulée : l'empreinte de situation, qui
-// complète la clé de cache, reste celle du code de production.
+// complète la clé de cache, reste celle du code de production, tout comme la
+// sérialisation des résultats.
 vi.mock(
   "@backend/lib/openfisca/compute-signature.js",
   async (importOriginal) => ({
@@ -17,25 +24,46 @@ vi.mock(
     getComputeSignature,
   }),
 )
+vi.mock("@backend/lib/openfisca/parameters.js", () => ({
+  areParametersLoaded,
+  getParametersAsync,
+}))
 vi.mock("@lib/benefits/compute.js", () => ({ computeAides }))
 vi.mock("@sentry/node", () => ({ captureException }))
 
 import mongoose from "mongoose"
 import Simulations from "@backend/models/simulation.js"
 import openfisca from "@backend/lib/openfisca/index.js"
+import benefits from "@root/data/all.js"
 import { getSituationSignature } from "@backend/lib/openfisca/compute-signature.js"
+import { serializeResults } from "@backend/lib/computed-results.js"
+import { SimulationStatus } from "@lib/enums/simulation.js"
 
 const A_CONTEXT =
-  "openfisca:openfisca-france@175.1.7|benefits:abc|simulation:17"
+  "openfisca:openfisca-france@175.1.7|environment:abc|benefits:abc|simulation:17"
 const ANOTHER_CONTEXT =
-  "openfisca:openfisca-france@176.0.7|benefits:abc|simulation:17"
+  "openfisca:openfisca-france@176.0.7|environment:abc|benefits:abc|simulation:17"
 
 const situation = { dateDeValeur: new Date("2024-01-01") }
 const A_SIGNATURE = `${A_CONTEXT}|${getSituationSignature(situation)}`
 const ANOTHER_SIGNATURE = `${ANOTHER_CONTEXT}|${getSituationSignature(situation)}`
 const openfiscaResponse = { individus: {} }
-const freshResults = { droitsEligibles: [{ id: "fresh", montant: 100 }] }
-const cachedResults = { droitsEligibles: [{ id: "cached", montant: 200 }] }
+
+// Les droits sont ceux du catalogue : la persistance ne garde que leur part
+// volatile et les reconstruit à la relecture.
+const aBenefit = (benefits.all as any[]).find((benefit) => benefit.id === "rsa")
+const anotherBenefit = (benefits.all as any[]).find(
+  (benefit) => benefit.id === "aah",
+)
+
+const freshResults = {
+  droitsEligibles: [{ ...aBenefit, montant: 100, legend: "/ mois" }],
+  droitsInjectes: [],
+}
+const cachedResults = {
+  droitsEligibles: [{ ...anotherBenefit, montant: 200, legend: "/ mois" }],
+  droitsInjectes: [],
+}
 
 function buildSimulation(computedResults?) {
   const simulation = new Simulations({
@@ -45,6 +73,14 @@ function buildSimulation(computedResults?) {
   })
   simulation.getSituation = () => situation
   return simulation
+}
+
+function aCacheEntry(results, { signature = A_SIGNATURE, computedAt } = {}) {
+  return {
+    signature,
+    computedAt: computedAt ?? new Date(),
+    results: serializeResults(results),
+  }
 }
 
 function hydrateSimulation() {
@@ -69,7 +105,9 @@ describe("Simulation.compute", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     computeAides.mockReturnValue(freshResults)
-    getComputeSignature.mockResolvedValue(A_CONTEXT)
+    getComputeSignature.mockReturnValue(A_CONTEXT)
+    areParametersLoaded.mockReturnValue(true)
+    getParametersAsync.mockResolvedValue({})
     calculateSpy = vi
       .spyOn(openfisca, "calculate")
       .mockImplementation((_situation, callback) =>
@@ -97,59 +135,126 @@ describe("Simulation.compute", () => {
         situation,
         String(simulation._id),
         openfiscaResponse,
-        undefined,
+        false,
       )
       expect(updateOneSpy).toHaveBeenCalledWith(
-        { _id: simulation._id },
+        { _id: simulation._id, status: { $ne: SimulationStatus.Anonymized } },
         {
           $set: {
             computedResults: {
               signature: A_SIGNATURE,
               computedAt: expect.any(Date),
-              results: freshResults,
+              results: serializeResults(freshResults),
             },
           },
         },
+      )
+    })
+
+    // Le document anonymisé a perdu les réponses dont ces montants dérivent :
+    // la condition vit dans le filtre pour rester atomique.
+    it("excludes anonymized documents from the cache write", async () => {
+      const simulation = buildSimulation()
+
+      await simulation.compute()
+
+      expect(updateOneSpy.mock.calls[0][0]).toEqual({
+        _id: simulation._id,
+        status: { $ne: SimulationStatus.Anonymized },
+      })
+    })
+
+    // Le résultat persisté ne garde que l'écart au catalogue : ni la
+    // description, ni les conditions, ni les propriétés fonction.
+    it("persists only the volatile part of each benefit", async () => {
+      const simulation = buildSimulation()
+
+      await simulation.compute()
+
+      const stored = updateOneSpy.mock.calls[0][1].$set.computedResults.results
+      expect(stored.droitsEligibles).toEqual([
+        { id: "rsa", overlay: { montant: 100, legend: "/ mois" } },
+      ])
+      expect(JSON.stringify(stored).length).toBeLessThan(
+        JSON.stringify(freshResults).length / 10,
       )
     })
   })
 
   describe("with cached results matching the current signature", () => {
     it("serves the cache without calling OpenFisca", async () => {
-      const simulation = buildSimulation({
-        signature: A_SIGNATURE,
-        computedAt: new Date("2024-01-02"),
-        results: cachedResults,
-      })
+      const simulation = buildSimulation(aCacheEntry(cachedResults))
 
       const results = await simulation.compute()
 
-      expect(results).toEqual(cachedResults)
+      expect(results).toEqual({
+        ...cachedResults,
+        _id: String(simulation._id),
+      })
       expect(calculateSpy).not.toHaveBeenCalled()
       expect(computeAides).not.toHaveBeenCalled()
       expect(updateOneSpy).not.toHaveBeenCalled()
     })
-  })
 
-  describe("with cached results from another signature", () => {
-    it("computes again and refreshes the cache", async () => {
+    // Le TTL borne la dérive que la signature ne voit pas : une correction de
+    // la logique JavaScript ne change pas toujours la version applicative.
+    it("computes again once the entry is older than the TTL", async () => {
+      const simulation = buildSimulation(
+        aCacheEntry(cachedResults, {
+          computedAt: new Date(Date.now() - 25 * 60 * 60 * 1000),
+        }),
+      )
+
+      const results = await simulation.compute()
+
+      expect(results).toEqual(freshResults)
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it("serves an entry that is still within the TTL", async () => {
+      const simulation = buildSimulation(
+        aCacheEntry(cachedResults, {
+          computedAt: new Date(Date.now() - 23 * 60 * 60 * 1000),
+        }),
+      )
+
+      await simulation.compute()
+
+      expect(calculateSpy).not.toHaveBeenCalled()
+    })
+
+    it("reports an unreadable entry and computes again", async () => {
       const simulation = buildSimulation({
-        signature: ANOTHER_SIGNATURE,
-        computedAt: new Date("2024-01-02"),
-        results: cachedResults,
+        signature: A_SIGNATURE,
+        computedAt: new Date(),
+        results: { droitsEligibles: [], droitsInjectes: [] },
       })
 
       const results = await simulation.compute()
 
       expect(results).toEqual(freshResults)
       expect(calculateSpy).toHaveBeenCalledTimes(1)
+      expect(captureException).toHaveBeenCalledWith(expect.any(Error))
+    })
+  })
+
+  describe("with cached results from another signature", () => {
+    it("computes again and refreshes the cache", async () => {
+      const simulation = buildSimulation(
+        aCacheEntry(cachedResults, { signature: ANOTHER_SIGNATURE }),
+      )
+
+      const results = await simulation.compute()
+
+      expect(results).toEqual(freshResults)
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
       expect(updateOneSpy).toHaveBeenCalledWith(
-        { _id: simulation._id },
+        expect.objectContaining({ _id: simulation._id }),
         expect.objectContaining({
           $set: expect.objectContaining({
             computedResults: expect.objectContaining({
               signature: A_SIGNATURE,
-              results: freshResults,
+              results: serializeResults(freshResults),
             }),
           }),
         }),
@@ -159,13 +264,9 @@ describe("Simulation.compute", () => {
 
   describe("when showPrivate is set", () => {
     it("bypasses the cache in both directions", async () => {
-      const simulation = buildSimulation({
-        signature: A_SIGNATURE,
-        computedAt: new Date("2024-01-02"),
-        results: cachedResults,
-      })
+      const simulation = buildSimulation(aCacheEntry(cachedResults))
 
-      const results = await simulation.compute(true)
+      const results = await simulation.compute({ showPrivate: true })
 
       expect(results).toEqual(freshResults)
       expect(getComputeSignature).not.toHaveBeenCalled()
@@ -180,20 +281,99 @@ describe("Simulation.compute", () => {
     })
   })
 
+  // Les téléservices calculent sur un document modifié en mémoire : leur
+  // résultat ne décrit pas le document persisté et ne doit pas en évincer
+  // l'entrée.
+  describe("when the caller opts out of the cache", () => {
+    it("bypasses the cache in both directions", async () => {
+      const simulation = buildSimulation(aCacheEntry(cachedResults))
+
+      const results = await simulation.compute({ cache: false })
+
+      expect(results).toEqual(freshResults)
+      expect(getComputeSignature).not.toHaveBeenCalled()
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+      expect(updateOneSpy).not.toHaveBeenCalled()
+    })
+  })
+
   describe("when the signature is unavailable", () => {
     it("neither reads nor writes the cache", async () => {
-      getComputeSignature.mockResolvedValue(null)
-      const simulation = buildSimulation({
-        signature: A_SIGNATURE,
-        computedAt: new Date("2024-01-02"),
-        results: cachedResults,
-      })
+      getComputeSignature.mockReturnValue(null)
+      const simulation = buildSimulation(aCacheEntry(cachedResults))
 
       const results = await simulation.compute()
 
       expect(results).toEqual(freshResults)
       expect(calculateSpy).toHaveBeenCalledTimes(1)
       expect(updateOneSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  // Sans paramètres, `getParameters` retombe sur des constantes figées et les
+  // légendes produites sont fausses : les graver serait les rendre permanentes.
+  describe("when the OpenFisca parameters are not loaded", () => {
+    it("serves the results without caching them", async () => {
+      areParametersLoaded.mockReturnValue(false)
+      const simulation = buildSimulation()
+
+      const results = await simulation.compute()
+
+      expect(results).toEqual(freshResults)
+      expect(updateOneSpy).not.toHaveBeenCalled()
+    })
+
+    it("reports the loading failure", async () => {
+      const error = new Error("OF offline")
+      getParametersAsync.mockRejectedValue(error)
+      areParametersLoaded.mockReturnValue(false)
+      const simulation = buildSimulation()
+
+      await simulation.compute()
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `Unable to load the OpenFisca parameters before computing simulation ${simulation._id}`,
+        error,
+      )
+      expect(captureException).toHaveBeenCalledWith(error)
+    })
+
+    it("loads them before computing so the legends are not the fallback constants", async () => {
+      const simulation = buildSimulation()
+
+      await simulation.compute()
+
+      expect(getParametersAsync).toHaveBeenCalledWith(situation.dateDeValeur)
+      expect(getParametersAsync.mock.invocationCallOrder[0]).toBeLessThan(
+        computeAides.mock.invocationCallOrder[0],
+      )
+    })
+  })
+
+  // Restauration d'onglet, iframes rechargées : les rafales portent sur le même
+  // document.
+  describe("with concurrent requests on the same document", () => {
+    it("computes once and shares the result", async () => {
+      const simulation = buildSimulation()
+
+      const results = await Promise.all([
+        simulation.compute(),
+        simulation.compute(),
+        simulation.compute(),
+      ])
+
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+      expect(updateOneSpy).toHaveBeenCalledTimes(1)
+      expect(results).toEqual([freshResults, freshResults, freshResults])
+    })
+
+    it("computes again for a later request", async () => {
+      const simulation = buildSimulation()
+
+      await simulation.compute()
+      await simulation.compute()
+
+      expect(calculateSpy).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -225,7 +405,10 @@ describe("Simulation.compute", () => {
 
       const results = await simulation.compute()
 
-      expect(results).toEqual(freshResults)
+      expect(results).toEqual({
+        ...freshResults,
+        _id: String(simulation._id),
+      })
       expect(calculateSpy).not.toHaveBeenCalled()
     })
 

--- a/tests/unit/backend/simulation-compute.spec.ts
+++ b/tests/unit/backend/simulation-compute.spec.ts
@@ -1,0 +1,261 @@
+import { expect, vi } from "vitest"
+
+const { getComputeSignature, computeAides, captureException } = vi.hoisted(
+  () => ({
+    getComputeSignature: vi.fn(),
+    computeAides: vi.fn(),
+    captureException: vi.fn(),
+  }),
+)
+
+// Seule la signature globale est simulée : l'empreinte de situation, qui
+// complète la clé de cache, reste celle du code de production.
+vi.mock(
+  "@backend/lib/openfisca/compute-signature.js",
+  async (importOriginal) => ({
+    ...((await importOriginal()) as object),
+    getComputeSignature,
+  }),
+)
+vi.mock("@lib/benefits/compute.js", () => ({ computeAides }))
+vi.mock("@sentry/node", () => ({ captureException }))
+
+import mongoose from "mongoose"
+import Simulations from "@backend/models/simulation.js"
+import openfisca from "@backend/lib/openfisca/index.js"
+import { getSituationSignature } from "@backend/lib/openfisca/compute-signature.js"
+
+const A_CONTEXT =
+  "openfisca:openfisca-france@175.1.7|benefits:abc|simulation:17"
+const ANOTHER_CONTEXT =
+  "openfisca:openfisca-france@176.0.7|benefits:abc|simulation:17"
+
+const situation = { dateDeValeur: new Date("2024-01-01") }
+const A_SIGNATURE = `${A_CONTEXT}|${getSituationSignature(situation)}`
+const ANOTHER_SIGNATURE = `${ANOTHER_CONTEXT}|${getSituationSignature(situation)}`
+const openfiscaResponse = { individus: {} }
+const freshResults = { droitsEligibles: [{ id: "fresh", montant: 100 }] }
+const cachedResults = { droitsEligibles: [{ id: "cached", montant: 200 }] }
+
+function buildSimulation(computedResults?) {
+  const simulation = new Simulations({
+    answers: { all: [], current: [] },
+    dateDeValeur: new Date("2024-01-01"),
+    computedResults,
+  })
+  simulation.getSituation = () => situation
+  return simulation
+}
+
+function hydrateSimulation() {
+  const answer = {
+    entityName: "individu",
+    id: "demandeur",
+    fieldName: "date_naissance",
+    value: "2000-01-01T00:00:00.000Z",
+  }
+
+  return Simulations.hydrate({
+    _id: new mongoose.Types.ObjectId(),
+    answers: { all: [answer], current: [answer] },
+    dateDeValeur: new Date("2024-01-01"),
+    version: 17,
+  })
+}
+
+describe("Simulation.compute", () => {
+  let calculateSpy, updateOneSpy, consoleSpy
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    computeAides.mockReturnValue(freshResults)
+    getComputeSignature.mockResolvedValue(A_CONTEXT)
+    calculateSpy = vi
+      .spyOn(openfisca, "calculate")
+      .mockImplementation((_situation, callback) =>
+        callback(null, openfiscaResponse),
+      )
+    updateOneSpy = vi
+      .spyOn(Simulations, "updateOne")
+      .mockResolvedValue({} as any)
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe("without cached results", () => {
+    it("calls OpenFisca and persists the computed results", async () => {
+      const simulation = buildSimulation()
+
+      const results = await simulation.compute()
+
+      expect(results).toEqual(freshResults)
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+      expect(computeAides).toHaveBeenCalledWith(
+        situation,
+        String(simulation._id),
+        openfiscaResponse,
+        undefined,
+      )
+      expect(updateOneSpy).toHaveBeenCalledWith(
+        { _id: simulation._id },
+        {
+          $set: {
+            computedResults: {
+              signature: A_SIGNATURE,
+              computedAt: expect.any(Date),
+              results: freshResults,
+            },
+          },
+        },
+      )
+    })
+  })
+
+  describe("with cached results matching the current signature", () => {
+    it("serves the cache without calling OpenFisca", async () => {
+      const simulation = buildSimulation({
+        signature: A_SIGNATURE,
+        computedAt: new Date("2024-01-02"),
+        results: cachedResults,
+      })
+
+      const results = await simulation.compute()
+
+      expect(results).toEqual(cachedResults)
+      expect(calculateSpy).not.toHaveBeenCalled()
+      expect(computeAides).not.toHaveBeenCalled()
+      expect(updateOneSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("with cached results from another signature", () => {
+    it("computes again and refreshes the cache", async () => {
+      const simulation = buildSimulation({
+        signature: ANOTHER_SIGNATURE,
+        computedAt: new Date("2024-01-02"),
+        results: cachedResults,
+      })
+
+      const results = await simulation.compute()
+
+      expect(results).toEqual(freshResults)
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+      expect(updateOneSpy).toHaveBeenCalledWith(
+        { _id: simulation._id },
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            computedResults: expect.objectContaining({
+              signature: A_SIGNATURE,
+              results: freshResults,
+            }),
+          }),
+        }),
+      )
+    })
+  })
+
+  describe("when showPrivate is set", () => {
+    it("bypasses the cache in both directions", async () => {
+      const simulation = buildSimulation({
+        signature: A_SIGNATURE,
+        computedAt: new Date("2024-01-02"),
+        results: cachedResults,
+      })
+
+      const results = await simulation.compute(true)
+
+      expect(results).toEqual(freshResults)
+      expect(getComputeSignature).not.toHaveBeenCalled()
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+      expect(computeAides).toHaveBeenCalledWith(
+        situation,
+        String(simulation._id),
+        openfiscaResponse,
+        true,
+      )
+      expect(updateOneSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when the signature is unavailable", () => {
+    it("neither reads nor writes the cache", async () => {
+      getComputeSignature.mockResolvedValue(null)
+      const simulation = buildSimulation({
+        signature: A_SIGNATURE,
+        computedAt: new Date("2024-01-02"),
+        results: cachedResults,
+      })
+
+      const results = await simulation.compute()
+
+      expect(results).toEqual(freshResults)
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+      expect(updateOneSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when caching fails", () => {
+    it("reports the error and still returns the computed results", async () => {
+      const error = new Error("write error")
+      updateOneSpy.mockRejectedValue(error)
+      const simulation = buildSimulation()
+
+      const results = await simulation.compute()
+
+      expect(results).toEqual(freshResults)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `Unable to cache the computed results of simulation ${simulation._id}`,
+        error,
+      )
+      expect(captureException).toHaveBeenCalledWith(error)
+    })
+  })
+
+  describe("with a document modified in memory", () => {
+    it("serves the cache written by an identical situation", async () => {
+      const simulation = hydrateSimulation()
+
+      await simulation.compute()
+      simulation.computedResults =
+        updateOneSpy.mock.calls[0][1].$set.computedResults
+      calculateSpy.mockClear()
+
+      const results = await simulation.compute()
+
+      expect(results).toEqual(freshResults)
+      expect(calculateSpy).not.toHaveBeenCalled()
+    })
+
+    it("computes again when the answers no longer match the cached situation", async () => {
+      const simulation = hydrateSimulation()
+
+      await simulation.compute()
+      simulation.computedResults =
+        updateOneSpy.mock.calls[0][1].$set.computedResults
+      calculateSpy.mockClear()
+      simulation.answers.current.push({
+        entityName: "menage",
+        fieldName: "loyer",
+        value: { loyer: 500 },
+      })
+
+      await simulation.compute()
+
+      expect(calculateSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("when OpenFisca fails", () => {
+    it("rejects and writes nothing", async () => {
+      const error = new Error("OF error")
+      calculateSpy.mockImplementation((_situation, callback) => callback(error))
+      const simulation = buildSimulation()
+
+      await expect(simulation.compute()).rejects.toThrow("OF error")
+      expect(updateOneSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/backend/simulation-controller.spec.ts
+++ b/tests/unit/backend/simulation-controller.spec.ts
@@ -1,0 +1,52 @@
+import { expect, vi } from "vitest"
+
+// Le chargement des migrations parcourt le système de fichiers à l'import :
+// hors de propos pour la création d'une simulation.
+vi.mock("@backend/lib/migrations/index.js", () => ({
+  apply: (model) => model,
+}))
+
+import simulationController from "@backend/controllers/simulation.js"
+import Simulations from "@backend/models/simulation.js"
+
+describe("simulation controller create", () => {
+  let req, res, next, createSpy
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    req = {
+      body: {
+        answers: { all: [], current: [] },
+        dateDeValeur: new Date("2024-01-01"),
+      },
+      cookies: {},
+    }
+    res = { cookie: vi.fn(), clearCookie: vi.fn(), status: vi.fn() }
+    next = vi.fn()
+    createSpy = vi.spyOn(Simulations, "create").mockResolvedValue({} as any)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("does not persist client-provided computed results", async () => {
+    req.body.computedResults = {
+      signature: "forged",
+      computedAt: new Date(),
+      results: { droitsEligibles: [{ id: "rsa", montant: 999999 }] },
+    }
+
+    await simulationController.create(req, res, next)
+
+    expect(createSpy).toHaveBeenCalledTimes(1)
+    expect(createSpy.mock.calls[0][0]).not.toHaveProperty("computedResults")
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it("keeps the simulation payload", async () => {
+    await simulationController.create(req, res, next)
+
+    expect(createSpy.mock.calls[0][0]).toEqual(req.body)
+  })
+})

--- a/tests/unit/tools/cleaner.spec.ts
+++ b/tests/unit/tools/cleaner.spec.ts
@@ -31,6 +31,12 @@ describe("anonymizeSimulation", () => {
       id: anId,
       status: SimulationStatus.New,
       dateDeValeur: "2023-04-20T13:36:57.634Z",
+      computedResults: {
+        signature:
+          "openfisca:openfisca-france@175.1.7|benefits:abc|simulation:17",
+        computedAt: new Date("2023-04-20T13:36:57.634Z"),
+        results: { droitsEligibles: [{ id: "rsa", montant: 500 }] },
+      },
       answers: {
         all: [
           {
@@ -147,6 +153,7 @@ describe("anonymizeSimulation", () => {
     expect(anonymizedSimulation.id).toEqual(anId)
     expect(anonymizedSimulation.status).toEqual(SimulationStatus.Anonymized)
     expect(anonymizedSimulation.answers.current).toEqual([])
+    expect(anonymizedSimulation.computedResults).toEqual(undefined)
 
     const anonymizedAnswers = anonymizedSimulation.answers.all
 

--- a/tests/unit/tools/cleaner.spec.ts
+++ b/tests/unit/tools/cleaner.spec.ts
@@ -33,9 +33,13 @@ describe("anonymizeSimulation", () => {
       dateDeValeur: "2023-04-20T13:36:57.634Z",
       computedResults: {
         signature:
-          "openfisca:openfisca-france@175.1.7|benefits:abc|simulation:17",
+          "openfisca:openfisca-france@175.1.7|environment:abc|benefits:abc|simulation:17",
         computedAt: new Date("2023-04-20T13:36:57.634Z"),
-        results: { droitsEligibles: [{ id: "rsa", montant: 500 }] },
+        results: {
+          format: 1,
+          droitsEligibles: [{ id: "rsa", overlay: { montant: 500 } }],
+          droitsInjectes: [],
+        },
       },
       answers: {
         all: [


### PR DESCRIPTION
## Le problème

`GET /api/simulation/:id/results` relance un calcul OpenFisca **complet à chaque
appel**. `Simulation.compute()` appelle `openfisca.calculate` sans aucun cache.

Or `src/lib/simulation.ts` (`restoreLatestSimulation`) rappelle cette route à chaque
chargement de la page résultats, à partir du cookie `lastestSimulation` qui vit 7
jours en `SameSite=None` — y compris lors des restaurations d'onglet iOS et des
chargements d'iframe partenaire.

**Ampleur réelle, mesurée sur vos logs nginx** — et elle est plus modeste que ce qu'on
avançait initialement :

| | appels `/results` | simulations distinctes | recalculs évitables |
|---|---|---|---|
| journée calme (7 août) | 9 233 | 8 601 | **6,8 %** |
| journée d'incident (6 août) | 59 542 | 44 078 | **26,0 %** |

Cette PR supprime donc environ un quart de la charge OpenFisca en situation de crise,
pas « l'essentiel » comme une version antérieure de cette description l'annonçait. Ces
26 % sont la boucle « c'est lent donc je recharge », et la casser a d'autant plus de
valeur qu'elle s'auto-entretient — mais le gain principal vient du dimensionnement du
pool, traité dans `aides-jeunes-ops`.

Une simulation est immuable — `save()` crée un **nouveau** document à chaque
modification de réponse, relié par `modifiedFrom`. Le résultat est donc mémorisable.

## Ce que fait cette PR

Persiste le résultat dans le document (`computedResults`) et le sert tant qu'il est
valide. Restaurations d'onglet, iframes et retours arrière deviennent gratuits.

L'essentiel du travail porte sur **la sûreté de l'invalidation**. Un cache qui rend un
montant périmé à un jeune est pire que la lenteur qu'il corrige, et cette PR a été
écrite dans cet ordre de priorité.

### La clé de cache

`<version paquet pays OpenFisca>|<empreinte du référentiel d'aides>|<version du modèle>|<empreinte de l'environnement>|<empreinte de la situation calculée>`

- **Empreinte de l'environnement** : `openfisca/requirements.txt` et la version plus
  les dépendances de `package.json`. Indispensable : `TaxBenefitSystem.get_package_metadata()`
  ne retourne que le paquet **pays**, et délègue à `baseline` pour une réforme — ce qui
  est le cas ici. `OpenFisca-France-Local`, où vivent les aides locales et qui bouge le
  plus souvent, `Openfisca-Paris` et la réforme EPCI sont donc **invisibles** dans les
  en-têtes de l'API. `@betagouv/aides-velo` ne l'est pas davantage.
- **Empreinte de la situation** : certains appelants modifient le document en mémoire
  avant de calculer. Le téléservice logement réécrit `answers.current` avec des
  scénarios de loyer et de commune ; sans cette empreinte, ses montants seraient écrits
  dans le document et ensuite servis à l'usager.
- **TTL**, 24 h par défaut (`COMPUTED_RESULTS_TTL_HOURS`), pour borner ce qu'une
  signature ne peut pas voir — un changement de logique JS sans bump de version.
  À 0, le cache est entièrement coupé, en lecture **et** en écriture : un interrupteur
  d'arrêt à moitié fonctionnel est un piège en incident.

Une signature qui ne peut pas être établie ne désactive pas seulement l'écriture :
elle désactive tout le cache. Aucune signature de repli n'est fabriquée.

### Ce qui est stocké

Seul **l'écart au catalogue** (`{id, overlay, undefinedKeys}`), réhydraté depuis
`data/all.js` à la lecture — le motif déjà utilisé dans ce dépôt par
`Followup.benefits` et `enrichBenefitsList`.

Ça évite trois choses d'un coup. Les propriétés fonction survivent : BSON les
supprime, et `labelFunction` est lue au rendu de l'email récapitulatif, ce qui
transformait « un taux de 2.2% / an » en « pour un montant de 2.2 % ». Les `undefined`
ne deviennent pas `null`. Et le volume chute : **91 % de moins** sur un cas extrême à
656 aides éligibles, 98,6 % sur un cas réaliste à 5 aides.

### Robustesse

- **La signature ne bloque jamais.** `getComputeSignature()` est synchrone : elle rend
  la dernière valeur connue et rafraîchit en fond. Sans ça, à expiration de la
  mémoïsation, la lecture du cache attendait jusqu'à 5 s sur la racine d'OpenFisca —
  le service déjà saturé — et un échec faisait recalculer tout le monde. Boucle :
  pool saturé → signature indisponible → recalculs → pool saturé.
- **Les paramètres OpenFisca sont chargés avant le calcul**, et rien n'est écrit tant
  qu'ils ne le sont pas. `getParameters` retombe sinon sur des constantes de 2022 :
  une légende « au lieu de 0.5 % » là où la valeur réelle est 1.7 %, jusqu'ici
  transitoire, serait devenue permanente par simulation. `requestParameters`
  mémoïsait par ailleurs un rejet à vie — une seule indisponibilité au démarrage d'un
  worker désactivait le cache pour toujours. Réessai avec palier de 60 s.
- **Un document anonymisé n'est jamais repeuplé.** La condition de statut vit dans le
  filtre du `updateOne` pour rester atomique : `tools/cleaner.ts` ne repasse jamais
  sur un document anonymisé, une écriture concurrente y aurait réinjecté des montants
  dérivés de réponses personnelles, définitivement.
- **Déduplication des calculs en vol** par `_id` et signature : une rafale sur une
  simulation froide — exactement le motif des restaurations d'onglet — ne déclenche
  qu'un seul calcul.
- `computedResults` est retiré du corps accepté par `POST /api/simulation` et purgé
  par `anonymizeSimulation`.

## Vérification

```
$ npx tsc --noEmit -p tsconfig.server.json
TypeScript: No errors found

$ npm run lint
(0 erreur, 0 warning)

$ NODE_OPTIONS='--max-old-space-size=4096' npx vitest run --pool=forks
25060 tests passants, EXIT=0        (référence sur main : 25003, EXIT=1)
```

La suite sort désormais en code 0 : la neutralisation du rejet de `requestParameters`
supprime une erreur non gérée qui subsiste sur `main`.

Aller-retour prouvé sur une vraie MongoDB : résultat servi identique entre premier
calcul et relecture depuis le cache, comparé octet à octet sur 657 droits et autant de
textes d'email, sur plusieurs territoires à personnalisation. Purge à l'anonymisation
effective en base. Chaque correctif dispose d'un test qui échoue quand on l'annule.

Cette PR a subi cinq tours de revue adversariale ; les quatre premiers y ont trouvé un
défaut critique ou haut à chaque fois, tous corrigés dans leur propre commit :
signature aveugle aux extensions OpenFisca, garde-fou des paramètres lu après l'appel
réseau, cache neutralisé pendant la saturation même qu'il doit soulager, document
anonymisé repeuplé, `undefined` imbriqués rendus en `null`.

## Limites connues

- La signature lit `openfisca/requirements.txt` à la racine du dépôt, ce que le
  déploiement actuel garantit. Si un jour seul `dist-server` était expédié, le digest
  échouerait et le cache serait **entièrement désactivé**, signalé à Sentry : jamais
  un mauvais montant, mais la performance disparaîtrait sans bruit.
- `toExternal` lit toujours `query` depuis l'URL vivante et non depuis
  `req.payload.query` signée dans le JWT. Hors périmètre, non touché ici : un porteur
  du jeton peut encore forcer un calcul, mais plus d'écriture dans le document d'un tiers.
- La branche `showPrivate` est du code mort en production. Conservée : c'est un
  garde-fou correct.

## Lien avec les autres correctifs

Deux PR complètent celle-ci : le bornage des timeouts dans ce dépôt, et le
dimensionnement du pool gunicorn plus le bornage de la file dans `aides-jeunes-ops`.

C'est cette dernière qui fait le gros du travail : l'analyse des logs situe le plafond
actuel autour de 2 000 à 2 500 simulations/heure, et doubler le pool le déplace à
environ 5 000. La présente PR retire 26 % de la demande un jour d'incident. Elle est
donc **complémentaire, pas prioritaire** — et c'est la plus risquée des trois, puisque
c'est la seule qui touche au calcul des montants affichés. Elle mérite une relecture
posée plutôt qu'un merge dans l'urgence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
