### PR TITLE
fix(openfisca): budgète le tracé sur un axe selon son coût réel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,9 +27,13 @@ OPENFISCA_AXE_URL=
 OPENFISCA_PUBLIC_ROOT_URL=
 OPENFISCA_TRACER_URL=
 # Délai d'abandon de l'appel Node -> OpenFisca, en ms (défaut 25000).
-# Doit rester inférieur à OPENFISCA_TIMEOUT (secondes, défaut 30).
+# Doit rester inférieur à OPENFISCA_TIMEOUT (secondes, défaut 90).
 OPENFISCA_TIMEOUT_MS=
-# Délai gunicorn avant recyclage d'un worker OpenFisca, en secondes (défaut 30).
+# Idem pour le tracé d'une variable sur un axe, qui empile 141 situations dans
+# une seule requête et coûte un multiple d'un calcul ordinaire (défaut 60000).
+OPENFISCA_BULK_TIMEOUT_MS=
+# Délai gunicorn avant recyclage d'un worker OpenFisca, en secondes (défaut 90).
+# Couvre le plus long appel légitime, donc OPENFISCA_BULK_TIMEOUT_MS.
 OPENFISCA_TIMEOUT=
 
 PIVOT_URL=

--- a/backend/config/index.ts
+++ b/backend/config/index.ts
@@ -52,6 +52,10 @@ const config: Configuration = {
   // Doit rester inférieur au `timeout` gunicorn d'OpenFisca (openfisca/config.py) :
   // abandonner côté client ne libère pas le worker, c'est gunicorn qui le recycle.
   openfiscaTimeout: Number(process.env.OPENFISCA_TIMEOUT_MS) || 25000,
+  // Le tracé d'une variable sur un axe empile 141 situations dans une seule
+  // requête : mesuré à 12 s sur un poste de développement, il dépasse les 25 s
+  // sur une machine de CI. Même contrainte vis-à-vis de gunicorn.
+  openfiscaBulkTimeout: Number(process.env.OPENFISCA_BULK_TIMEOUT_MS) || 60000,
   openfiscaAxeURL: isProduction
     ? "https://betagouv.github.io/mes-aides-changent"
     : "http://127.0.0.1:3000",

--- a/backend/lib/openfisca/index.ts
+++ b/backend/lib/openfisca/index.ts
@@ -40,7 +40,14 @@ export function normalizeError(err: any) {
   }
 }
 
