### PR TITLE
fix(followup): authentifie par le jeton les appels qui échouent en iframe

### DIFF
--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -111,7 +111,12 @@ const postFollowup = async (surveyOptin, email?, phone?) => {
     email,
     contactRequired: true,
   }
-  return await axios.post(uri, payload)
+  // Le cookie d'accès est un cookie tiers quand le simulateur est intégré en
+  // iframe : Safari le bloque systématiquement. Le jeton porté par l'en-tête
+  // reste, lui, disponible dans tous les contextes.
+  const token = store.getSimulationToken
+  const headers = token ? { Authorization: `Bearer ${token}` } : undefined
+  return await axios.post(uri, payload, { headers })
 }
 
 const sendRecapByEmailAndSms = async (surveyOptin) => {

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -111,12 +111,7 @@ const postFollowup = async (surveyOptin, email?, phone?) => {
     email,
     contactRequired: true,
   }
-  // Le cookie d'accès est un cookie tiers quand le simulateur est intégré en
-  // iframe : Safari le bloque systématiquement. Le jeton porté par l'en-tête
-  // reste, lui, disponible dans tous les contextes.
-  const token = store.getSimulationToken
-  const headers = token ? { Authorization: `Bearer ${token}` } : undefined
-  return await axios.post(uri, payload, { headers })
+  return await axios.post(uri, payload, { headers: store.authHeaders })
 }
 
 const sendRecapByEmailAndSms = async (surveyOptin) => {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -215,6 +215,7 @@ export const useStore = defineStore("store", {
             `/api/simulation/${
               simulationId || this.simulationId
             }/${representation}`,
+            { headers: this.authHeaders },
           )
           .then((response) => response.data)
       }
@@ -231,6 +232,13 @@ export const useStore = defineStore("store", {
     },
     getSimulationToken(): string | undefined {
       return this.simulation.simulationToken
+    },
+    // Le cookie d'accès est un cookie tiers quand le simulateur est intégré en
+    // iframe : Safari le bloque sans exception. Le jeton porté par l'en-tête
+    // reste, lui, disponible dans tous les contextes.
+    authHeaders(): Record<string, string> | undefined {
+      const token = this.getSimulationToken
+      return token ? { Authorization: `Bearer ${token}` } : undefined
     },
     getFCUserInfoEmailValue() {
       const userinfo = this.simulation.answers.all.find(
@@ -446,7 +454,13 @@ export const useStore = defineStore("store", {
     },
     reset(simulation: Simulation) {
       this.access.fetching = false
-      this.simulation = simulation
+      // Le serveur nomme le jeton `token`, le store `simulationToken` : sans
+      // cette reprise, toute simulation rechargée repart sans jeton d'accès.
+      this.simulation = {
+        ...simulation,
+        simulationToken:
+          simulation.token ?? this.simulation.simulationToken ?? undefined,
+      }
       this.dates = datesGenerator(simulation.dateDeValeur || new Date())
       this.calculs.dirty = false
     },

--- a/src/views/simulation/revenir-plus-tard.vue
+++ b/src/views/simulation/revenir-plus-tard.vue
@@ -19,7 +19,12 @@ const postRecapFollowup = async () => {
   const payload = {
     surveyOptin: false,
   }
-  return await axios.post(uri, payload)
+  // Le cookie d'accès est un cookie tiers quand le simulateur est intégré en
+  // iframe : Safari le bloque systématiquement. Le jeton porté par l'en-tête
+  // reste, lui, disponible dans tous les contextes.
+  const token = store.getSimulationToken
+  const headers = token ? { Authorization: `Bearer ${token}` } : undefined
+  return await axios.post(uri, payload, { headers })
 }
 
 const saveSimulationAndShowLink = async () => {

--- a/src/views/simulation/revenir-plus-tard.vue
+++ b/src/views/simulation/revenir-plus-tard.vue
@@ -19,12 +19,7 @@ const postRecapFollowup = async () => {
   const payload = {
     surveyOptin: false,
   }
-  // Le cookie d'accès est un cookie tiers quand le simulateur est intégré en
-  // iframe : Safari le bloque systématiquement. Le jeton porté par l'en-tête
-  // reste, lui, disponible dans tous les contextes.
-  const token = store.getSimulationToken
-  const headers = token ? { Authorization: `Bearer ${token}` } : undefined
-  return await axios.post(uri, payload, { headers })
+  return await axios.post(uri, payload, { headers: store.authHeaders })
 }
 
 const saveSimulationAndShowLink = async () => {

--- a/tests/unit/components/followup-token.spec.ts
+++ b/tests/unit/components/followup-token.spec.ts
@@ -1,0 +1,120 @@
+import { expect, vi, beforeEach } from "vitest"
+import { mount } from "@vue/test-utils"
+import { setActivePinia, createPinia } from "pinia"
+import axios from "axios"
+
+import { useStore } from "@/stores/index.js"
+import RecapForm from "@/components/recap-email-and-sms-form.vue"
+import ComeBackLater from "@/views/simulation/revenir-plus-tard.vue"
+
+vi.mock("vue-router", () => {
+  const route = {
+    fullPath: "/simulation/resultats",
+    path: "/simulation/resultats",
+  }
+  return {
+    useRouter: () => ({
+      currentRoute: { value: route },
+      push: vi.fn(),
+      go: vi.fn(),
+      replace: vi.fn(),
+    }),
+    useRoute: () => route,
+  }
+})
+
+vi.mock("@/router", () => ({
+  default: {
+    currentRoute: { value: { fullPath: "/x", path: "/x" } },
+    push: vi.fn(),
+    go: vi.fn(),
+    replace: vi.fn(),
+  },
+}))
+
+// Le cookie d'accès est un cookie tiers quand le simulateur est intégré en
+// iframe : Safari le bloque sans exception. Ces enregistrements doivent donc
+// s'authentifier par l'en-tête, seul canal disponible dans tous les contextes.
+describe("le suivi s'authentifie par le jeton, pas par le cookie", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+  })
+
+  it("porte le jeton depuis le formulaire de récapitulatif", async () => {
+    const store = useStore()
+    store.setSimulationToken("TOKEN-A")
+    store.setResults({
+      _id: "sim-1",
+      droitsEligibles: [],
+      droitsInjectes: [],
+    } as any)
+    store.calculs.dirty = false
+
+    const post = vi
+      .spyOn(axios, "post")
+      .mockResolvedValue({ data: { result: "OK" } } as any)
+
+    const wrapper = mount(RecapForm, {
+      global: { stubs: { WarningMessage: true } },
+    })
+    await wrapper.find("input#email").setValue("prenom.nom@beta.gouv.fr")
+    await wrapper.find("form").trigger("submit")
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(post).toHaveBeenCalledOnce()
+    const [url, , config] = post.mock.calls[0]
+    expect(url).toBe("/api/simulation/sim-1/followup")
+    expect((config as any)?.headers?.Authorization).toBe("Bearer TOKEN-A")
+  })
+
+  it("porte le jeton issu du save() qui précède, depuis « revenir plus tard »", async () => {
+    const store = useStore()
+    const post = vi
+      .spyOn(axios, "post")
+      .mockImplementation(async (url: string) => {
+        if (url === "/api/simulation") {
+          return { data: { _id: "sim-2", token: "TOKEN-B" } } as any
+        }
+        return {
+          data: { simulationRecapUrl: "https://exemple.test/s/t/abc" },
+        } as any
+      })
+
+    const wrapper = mount(ComeBackLater)
+    await wrapper
+      .find('[data-testid="temporary-save-simulation-button"]')
+      .trigger("click")
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const followupCall = post.mock.calls.find(([url]) =>
+      String(url).includes("/followup"),
+    )
+    expect(followupCall?.[0]).toBe("/api/simulation/sim-2/followup")
+    expect((followupCall?.[2] as any)?.headers?.Authorization).toBe(
+      "Bearer TOKEN-B",
+    )
+  })
+
+  it("conserve le jeton quand une simulation est rechargée", () => {
+    const store = useStore()
+    store.setSimulationToken("TOKEN-C")
+
+    // Le serveur nomme le jeton `token` ; sans reprise explicite, l'affectation
+    // en bloc de `reset` l'effacerait et l'en-tête repartirait vide.
+    store.reset({
+      _id: "sim-3",
+      token: "TOKEN-D",
+      answers: store.simulation.answers,
+    } as any)
+
+    expect(store.getSimulationToken).toBe("TOKEN-D")
+    expect(store.authHeaders).toEqual({ Authorization: "Bearer TOKEN-D" })
+  })
+
+  it("n'envoie aucun en-tête d'autorisation en l'absence de jeton", () => {
+    const store = useStore()
+    expect(store.getSimulationToken).toBeUndefined()
+    expect(store.authHeaders).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Constat

**83 % des enregistrements de suivi sont refusés** (`POST /api/simulation/:id/followup` → 403). L'usager qui demande ses résultats par courriel ou SMS ne les reçoit pas, et l'échec est silencieux.

Mesuré sur les journaux des 5 et 6 août : 24 506 refus sur 29 463 le 5, 29 610 sur 35 599 le 6. Le 4 août, avant le pic, le taux était de 14 %.

## Cause

Le simulateur est massivement intégré **en iframe** sur www.jeunes.gouv.fr — 83 % du trafic au pic. Le contexte est donc tiers, et le cookie d'accès posé par `attachAccessCookie` (`sameSite: "none"; secure`) est **bloqué par Safari sans exception** (ITP), de plus en plus par Chrome. `validateAccess` répond alors 403.

La séparation est nette, sur ~190 000 requêtes passant toutes par le même middleware :

| route | total | 403 | % | envoie le jeton |
|---|---|---|---|---|
| `POST /api/simulation` | 77 889 | 0 | 0 % | — |
| `GET /api/simulation/:id/results` | 68 775 | 0 | **0 %** | oui |
| `GET /api/simulation/:id` | 5 855 | 0 | **0 %** | oui |
| `GET /api/simulation/:id/followup` | 52 | 0 | **0 %** | oui |
| `POST /api/simulation/:id/followup` | 34 317 | 31 121 | **90,7 %** | non |
| `GET /api/simulation/:id/{openfisca_axe,openfisca_tracer,PNDS}` | 1 722 | 1 335 | **77,5 %** | non |

**0 % de refus sur les 74 682 requêtes portant le jeton, 77–91 % sur les 35 465 qui ne le portent pas.** Mêmes sessions, mêmes navigateurs, même middleware.

Par navigateur, sur `POST /followup` : **Safari 96,8 %**, Chrome 48,2 %, autres 16,8 % — le gradient exact des politiques de cookies tiers.

## Correctif

`isAccessible` accepte déjà `Authorization: Bearer <jeton>`. Trois appels du front le transmettaient, les autres non. Cette PR :

- ajoute l'en-tête aux deux enregistrements de suivi et à `fetchRepresentation` (téléservices) ;
- corrige `reset`, qui effaçait le jeton à chaque rechargement de simulation — le serveur le nomme `token`, le store `simulationToken` ;
- regroupe la construction de l'en-tête, jusque-là recopiée sous deux formes, dans un getter `authHeaders`.

## ⚠️ À connaître avant de déployer

`FollowupFactory.createWithResults` appelle `simulation.compute()` : **un calcul OpenFisca complet** pour chaque enregistrement porteur d'un courriel ou d'un téléphone. Aujourd'hui 83 % de ces requêtes s'arrêtent sur le 403 avant tout calcul ; après ce correctif, elles calculeront toutes.

Or `/followup` partage la **même `limit_conn simulation_concurrency` que `/results`**. Ordre de grandeur mesuré sur une fenêtre saine : **+17,7 % de demande de calcul OpenFisca**, en bas de l'entonnoir, sur l'enveloppe plafonnée après l'incident 504.

Deux conséquences à assumer :

1. **Surveiller le plafond de concurrence** après déploiement (les 503 sur `/results`), pas seulement les 5xx.
2. **Atténuation possible, non incluse ici** : `persist` recalcule ce que `GET /results` vient de calculer quelques secondes plus tôt pour la même simulation. Réutiliser ce calcul supprimerait entièrement le surcoût.

Le volume d'envois augmente aussi : parmi les enregistrements qui aboutissent aujourd'hui, 24,1 % déclenchent un courriel ou un SMS. Cette proportion est mesurée sur les requêtes **réussies**, majoritairement hors iframe ; rien ne garantit qu'elle vaille pour les requêtes refusées, majoritairement en iframe. À prendre comme un ordre de grandeur, pas comme une prévision.

## Vérification

Revue adversariale menée sur le premier commit ; ses findings HAUT et MOYEN sont traités ici ou documentés ci-dessus.

- `npx prettier --check .` ✓ · `npm run lint` ✓ (0 warning) · `npm run build` ✓ (serveur, iframes, front)
- `npm test` → **49 fichiers, 25 026 tests passent**. L'erreur résiduelle est le `OF maybe offline` déjà présent sur `main`.
- Test de non-régression ajouté, **éprouvé contre `origin/main` : 3 de ses 4 cas y échouent**, le quatrième étant le cas neutre sans jeton. Il monte les vrais composants sur le vrai store et assert sur l'en-tête réellement transmis à axios — les tests Cypress ne peuvent pas attraper ce défaut, ils tournent en contexte premier où le cookie fonctionne.

Vérifié sans finding : l'URI reste relative et aucun interceptor axios n'existe côté front, donc le jeton ne part pas vers un tiers ; Sentry ne le fait pas fuiter (testé sur un 403 réel) ; nginx ne journalise pas les en-têtes ; `headers: undefined` n'écrase pas le `Content-Type` (testé contre un vrai serveur) ; le correctif est purement additif, un cookie valide continue de suffire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)