### PR TITLE
Revert "Revert to 8feb45a12" — le rollback n'a pas résolu le 504 en prod

### DIFF
--- a/backend/lib/definitions.ts
+++ b/backend/lib/definitions.ts
@@ -20,6 +20,7 @@ const individuBase = [
   "id",
   "_bourseCriteresSociauxCommuneDomicileFamilial",
   "_hasRessources",
+  "_interetUnivParisCite",
   "_role",
 ]
 

--- a/data/benefits/javascript/caf-eure-et-loir-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-eure-et-loir-aide-bafa-approfondissement.yml
@@ -1,8 +1,9 @@
 label: aide au BAFA
 institution: caf_eure_et_loir
-description: La Caf d'Eure-et-Loir vous aide à financer votre formation BAFA,
-  à condition que vous suiviez un parcours complet de formation (formation générale,
-  stage pratique, puis stage d'approfondissement ou de qualification). L'aide est versée directement au stagiaire.
+description: La Caf d'Eure-et-Loir vous aide à financer votre formation BAFA, à
+  condition que vous suiviez un parcours complet de formation (formation
+  générale, stage pratique, puis stage d'approfondissement ou de qualification).
+  L'aide est versée directement au stagiaire.
 prefix: l’
 conditions_generales:
   - type: age
@@ -15,8 +16,9 @@ profils: []
 conditions:
   - Envoyer le <a target="_blank" title="Formulaire - Nouvelle fenêtre"
     rel="noopener"
-    href="https://caf.fr/sites/default/files/medias/281/Documents/Action-sociale/Bafa/Cerfa_bafa.pdf">formulaire</a>
-    dans un délai de 3 mois maximum suivant l'inscription au stage d'approfondissement ou de qualification.
+    href="https://www.calameo.com/caf-d-eure-et-loir/read/006004434a4b66221cb45">formulaire</a>
+    dans un délai de 3 mois maximum suivant l'inscription au stage
+    d'approfondissement ou de qualification.
 interestFlag: _interetBafa
 type: float
 unit: €
@@ -24,4 +26,5 @@ periodicite: ponctuelle
 legend: maximum
 montant: 600
 link: https://caf.fr/allocataires/caf-d-eure-et-loir/offre-de-service/vie-personnelle/bafa
-form: https://caf.fr/sites/default/files/medias/281/Documents/Action-sociale/Bafa/Cerfa_bafa.pdf
+form: https://www.calameo.com/caf-d-eure-et-loir/read/006004434a4b66221cb45
+private: true

--- a/data/benefits/javascript/caf-loiret-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-loiret-aide-bafa-approfondissement.yml
@@ -1,11 +1,11 @@
 label: aide au BAFA pour une session de formation d'approfondissement
 institution: caf_loiret
-description:
-  La CAF du Loiret vous aide à financer votre session de formation d'approfondissement
-  (troisième et dernière étape du diplôme du BAFA) en complément de l'aide nationale apportée par la CNAF.
-  Le dossier de demande doit être complété, signé et adressé à la CAF du Loiret à l’issue
-  de la formation d'approfondissement, dans un délai maximum de 3 mois. L’aide est versée en une seule fois
-  au jeune ou à sa famille.
+description: La CAF du Loiret vous aide à financer votre session de formation
+  d'approfondissement (troisième et dernière étape du diplôme du BAFA) en
+  complément de l'aide nationale apportée par la CNAF. Le dossier de demande
+  doit être complété, signé et adressé à la CAF du Loiret à l’issue de la
+  formation d'approfondissement, dans un délai maximum de 3 mois. L’aide est
+  versée en une seule fois au jeune ou à sa famille.
 prefix: l’
 conditions_generales:
   - type: age
@@ -20,7 +20,8 @@ conditions_generales:
 profils: []
 conditions:
   - Être allocataire ou rattaché au dossier allocataire de vos parents.
-  - Adresser votre demande à la CAF, dans un délai maximum de trois mois à l'issue de la session d'approfondissement.
+  - Adresser votre demande à la CAF, dans un délai maximum de trois mois à l'issue
+    de la session d'approfondissement.
 interestFlag: _interetBafa
 type: float
 unit: €
@@ -28,5 +29,5 @@ periodicite: ponctuelle
 legend: maximum
 montant: 200
 link: https://caf.fr/allocataires/caf-du-loiret/offre-de-service/vie-professionnelle/vous-souhaitez-devenir-animateur-grace-au-bafa-bafd
-instructions: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/Bafa_2025.pdf
-form: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/2025-Formulaire-Bafa-Caf45.pdf
+instructions: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/Bafa_2026.pdf
+form: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/2026-Formulaire-Bafa-Caf45.pdf

--- a/data/benefits/javascript/caf-loiret-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-loiret-aide-bafa-generale.yml
@@ -1,11 +1,11 @@
 label: aide au BAFA pour une session de formation générale
 institution: caf_loiret
-description:
-  La CAF du Loiret vous aide à financer votre session de formation générale
-  (première étape du diplôme du BAFA) en complément de l'aide nationale apportée par la CNAF.
-  Le dossier de demande doit être complété, signé et adressé à la CAF du Loiret à l’issue
-  de la formation générale, dans un délai maximum de 3 mois. L’aide est versée en une seule fois
-  au jeune ou à sa famille.
+description: La CAF du Loiret vous aide à financer votre session de formation
+  générale (première étape du diplôme du BAFA) en complément de l'aide nationale
+  apportée par la CNAF. Le dossier de demande doit être complété, signé et
+  adressé à la CAF du Loiret à l’issue de la formation générale, dans un délai
+  maximum de 3 mois. L’aide est versée en une seule fois au jeune ou à sa
+  famille.
 prefix: l’
 conditions_generales:
   - type: age
@@ -20,7 +20,8 @@ conditions_generales:
 profils: []
 conditions:
   - Etre allocataire ou rattaché au dossier allocataire de vos parents.
-  - Adresser votre demande à la CAF du Loiret, dans un délai maximum de trois mois à l'issue de la formation générale.
+  - Adresser votre demande à la CAF du Loiret, dans un délai maximum de trois mois
+    à l'issue de la formation générale.
 interestFlag: _interetBafa
 type: float
 unit: €
@@ -28,5 +29,5 @@ periodicite: ponctuelle
 legend: maximum
 montant: 300
 link: https://caf.fr/allocataires/caf-du-loiret/offre-de-service/vie-professionnelle/vous-souhaitez-devenir-animateur-grace-au-bafa-bafd
-instructions: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/Bafa_2025.pdf
-form: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/2025-Formulaire-Bafa-Caf45.pdf
+instructions: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/Bafa_2026.pdf
+form: https://caf.fr/sites/default/files/medias/451/Vie-professionnelle/2026-Formulaire-Bafa-Caf45.pdf

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-approfondissement.yml
@@ -19,12 +19,14 @@ profils: []
 conditions:
   - Être allocataire ou rattaché au dossier allocataire de vos parents.
   - Être sans emploi fixe rémunéré.
-  - 'Renvoyer le formulaire de demande dûment complété par email à <a href="mailto:transmettreundocument.caf84@info-caf.fr">transmettreundocument.caf84@info-caf.fr</a> ou par voie postale à lʼadresse suivante : Caf de Vaucluse - SIDP-BAFA - 218 boulevard Pierre BOULLE - 84049 AVIGNON Cedex 9.'
+  - 'Renvoyer le formulaire de demande dûment complété par email à <a href="mailto:transmettreundocument.caf84@info-caf.fr">transmettreundocument.caf84@info-caf.fr</a>
+    ou par voie postale à lʼadresse suivante : Caf de Vaucluse - SIDP-BAFA - 218 boulevard
+    Pierre BOULLE - 84049 AVIGNON Cedex 9.'
 interestFlag: _interetBafa
 type: float
 unit: €
 periodicite: ponctuelle
 montant: 200
 link: https://caf.fr/allocataires/caf-de-vaucluse/offre-de-service/vie-professionnelle/le-bafa
-form: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
-instructions: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Plaquette_AFI_BAFA_BAFD.pdf
+form: https://www.caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
+instructions: https://www.caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf

--- a/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
+++ b/data/benefits/javascript/caf-vaucluse-aide-bafa-generale.yml
@@ -1,12 +1,14 @@
 label: aide au BAFA pour une session de formation générale
 institution: caf_vaucluse
 description: L'aide à la formation du BAFA est une aide locale mise à
-  disposition par la CAF du Vaucluse pour vous aider à financer votre session générale en
-  complément de l'aide nationale apportée par la CAF.
+  disposition par la CAF du Vaucluse pour vous aider à financer votre session
+  générale en complément de l'aide nationale apportée par la CAF.
 conditions:
   - Être allocataire ou rattaché au dossier allocataire de vos parents.
   - Être sans emploi fixe rémunéré.
-  - 'Renvoyer le formulaire de demande dûment complété par email à <a href="transmettreundocument.caf84@info-caf.fr">transmettreundocument.caf84@info-caf.fr</a> ou par voie postale à lʼadresse suivante : Caf de Vaucluse - SIDP-BAFA - 218 boulevard Pierre BOULLE - 84049 AVIGNON Cedex 9.'
+  - 'Renvoyer le formulaire de demande dûment complété par email à <a href="transmettreundocument.caf84@info-caf.fr">transmettreundocument.caf84@info-caf.fr</a>
+    ou par voie postale à lʼadresse suivante : Caf de Vaucluse - SIDP-BAFA - 218 boulevard
+    Pierre BOULLE - 84049 AVIGNON Cedex 9.'
 conditions_generales:
   - type: age
     operator: ">="
@@ -19,7 +21,7 @@ conditions_generales:
       - "84"
 profils: []
 link: https://caf.fr/allocataires/caf-de-vaucluse/offre-de-service/vie-professionnelle/le-bafa
-instructions: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Plaquette_AFI_BAFA_BAFD.pdf
+instructions: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
 form: https://caf.fr/sites/default/files/medias/841/VIE%20PROFESSIONNELLE/BAFA/2024_Dossier_AFI_Bafa_Bafd.pdf
 prefix: l’
 type: float

--- a/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
+++ b/data/benefits/javascript/caf_ille_et_vilaine-aides-au-bafa-et-bafd-pour-une-formation-générale-ou-dapprofondissement-qualification.yml
@@ -1,11 +1,11 @@
 label: Aides au BAFA ou BAFD
 institution: caf_ille_et_vilaine
-description:
-  Le brevet d’aptitude aux fonctions d’animateur (BAFA) et le brevet d’aptitude
-  aux fonctions de directeur (BAFD) sont des diplômes qui permettent d’encadrer
-  des enfants et des adolescents en accueil collectif de mineurs. La Caf d'Ille-et-Vilaine
-  vous aide à financer ces formations, sous conditions de ressources. Cette aide est cumulable
-  avec celle de la CNAF et son montant dépend de votre quotient familial.
+description: Le brevet d’aptitude aux fonctions d’animateur (BAFA) et le brevet
+  d’aptitude aux fonctions de directeur (BAFD) sont des diplômes qui permettent
+  d’encadrer des enfants et des adolescents en accueil collectif de mineurs. La
+  Caf d'Ille-et-Vilaine vous aide à financer ces formations, sous conditions de
+  ressources. Cette aide est cumulable avec celle de la CNAF et son montant
+  dépend de votre quotient familial.
 prefix: les
 conditions_generales:
   - type: age
@@ -23,4 +23,4 @@ interestFlag: _interetBafa
 type: bool
 periodicite: autre
 link: https://caf.fr/allocataires/caf-d-ille-et-vilaine/offre-de-service/vie-professionnelle/je-passe-le-bafa-ou-le-bafd
-form: https://caf.fr/sites/default/files/medias/351/Offre-de-service/vie-professionnelle/aide-au-bafa-bafd/Formulaire%20BAFA-2025_mod%C3%A8le.pdf
+form: https://caf.fr/sites/default/files/medias/351/Offre-de-service/vie-professionnelle/aide-au-bafa-bafd/Imprime_1138102.pdf

--- a/lib/cleaner-functions.ts
+++ b/lib/cleaner-functions.ts
@@ -35,6 +35,7 @@ function getAnonymizedAnswer(answer, simulation) {
           case "_interetAidesSanitaireSocial":
           case "_interetBafa":
           case "_interetEtudesEtranger":
+          case "_interetUnivParisCite":
           case "_interetPermisDeConduire":
           case "_interetsAidesVelo":
           case "activite":

--- a/lib/enums/themes.ts
+++ b/lib/enums/themes.ts
@@ -3,6 +3,7 @@ export enum Theme {
   LightBlue = "light-blue",
   BordeauxMetropole = "bordeaux-metropole",
   Soliguide = "soliguide",
+  UnivParisCite = "univ-paris-cite",
   VilleDeVannes = "ville-de-vannes",
 }
 
@@ -12,4 +13,5 @@ export enum ThemeLabel {
   BordeauxMetropole = "Thème Bordeaux Métropole",
   Soliguide = "Thème Soliguide",
   VilleDeVannes = "Thème Ville de Vannes",
+  UnivParisCite = "Thème Université Paris Cité",
 }

--- a/lib/types/individu.d.ts
+++ b/lib/types/individu.d.ts
@@ -21,6 +21,7 @@ export interface Individu {
   handicap?: boolean
   taux_incapacite?: number
   _interetsAidesVelo?: Velo[]
+  _interetUnivParisCite?: boolean
 }
 
 export interface IndividuGenerator {

--- a/openfisca/requirements.txt
+++ b/openfisca/requirements.txt
@@ -1,8 +1,8 @@
 gunicorn>=21.2.0
 pytest==8.4.2
-Openfisca-France==175.1.7
+Openfisca-France==176.0.7
 Openfisca-Core[web-api]==44.7.0
-OpenFisca-France-Local[excel-reader]==6.17.10
-Openfisca-Paris==5.5.14
+OpenFisca-France-Local[excel-reader]==6.17.11
+Openfisca-Paris==5.5.15
 typing_extensions==4.14.1
 numpy >=1.24.2, <2.0.0

--- a/src/plugins/theme-service.ts
+++ b/src/plugins/theme-service.ts
@@ -28,6 +28,11 @@ const options = [
     value: Soliguide,
   },
   {
+    title: ThemeLabel.UnivParisCite,
+    label: Theme.UnivParisCite,
+    value: DefaultDsfr,
+  },
+  {
     title: ThemeLabel.VilleDeVannes,
     label: Theme.VilleDeVannes,
     value: VilleDeVannes,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -10,6 +10,7 @@ import axios from "axios"
 import { generateSituation } from "@lib/situations.js"
 import ABTestingService from "@/plugins/ab-testing-service.js"
 import storageService from "@/lib/storage-service.js"
+import { useThemeStore } from "@/stores/theme.js"
 import {
   Calculs,
   PersistedStore,
@@ -416,6 +417,21 @@ export const useStore = defineStore("store", {
       const simulation = { ...this.simulation, _id: undefined }
       if (this.simulationId) {
         simulation.modifiedFrom = this.simulationId
+      }
+
+      //custom interest school
+      if (useThemeStore().theme === "univ-paris-cite") {
+        const flagAnswer: Answer = {
+          entityName: "individu",
+          id: "demandeur",
+          fieldName: "_interetUnivParisCite",
+          value: true,
+        }
+        simulation.answers = {
+          ...simulation.answers,
+          all: storeAnswer(simulation.answers.all, flagAnswer),
+          current: storeAnswer(simulation.answers.current, flagAnswer),
+        }
       }
 
       simulation.abtesting = ABTestingService.getValues()

--- a/src/views/iframe.vue
+++ b/src/views/iframe.vue
@@ -1,6 +1,16 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue"
+import { computed, getCurrentInstance, onMounted, ref, watch } from "vue"
 import { Theme } from "@lib/enums/themes"
+
+// Thèmes à ne pas exposer publiquement dans le listing d'intégration
+const excludedThemes: string[] = [Theme.UnivParisCite]
+
+const $theme = getCurrentInstance()?.appContext.config.globalProperties.$theme
+const availableThemes = computed(() =>
+  ($theme?.options ?? []).filter(
+    (option) => !excludedThemes.includes(option.label),
+  ),
+)
 
 const selectedTheme = ref(Theme.Default)
 const options = ref(["data-from-home", "data-with-logo"])
@@ -102,7 +112,7 @@ watch(selectedTheme, () => {
         </legend>
         <div class="fr-row">
           <div
-            v-for="(option, index) in $theme.options"
+            v-for="(option, index) in availableThemes"
             :key="index"
             class="fr-radio-group fr-radio-rich fr-mb-2w fr-mt-1w"
           >


### PR DESCRIPTION
## Contexte
Annule #5204. Après déploiement manuel du rollback sur le serveur de production (contournant la panne GitHub Actions), le 504 persiste à l'identique même en `Openfisca-France==175.1.7`

Ça infirme l'hypothèse "régression de perf du bump openfisca-france 176.0.7" : le problème est présent indépendamment de la version. Pas de raison de rester sur l'ancienne version.

## Contenu
Restaure l'état d'avant #5204 :
- Bump openfisca-france/France-Local/Paris (176.0.7)
- Thème "Paris cité"
- 6 aide modifiées - passage en private

## Suite
La cause du 504 reste à investiguer côté infra serveur (charge, mémoire, process bloqué) plutôt que côté code applicatif.