### PR TITLE
perf(openfisca): ne demande pas les aides hors du territoire de l'usager

### DIFF
--- a/backend/lib/openfisca/mapping/index.ts
+++ b/backend/lib/openfisca/mapping/index.ts
@@ -7,6 +7,7 @@ import { buildOpenFiscaMenage } from "./menage/index.js"
 import propertyMove from "./property-move.js"
 import last3MonthsDuplication from "./last3-months-duplication.js"
 import { filterByInterestFlag } from "../../../../lib/benefits/filter-interest-flag.js"
+import { isOutOfTerritory } from "../../../../lib/benefits/territory.js"
 
 import SituationMethods from "../../../../lib/situation.js"
 import { Situation } from "../../../../lib/types/situations.js"
@@ -261,10 +262,16 @@ export function buildOpenFiscaRequest(sourceSituation) {
   )
   last3MonthsDuplication(testCase, situation.dateDeValeur)
 
+  // Une aide portée par une collectivité dont l'usager ne relève pas ne peut
+  // pas lui être due : la demander à OpenFisca fait calculer son arbre de
+  // dépendances pour un résultat nul.
   const prestationsWithInterest: Record<string, any> = pickBy(
     requestedVariables,
     function (definition) {
-      return filterByInterestFlag(definition, situation.demandeur)
+      return (
+        filterByInterestFlag(definition, situation.demandeur) &&
+        !isOutOfTerritory(definition, situation.menage)
+      )
     },
   )
 

--- a/lib/benefits/compute-javascript.ts
+++ b/lib/benefits/compute-javascript.ts
@@ -1,3 +1,4 @@
+import { isAttachedToInstitution } from "./territory.js"
 import dayjs from "dayjs"
 import { datesGenerator } from "../dates.js"
 import { filterByInterestFlag } from "./filter-interest-flag.js"