-export function sendToOpenfisca(endpoint, transform?: any) {
+// `config.openfiscaTimeout` budgète le calcul d'une situation. Un appel qui en
+// empile plusieurs — le tracé d'une variable sur un axe — coûte un multiple de
+// ce temps et déclare son propre budget.
+export function sendToOpenfisca(
+  endpoint,
+  transform?: any,
+  { timeout = config.openfiscaTimeout }: { timeout?: number } = {},
+) {
   if (!transform) {
     transform = buildOpenFiscaRequest
   }
@@ -55,9 +62,7 @@ export function sendToOpenfisca(endpoint, transform?: any) {
     }
 
     axios
-      .post(`${config.openfiscaURL}/${endpoint}`, request, {
-        timeout: config.openfiscaTimeout,
-      })
+      .post(`${config.openfiscaURL}/${endpoint}`, request, { timeout })
       .then((response) => {
         // Une réponse vide n'est pas un résultat : la laisser passer ferait
         // échouer le calcul des aides plus loin, hors du chemin d'erreur.

--- a/backend/lib/teleservices/openfisca-axe.ts
+++ b/backend/lib/teleservices/openfisca-axe.ts
@@ -1,10 +1,15 @@
 import Promise from "bluebird"
 
+import config from "../../config/index.js"
 import openfiscaImport from "../openfisca/index.js"
 
 const openfisca = Promise.promisifyAll(openfiscaImport)
+// La requête empile une situation par point du tracé : son coût est celui d'un
+// calcul ordinaire multiplié par leur nombre, d'où un budget distinct.
 const request = Promise.promisify(
-  openfisca.sendToOpenfisca("calculate", (s) => s),
+  openfisca.sendToOpenfisca("calculate", (s) => s, {
+    timeout: config.openfiscaBulkTimeout,
+  }),
 )
 
 import bulk from "../openfisca/bulk/index.js"

--- a/backend/types/config.d.ts
+++ b/backend/types/config.d.ts
@@ -18,6 +18,7 @@ export interface Configuration {
   }
   openfiscaURL: string
   openfiscaTimeout: number
+  openfiscaBulkTimeout: number
   openfiscaAxeURL: string
   openfiscaPublicURL: string
   openfiscaTracerURL: string

--- a/openfisca/config.py
+++ b/openfisca/config.py
@@ -2,10 +2,15 @@ import os
 
 port = os.getenv('OPENFISCA_PORT', '2000')
 bind = os.getenv('OPENFISCA_BIND_HOST', '127.0.0.1:' + port)
-# Un calcul normal prend quelques secondes. Au-delà, le worker est tué et
-# recyclé plutôt que de rester immobilisé : avec un pool de workers sync,
-# chaque worker bloqué retire une place de concurrence à tout le cluster.
-timeout = int(os.getenv('OPENFISCA_TIMEOUT') or 30)
+# Chien de garde : au-delà, le worker est tué et recyclé plutôt que de rester
+# immobilisé — avec un pool de workers sync, chaque worker bloqué retire une
+# place de concurrence à tout le cluster.
+#
+# Le seuil couvre le plus long appel légitime, et non le plus courant : le tracé
+# d'une variable sur un axe empile 141 situations dans une seule requête. Il
+# doit donc rester supérieur à OPENFISCA_BULK_TIMEOUT_MS côté Node, sans quoi
+# c'est gunicorn qui interromprait un calcul que le client attend encore.
+timeout = int(os.getenv('OPENFISCA_TIMEOUT') or 90)
 workers = os.getenv('OPENFISCA_WORKERS', 8)
 
 profiler = False

--- a/tests/unit/backend/openfisca-error-handling.spec.ts
+++ b/tests/unit/backend/openfisca-error-handling.spec.ts
@@ -11,6 +11,7 @@ vi.mock("@backend/lib/migrations/index.js", () => ({
 }))
 
 import axios from "axios"
+import config from "@backend/config/index.js"
 import { sendToOpenfisca } from "@backend/lib/openfisca/index.js"
 import simulationController from "@backend/controllers/simulation.js"
 import teleservices from "@backend/controllers/teleservices/index.js"
@@ -140,6 +141,30 @@ describe("remontée des erreurs OpenFisca", () => {
       )
 
       expect(err).toEqual({ error: "unknown variable" })
+    })
+
+    // Le budget par défaut vaut pour le calcul d'une situation. Le tracé d'une
+    // variable sur un axe en empile 141 dans une seule requête et coûte un
+    // multiple de ce temps : sans budget propre, il est abandonné en vol.
+    it("budgète chaque appel selon son coût", async () => {
+      vi.mocked(axios.post).mockResolvedValue({ data: {} })
+
+      await callbackOf((cb) => sendToOpenfisca("calculate", () => ({}))({}, cb))
+      expect(vi.mocked(axios.post).mock.calls[0][2]).toEqual({
+        timeout: config.openfiscaTimeout,
+      })
+
+      await callbackOf((cb) =>
+        sendToOpenfisca("calculate", () => ({}), {
+          timeout: config.openfiscaBulkTimeout,
+        })({}, cb),
+      )
+      expect(vi.mocked(axios.post).mock.calls[1][2]).toEqual({
+        timeout: config.openfiscaBulkTimeout,
+      })
+      expect(config.openfiscaBulkTimeout).toBeGreaterThan(
+        config.openfiscaTimeout,
+      )
     })
   })
 


### PR DESCRIPTION
## Constat

Le job **End-to-End Tests (base)** est rouge sur `main`. Le seul test du spec échoue :

```
CypressError: cy.request() failed on:
http://localhost:8080/api/simulation/via/***
  > 500: Internal Server Error
```

**C'est une régression de #5205, que j'ai introduite ce matin.** Je l'avais d'abord classée « antérieure à nos travaux » en constatant l'échec sur `de82669f` — sans voir que ce commit *est* le merge de #5205. `git log -S "openfiscaTimeout" -- backend/config/index.ts` ne remonte que lui.

## Cause

#5205 a posé un délai d'abandon axios **global de 25 s** sur tous les appels Node → OpenFisca. Un appel n'est pas comme les autres : `openfisca_axe` empile **141 situations dans une seule requête `/calculate`** (282 individus, 1 096 variables) pour tracer les aides en fonction du salaire. Il coûte structurellement un multiple d'un calcul ordinaire.

```
OpenFisca calculate request failed timeout of 25000ms exceeded
{ name: 'AxiosError', code: 'ECONNABORTED', message: 'timeout of 25000ms exceeded' }
"GET /api/simulation/via/*** HTTP/1.1" 500 83
```

Chemin : `exportRepresentation` → `OpenFiscaAxe.toExternal` → `sendToOpenfisca("calculate")` → abandon → `.catch(next)` → 500.

Durées mesurées sur la situation réelle du test :

| appel | durée |
|---|---|
| `/calculate` sur une situation | 2,2 – 3,6 s |
| axe, 141 points, 1 requête | **12,2 s** (32 cœurs) / **15,8 s** (épinglé sur 2 cœurs) |

Le runner GitHub partage 4 vCPU avec Chrome et Node : au-delà de 25 s. La machine de production, elle, tient — **vérifié sur les journaux du jour : 128 réponses 200 sur `openfisca_axe`, 146 sur `simulation/via`, aucun 5xx, aucun timeout upstream.** L'incident est donc confiné à la CI, mais le risque redevient réel dès que la machine est chargée.

## Correctif

Le budget devient **propre à chaque appel** plutôt que global : `sendToOpenfisca` accepte un `timeout`, et le tracé sur un axe déclare le sien (`openfiscaBulkTimeout`, 60 s, réglable par `OPENFISCA_BULK_TIMEOUT_MS`).

Aucun `try/catch` ajouté, aucun chemin d'erreur adouci : un dépassement de 60 s produit toujours le même 500 explicite. Seule la taille du budget change.

### Découper la requête serait pire — mesuré, pas supposé

OpenFisca vectorise les situations empilées ; les découper détruit ce gain :

| découpage | séquentiel | parallèle |
|---|---|---|
| 1 × 141 points | **12,2 s** | — |
| 6 × 24 points | 24,3 s | 12,3 s |
| 12 × 12 points | 37,7 s | 19,2 s |
| 141 × 1 point | 326 s | 170 s |

Le découpage parallèle n'améliore pas la durée et mobiliserait 6 workers au lieu d'un.

### Le point à assumer : le chien de garde gunicorn passe de 30 s à 90 s

`timeout` gunicorn est **global et par worker** : il doit couvrir le plus long appel légitime, sinon il interromprait un calcul que le client attend encore. Avec un budget client de 60 s, le chien de garde doit lui rester supérieur.

C'est un desserrage partiel de ce que #5205 avait resserré, et il mérite d'être pesé plutôt que subi :

- l'invariant de #5205 (budget client < chien de garde) tient dans les deux cas : 25 < 90 et 60 < 90 ;
- 90 s reste **sous les 120 s** en vigueur avant #5205 ;
- le chien de garde ne freine pas le débit, il ne tue que les workers immobilisés — un calcul ordinaire prend 2 à 4 s ;
- coût réel du tracé sur un axe en production : **128 appels par jour × ~15 s ≈ 1 900 secondes-worker**, contre 691 200 disponibles (8 workers × 24 h). **0,3 %.**

`OPENFISCA_TIMEOUT` n'étant pas défini dans l'unité systemd (vérifié sur la machine de production), ce nouveau défaut s'applique automatiquement : **aucun changement côté ops n'est nécessaire.**

## Vérification

Le test passe en local avec les valeurs par défaut (l'axe y tient en 14 s < 25 s). Pour reproduire fidèlement la CI, le budget ordinaire a été ramené à 8 s — modèle à la même échelle (calcul normal 3,6 s ✓, axe 15,8 s ✗) :

| état | `OPENFISCA_TIMEOUT_MS` | résultat |
|---|---|---|
| avant correctif | 8000 | **1 failing** — même route, même corps `ECONNABORTED`, même ligne de journal qu'en CI |
| après correctif | 8000 | **1 passing** (47,7 s) |
| après correctif | défaut | **1 passing** (52 s) |

Portes de CI, sur l'arbre final : `npx prettier --check .` ✓ · `npm run lint` ✓ · `npm test` ✓ (49 fichiers, 25 027 tests) · `npm run build` ✓.

## Piste de fond, non prise ici

OpenFisca-Core sait nativement traiter les `axes` dans `SimulationBuilder.build_from_entities`. `backend/lib/openfisca/bulk` en est une réimplémentation manuelle par préfixage d'entités. Passer aux axes natifs rendrait cet appel ordinaire — mais change la forme de la réponse et impose de réécrire `extractResults`, avec un vrai risque sur les données du graphique. À évaluer séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)