@@ -171,19 +172,7 @@ export const CONDITION_STRATEGY: Conditions = {
       },
       benefit,
     ): boolean => {
-      const institution = benefit.institution
-
-      switch (institution.type) {
-        case "region":
-          return situation.menage._region === institution.code_insee
-        case "departement":
-          return situation.menage._departement === institution.code_insee
-        case "epci":
-          return situation.menage._epci === institution.code_siren
-        case "commune":
-          return situation.menage.depcom === institution.code_insee
-      }
-      return false
+      return isAttachedToInstitution(benefit.institution, situation.menage)
     },
   },
   not: {

--- a/lib/benefits/territory.ts
+++ b/lib/benefits/territory.ts
@@ -1,0 +1,71 @@
+import { Situation } from "../types/situations.d.js"
+
+type Menage = Situation["menage"]
+
+/**
+ * Une aide portée par une collectivité ne concerne que son territoire. La
+ * correspondance entre le type d'institution et le champ décrivant la commune
+ * de l'usager est la même partout : c'est elle qui décide de l'éligibilité
+ * géographique des aides calculées en JavaScript, et de ce qu'il est inutile de
+ * faire calculer à OpenFisca.
+ */
+export function isAttachedToInstitution(
+  institution: { type?: string; code_insee?: string; code_siren?: string },
+  menage: Menage,
+): boolean {
+  switch (institution?.type) {
+    case "region":
+      return menage?._region === institution.code_insee
+    case "departement":
+      return menage?._departement === institution.code_insee
+    case "epci":
+      return menage?._epci === institution.code_siren
+    case "commune":
+      return menage?.depcom === institution.code_insee
+  }
+  return false
+}
+
+const TERRITORIAL_TYPES = ["region", "departement", "epci", "commune"]
+
+const SITUATION_FIELD = {
+  region: "_region",
+  departement: "_departement",
+  epci: "_epci",
+  commune: "depcom",
+}
+
+const INSTITUTION_FIELD = {
+  region: "code_insee",
+  departement: "code_insee",
+  epci: "code_siren",
+  commune: "code_insee",
+}
+
+/**
+ * Vrai seulement lorsqu'on sait positivement que l'usager ne relève pas du
+ * territoire de l'aide. Une institution non territoriale, un code manquant côté
+ * institution, ou une commune dont l'enrichissement n'a pas fourni le
+ * département, la région ou l'EPCI donnent faux : dans le doute, l'aide est
+ * conservée et sera évaluée normalement.
+ */
+export function isOutOfTerritory(
+  benefit: { institution?: any },
+  menage: Menage,
+): boolean {
+  const institution = benefit?.institution
+  const type = institution?.type
+
+  if (!institution || !menage || !TERRITORIAL_TYPES.includes(type)) {
+    return false
+  }
+
+  const expected = institution[INSTITUTION_FIELD[type]]
+  const actual = menage[SITUATION_FIELD[type]]
+
+  if (!expected || !actual) {
+    return false
+  }
+
+  return expected !== actual
+}

--- a/tests/unit/backend/openfisca-request-territory.spec.ts
+++ b/tests/unit/backend/openfisca-request-territory.spec.ts
@@ -1,0 +1,122 @@
+import { expect } from "vitest"
+
+import { buildOpenFiscaRequest } from "@backend/lib/openfisca/mapping/index.js"
+import { generateSituation } from "@lib/situations.js"
+import benefits from "@root/data/all.js"
+import { isOutOfTerritory } from "@lib/benefits/territory.js"
+
+function situationFor(commune: Record<string, string> | null) {
+  const situation: any = generateSituation({
+    answers: {
+      all: [
+        {
+          entityName: "individu",
+          id: "demandeur",
+          fieldName: "date_naissance",
+          value: "2003-05-01",
+        },
+        {
+          entityName: "menage",
+          fieldName: "depcom",
+          value: commune ?? { depcom: "69123" },
+        },
+        {
+          entityName: "individu",
+          id: "demandeur",
+          fieldName: "salaire_imposable",
+          value: 1200,
+        },
+      ],
+      current: [],
+    },
+    dateDeValeur: new Date("2026-08-01"),
+  } as any)
+
+  if (commune) {
+    Object.assign(situation.menage, commune)
+  }
+  return situation
+}
+
+const LYON = {
+  depcom: "69123",
+  _departement: "69",
+  _region: "84",
+  _epci: "200046977",
+}
+
+function requestedVariables(request: any): Set<string> {
+  const names = new Set<string>()
+  for (const items of Object.values(request)) {
+    if (!items || typeof items !== "object") continue
+    for (const item of Object.values(items as any)) {
+      for (const [key, periods] of Object.entries((item as any) || {})) {
+        if (periods && typeof periods === "object") names.add(key)
+      }
+    }
+  }
+  return names
+}
+
+describe("périmètre territorial de la requête OpenFisca", () => {
+  const openfiscaBenefits = (benefits.all as any[]).filter(
+    (benefit) => (benefit.source || "openfisca") === "openfisca",
+  )
+
+  it("ne demande aucune aide portée par une collectivité dont l'usager ne relève pas", () => {
+    const situation = situationFor(LYON)
+    const demandees = requestedVariables(buildOpenFiscaRequest(situation))
+
+    const indues = openfiscaBenefits
+      .filter((benefit) => isOutOfTerritory(benefit, situation.menage))
+      .map((benefit) => benefit.openfisca_eligibility_source || benefit.id)
+      .filter((name) => demandees.has(name))
+
+    expect(indues).toEqual([])
+  })
+
+  it("continue de demander les aides du territoire de l'usager", () => {
+    const situation = situationFor(LYON)
+    const demandees = requestedVariables(buildOpenFiscaRequest(situation))
+
+    const duTerritoire = openfiscaBenefits.filter(
+      (benefit) =>
+        ["commune", "departement", "region", "epci"].includes(
+          benefit.institution?.type,
+        ) && !isOutOfTerritory(benefit, situation.menage),
+    )
+
+    // Le catalogue évolue : on vérifie qu'aucune de ces aides n'a disparu de la
+    // requête, sans figer leur nombre.
+    const manquantes = duTerritoire
+      .map((benefit) => benefit.openfisca_eligibility_source || benefit.id)
+      .filter((name) => !demandees.has(name))
+
+    expect(manquantes).toEqual([])
+  })
+
+  it("allège réellement la requête", () => {
+    const complete = requestedVariables(
+      buildOpenFiscaRequest(situationFor(null)),
+    )
+    const ciblee = requestedVariables(buildOpenFiscaRequest(situationFor(LYON)))
+
+    expect(ciblee.size).toBeLessThan(complete.size)
+  })
+
+  it("n'écarte aucun échelon supra-communal quand la commune n'est pas enrichie", () => {
+    // Sans département, région ni EPCI, ces échelons ne sont pas décidables :
+    // en écarter une aide priverait l'usager d'un droit. On éprouve le filtre
+    // lui-même sur tout le catalogue, la requête pouvant omettre une aide pour
+    // d'autres raisons légitimes.
+    const situation = situationFor({ depcom: "69123" })
+
+    const ecartees = openfiscaBenefits.filter(
+      (benefit) =>
+        ["departement", "region", "epci"].includes(benefit.institution?.type) &&
+        isOutOfTerritory(benefit, situation.menage),
+    )
+
+    expect(ecartees).toEqual([])
+  })
+})

--- a/tests/unit/other/territory.spec.ts
+++ b/tests/unit/other/territory.spec.ts
@@ -1,0 +1,99 @@
+import { expect } from "vitest"
+import {
+  isAttachedToInstitution,
+  isOutOfTerritory,
+} from "@lib/benefits/territory.js"
+
+const lyon = {
+  depcom: "69123",
+  _departement: "69",
+  _region: "84",
+  _epci: "200046977",
+} as any
+
+describe("territoire d'une aide", () => {
+  describe("isOutOfTerritory", () => {
+    it.each([
+      ["commune voisine", { type: "commune", code_insee: "69381" }],
+      ["autre département", { type: "departement", code_insee: "75" }],
+      ["autre région", { type: "region", code_insee: "11" }],
+      ["autre EPCI", { type: "epci", code_siren: "200054781" }],
+    ])("exclut une aide portée par %s", (_libelle, institution) => {
+      expect(isOutOfTerritory({ institution }, lyon)).toBe(true)
+    })
+
+    it.each([
+      ["la commune", { type: "commune", code_insee: "69123" }],
+      ["le département", { type: "departement", code_insee: "69" }],
+      ["la région", { type: "region", code_insee: "84" }],
+      ["l'EPCI", { type: "epci", code_siren: "200046977" }],
+    ])("conserve une aide portée par %s de l'usager", (_l, institution) => {
+      expect(isOutOfTerritory({ institution }, lyon)).toBe(false)
+    })
+
+    // Dans le doute, on conserve : une aide écartée à tort est un droit que
+    // l'usager ne verra jamais.
+    it.each([
+      ["institution nationale", { institution: { type: "national" } }, lyon],
+      ["type inconnu", { institution: { type: "syndicat" } }, lyon],
+      ["institution absente", {}, lyon],
+      [
+        "code d'institution manquant",
+        { institution: { type: "commune" } },
+        lyon,
+      ],
+      [
+        "EPCI de l'usager inconnu",
+        { institution: { type: "epci", code_siren: "200054781" } },
+        { ...lyon, _epci: undefined },
+      ],
+      [
+        "département de l'usager inconnu",
+        { institution: { type: "departement", code_insee: "75" } },
+        { ...lyon, _departement: undefined },
+      ],
+      [
+        "commune non renseignée",
+        { institution: { type: "commune", code_insee: "69381" } },
+        {},
+      ],
+      [
+        "ménage absent",
+        { institution: { type: "commune", code_insee: "69381" } },
+        undefined,
+      ],
+    ])("conserve l'aide quand %s", (_l, benefit, menage) => {
+      expect(isOutOfTerritory(benefit as any, menage as any)).toBe(false)
+    })
+  })
+
+  describe("isAttachedToInstitution", () => {
+    it("reconnaît chaque échelon territorial", () => {
+      expect(
+        isAttachedToInstitution({ type: "commune", code_insee: "69123" }, lyon),
+      ).toBe(true)
+      expect(
+        isAttachedToInstitution(
+          { type: "departement", code_insee: "69" },
+          lyon,
+        ),
+      ).toBe(true)
+      expect(
+        isAttachedToInstitution({ type: "region", code_insee: "84" }, lyon),
+      ).toBe(true)
+      expect(
+        isAttachedToInstitution(
+          { type: "epci", code_siren: "200046977" },
+          lyon,
+        ),
+      ).toBe(true)
+    })
+
+    it("rejette un autre territoire et un type non territorial", () => {
+      expect(
+        isAttachedToInstitution({ type: "commune", code_insee: "75056" }, lyon),
+      ).toBe(false)
+      expect(isAttachedToInstitution({ type: "national" }, lyon)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Le constat

La requête envoyée à OpenFisca comprend **toutes** les aides du catalogue portées par
une collectivité, quelle qu'elle soit. Un usager lyonnais fait donc calculer
l'éligibilité aux aides d'Antony, de Montpellier ou de Paris.

Ce ne sont pas les variables elles-mêmes qui coûtent, c'est leur arbre de dépendances :
chacune tire des variables intermédiaires sur douze mois.

## Ce que fait cette PR

Elle retire de la requête les aides portées par une collectivité dont l'usager ne
relève pas.

Le filtrage **réutilise la correspondance institution/territoire qui existe déjà** —
celle qui décide de l'éligibilité géographique des aides calculées en JavaScript
(`attached_to_institution`). Elle est extraite dans `lib/benefits/territory.ts` pour
n'exister qu'à un seul endroit, et le calcul JavaScript s'appuie désormais dessus :
les deux chemins ne peuvent plus diverger.

## La prudence est dans le prédicat

`isOutOfTerritory` ne renvoie vrai que lorsqu'on sait **positivement** que l'usager
n'est pas sur le territoire de l'aide. Donnent faux, donc conservent l'aide :

- une institution non territoriale (nationale, caisse, organisme)
- un type d'institution inconnu
- un code d'institution absent
- une commune dont l'enrichissement n'a pas fourni le département, la région ou l'EPCI

C'est volontaire : une aide écartée à tort est un droit qu'un jeune ne verrait jamais.
Une simulation dont la commune est mal renseignée se comporte donc exactement comme
avant.

## Mesures

OpenFisca lancé en local depuis `openfisca/Dockerfile`, même situation (23 ans,
1 200 € de salaire), trois territoires, 5 mesures après chauffe :

| Territoire | avant | après | |
|---|---|---|---|
| Lyon | 2,043 s | **1,190 s** | −42 % |
| Paris | 2,072 s | **1,208 s** | −42 % |
| Millau | 2,094 s | **1,209 s** | −42 % |

36 à 38 variables retirées sur 102 demandées.

**Aucun montant ne change.** Les réponses complètes sont comparées clé à clé :

```
lyon  : 129 clés communes | écarts=0 | retirées=36 dont non nulles=0
paris : 127 clés communes | écarts=0 | retirées=38 dont non nulles=0
rural : 128 clés communes | écarts=0 | retirées=37 dont non nulles=0
```

Toutes les variables retirées valaient zéro : ce sont des aides auxquelles l'usager
n'avait de toute façon pas droit.

## Vérification

```
$ npx tsc --noEmit -p tsconfig.server.json   → 0 erreur
$ npm run lint                                → 0
$ npx prettier --check .                      → propre
$ npx vitest run --pool=forks                 → 25045 tests passants
```

22 tests ajoutés, dont huit cas qui vérifient explicitement que l'aide est **conservée**
en cas de doute, et un qui éprouve le prédicat sur l'intégralité du catalogue réel.

La sortie en code 1 de la suite vient d'une erreur non gérée `OF maybe offline`
pré-existante sur `main`.

## Portée

Le plafond de calcul mesuré pendant l'incident était d'environ 2 000 à 2 500
simulations/heure à 4 workers, soit ~5 000 depuis le passage à 8. Diviser par ~1,7 le
coût d'un calcul vaudrait un doublement supplémentaire, sans matériel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
