### PR TITLE
fix(openfisca): rend leurs résultats aux usagers déclarant un taux d'incapacité

### DIFF
--- a/backend/lib/migrations/simulations/to-v18.ts
+++ b/backend/lib/migrations/simulations/to-v18.ts
@@ -1,0 +1,40 @@
+/*
+ * Supprime les réponses `taux_incapacite` enregistrées sans valeur exploitable.
+ *
+ * Les paliers de cette question sont les seuls du simulateur à être calculés à
+ * partir d'un paramètre OpenFisca. Lorsque ce paramètre manquait, deux des
+ * trois options valaient NaN — que JSON écrit `null` — et cette valeur
+ * s'enregistrait à la place de la réponse. Le taux choisi est alors
+ * irrécupérable : les deux paliers hauts donnaient le même NaN.
+ *
+ * La réponse est retirée plutôt que devinée : l'étape redevient sans réponse et
+ * la question est reposée, avec des paliers désormais corrects. Corriger un
+ * taux au jugé ferait varier l'AAH de plus de quatre cents euros par mois.
+ */
+
+const VERSION = 18
+
+function isUsableTaux(value) {
+  return typeof value === "number" && Number.isFinite(value)
+}
+
+function removeUnusableTauxIncapacite(answers) {
+  return answers.filter(
+    (answer) =>
+      answer.fieldName !== "taux_incapacite" || isUsableTaux(answer.value),
+  )
+}
+
+export default {
+  apply(simulation) {
+    simulation.answers.all = removeUnusableTauxIncapacite(
+      simulation.answers.all,
+    )
+    simulation.answers.current = removeUnusableTauxIncapacite(
+      simulation.answers.current,
+    )
+
+    return simulation
+  },
+  version: VERSION,
+}

--- a/backend/lib/migrations/simulations/to-v18.ts
+++ b/backend/lib/migrations/simulations/to-v18.ts
@@ -12,24 +12,21 @@
  * taux au jugé ferait varier l'AAH de plus de quatre cents euros par mois.
  */
 
-import { fieldsToAnswerAgain } from "../../../../lib/simulation.js"
+import {
+  fieldsToAnswerAgain,
+  isUnusableAnswer,
+} from "../../../../lib/simulation.js"
 
 const VERSION = 18
 
-// Seule la corruption réellement produite est visée : `null`, ce que JSON écrit
-// d'un NaN. Écarter par le type retirerait une chaîne — « 0.9 » — qu'OpenFisca
-// accepte, et que `POST /api/simulation`, public, peut légitimement recevoir.
-function isUnusableValue(value) {
-  return (
-    value === null || (typeof value === "number" && !Number.isFinite(value))
-  )
-}
-
+// Seule la corruption réellement produite est visée. Écarter par le type
+// retirerait une chaîne — « 0.9 » — qu'OpenFisca accepte, et que
+// `POST /api/simulation`, public, peut légitimement recevoir.
 function removeUnusableAnswers(answers) {
   return answers.filter(
     (answer) =>
       !fieldsToAnswerAgain.includes(answer.fieldName) ||
-      !isUnusableValue(answer.value),
+      !isUnusableAnswer(answer.value),
   )
 }
 

--- a/backend/lib/migrations/simulations/to-v18.ts
+++ b/backend/lib/migrations/simulations/to-v18.ts
@@ -12,25 +12,31 @@
  * taux au jugé ferait varier l'AAH de plus de quatre cents euros par mois.
  */
 
+import { fieldsToAnswerAgain } from "../../../../lib/simulation.js"
+
 const VERSION = 18
 
-function isUsableTaux(value) {
-  return typeof value === "number" && Number.isFinite(value)
+// Seule la corruption réellement produite est visée : `null`, ce que JSON écrit
+// d'un NaN. Écarter par le type retirerait une chaîne — « 0.9 » — qu'OpenFisca
+// accepte, et que `POST /api/simulation`, public, peut légitimement recevoir.
+function isUnusableValue(value) {
+  return (
+    value === null || (typeof value === "number" && !Number.isFinite(value))
+  )
 }
 
-function removeUnusableTauxIncapacite(answers) {
+function removeUnusableAnswers(answers) {
   return answers.filter(
     (answer) =>
-      answer.fieldName !== "taux_incapacite" || isUsableTaux(answer.value),
+      !fieldsToAnswerAgain.includes(answer.fieldName) ||
+      !isUnusableValue(answer.value),
   )
 }
 
 export default {
   apply(simulation) {
-    simulation.answers.all = removeUnusableTauxIncapacite(
-      simulation.answers.all,
-    )
-    simulation.answers.current = removeUnusableTauxIncapacite(
+    simulation.answers.all = removeUnusableAnswers(simulation.answers.all)
+    simulation.answers.current = removeUnusableAnswers(
       simulation.answers.current,
     )
 

--- a/backend/lib/openfisca/parameters.ts
+++ b/backend/lib/openfisca/parameters.ts
@@ -2,14 +2,10 @@ import * as Sentry from "@sentry/node"
 import openfisca from "./getter.js"
 
 import { OpenfiscaParameters } from "../../../lib/types/parameters.js"
+// La liste est partagée avec le navigateur, qui s'en sert de valeur initiale.
+import { parametersList } from "../../../lib/openfisca-parameters.js"
 
-export const parametersList: OpenfiscaParameters = {
-  "prestations_sociales.education.carte_des_metiers.age_maximal": 26,
-  "prestations_sociales.prestations_etat_de_sante.invalidite.aah.taux_capacite.taux_incapacite": 0.8,
-  "taxation_capital.epargne.livret_a.taux": 0.005,
-  "marche_travail.salaire_minimum.smic.smic_b_horaire": 10.57,
-  "marche_travail.salaire_minimum.smic.nb_heures_travail_mensuel": 151.67,
-}
+export { parametersList }
 
 // Délai avant qu'une tentative échouée puisse être relancée. Sans lui, chaque
 // appel de `getParameters` — un par droit calculé — repartirait sur le réseau

--- a/backend/lib/openfisca/parameters.ts
+++ b/backend/lib/openfisca/parameters.ts
@@ -14,6 +14,11 @@ export const parametersList: OpenfiscaParameters = {
 // Délai avant qu'une tentative échouée puisse être relancée. Sans lui, chaque
 // appel de `getParameters` — un par droit calculé — repartirait sur le réseau
 // et s'ajouterait à la charge d'un OpenFisca déjà en difficulté.
+//
+// Ce qu'il coûte, en regard : pendant une panne, une tentative toutes les
+// trente secondes quelle que soit la charge, soit six cents requêtes par heure
+// et par processus, bornées par le temps et non par le trafic. C'est le prix
+// d'un rétablissement en trente secondes plutôt qu'au redémarrage.
 const FAILURE_COOLDOWN_MS = 30_000
 
 let parameterPromise

--- a/backend/lib/openfisca/parameters.ts
+++ b/backend/lib/openfisca/parameters.ts
@@ -11,6 +11,11 @@ export const parametersList: OpenfiscaParameters = {
   "marche_travail.salaire_minimum.smic.nb_heures_travail_mensuel": 151.67,
 }
 
+// Délai avant qu'une tentative échouée puisse être relancée. Sans lui, chaque
+// appel de `getParameters` — un par droit calculé — repartirait sur le réseau
+// et s'ajouterait à la charge d'un OpenFisca déjà en difficulté.
+const FAILURE_COOLDOWN_MS = 30_000
+
 let parameterPromise
 let parameters
 
@@ -30,10 +35,28 @@ async function fetchParameters() {
 
 function requestParameters() {
   if (!parameterPromise) {
-    parameterPromise = fetchParameters().then((values) => {
-      parameters = values
-      return values
-    })
+    parameterPromise = fetchParameters()
+      .then((values) => {
+        parameters = values
+        return values
+      })
+      // Une tentative échouée n'est pas conservée indéfiniment : elle figerait
+      // une indisponibilité passagère d'OpenFisca pour toute la durée de vie du
+      // processus, et les paramètres resteraient sur leurs valeurs de repli
+      // jusqu'au redémarrage.
+      .catch((error) => {
+        const retry: any = setTimeout(() => {
+          parameterPromise = undefined
+        }, FAILURE_COOLDOWN_MS)
+        // `unref` n'existe que sur les minuteurs de Node : ce délai d'attente
+        // ne doit pas à lui seul retenir un processus prêt à se terminer.
+        retry.unref?.()
+        throw error
+      })
+    // `getParameters` est synchrone et ne peut pas attendre cette promesse :
+    // sans ce gestionnaire terminal, son rejet abattrait le processus. L'échec
+    // est déjà journalisé par le getter et signalé par `computeParameter`.
+    parameterPromise.catch(() => undefined)
   }
   return parameterPromise
 }
@@ -76,7 +99,20 @@ export function getParameters(date): OpenfiscaParameters {
 }
 
 export async function getParametersAsync(date): Promise<OpenfiscaParameters> {
-  await requestParameters()
+  try {
+    await requestParameters()
+  } catch (error: any) {
+    // Échouer ici priverait le navigateur de TOUT paramètre. Les paliers de la
+    // question du taux d'incapacité se calculent à partir de l'un d'eux : sans
+    // lui, deux des trois options vaudraient NaN, que JSON écrit `null`, et
+    // cette valeur s'enregistrerait définitivement à la place de la réponse.
+    // `computeParameter` sert alors les valeurs de `parametersList` et le
+    // signale à Sentry : le repli est daté, tracé, et jamais muet.
+    console.error(
+      "OpenFisca parameters unavailable, serving fallback values",
+      error.message,
+    )
+  }
   return getParameters_(date)
 }
 

--- a/lib/openfisca-parameters.ts
+++ b/lib/openfisca-parameters.ts
@@ -1,0 +1,17 @@
+import { OpenfiscaParameters } from "./types/parameters.js"
+
+// Valeurs servies tant qu'OpenFisca n'a pas répondu, côté serveur comme côté
+// navigateur. Un paramètre absent n'est pas neutre : les options de la question
+// du taux d'incapacité se calculent à partir de l'un d'eux et vaudraient NaN,
+// que JSON écrit `null` — cette valeur s'enregistrerait à la place de la
+// réponse, définitivement.
+//
+// Ce sont des valeurs figées, servies à titre transitoire : `computeParameter`
+// signale à Sentry chaque recours à cette liste.
+export const parametersList: OpenfiscaParameters = {
+  "prestations_sociales.education.carte_des_metiers.age_maximal": 26,
+  "prestations_sociales.prestations_etat_de_sante.invalidite.aah.taux_capacite.taux_incapacite": 0.8,
+  "taxation_capital.epargne.livret_a.taux": 0.005,
+  "marche_travail.salaire_minimum.smic.smic_b_horaire": 10.57,
+  "marche_travail.salaire_minimum.smic.nb_heures_travail_mensuel": 151.67,
+}

--- a/lib/openfisca-parameters.ts
+++ b/lib/openfisca-parameters.ts
@@ -7,11 +7,14 @@ import { OpenfiscaParameters } from "./types/parameters.js"
 // réponse, définitivement.
 //
 // Ce sont des valeurs figées, servies à titre transitoire : `computeParameter`
-// signale à Sentry chaque recours à cette liste.
+// signale à Sentry chaque recours à cette liste. Certaines sont affichées telles
+// quelles — le taux du livret A apparaît dans la légende du LEP : les laisser
+// vieillir revient à écrire un chiffre faux à l'écran. Relevées sur OpenFisca,
+// applicables au 2026-08.
 export const parametersList: OpenfiscaParameters = {
   "prestations_sociales.education.carte_des_metiers.age_maximal": 26,
   "prestations_sociales.prestations_etat_de_sante.invalidite.aah.taux_capacite.taux_incapacite": 0.8,
-  "taxation_capital.epargne.livret_a.taux": 0.005,
-  "marche_travail.salaire_minimum.smic.smic_b_horaire": 10.57,
+  "taxation_capital.epargne.livret_a.taux": 0.015,
+  "marche_travail.salaire_minimum.smic.smic_b_horaire": 12.31,
   "marche_travail.salaire_minimum.smic.nb_heures_travail_mensuel": 151.67,
 }

--- a/lib/simulation.ts
+++ b/lib/simulation.ts
@@ -1,1 +1,7 @@
 export const version = 18
+
+// Réponses que la migration v18 retire lorsque leur valeur enregistrée est
+// inexploitable. Le taux choisi est irrécupérable : la question doit être
+// reposée avant tout affichage de résultats, sinon le droit qui en dépend
+// manquerait sur une page d'apparence complète.
+export const fieldsToAnswerAgain = ["taux_incapacite"]

--- a/lib/simulation.ts
+++ b/lib/simulation.ts
@@ -1,1 +1,1 @@
-export const version = 17
+export const version = 18

--- a/lib/simulation.ts
+++ b/lib/simulation.ts
@@ -1,7 +1,23 @@
 export const version = 18
 
-// Réponses que la migration v18 retire lorsque leur valeur enregistrée est
-// inexploitable. Le taux choisi est irrécupérable : la question doit être
-// reposée avant tout affichage de résultats, sinon le droit qui en dépend
-// manquerait sur une page d'apparence complète.
+// Réponses dont la valeur enregistrée a pu être perdue, et qui doivent alors
+// être reposées plutôt que devinées : le taux d'incapacité fait varier l'AAH de
+// plus de mille euros par mois.
+//
+// Attention avant d'allonger cette liste : la garde des résultats renvoie dans
+// le parcours TOUTE simulation vivante à qui la réponse manque, migrée ou non.
+// Un nom ajouté sans migration correspondante y renverrait aussitôt les
+// simulations qui ne l'ont jamais eue. Une question nouvelle se traite comme
+// `to-v15`, qui fabrique la réponse manquante et n'a besoin d'aucune garde.
 export const fieldsToAnswerAgain = ["taux_incapacite"]
+
+// `null` est ce que JSON écrit d'un NaN : la question a bien été posée, mais la
+// valeur choisie est perdue. Une chaîne, elle, reste exploitable — OpenFisca
+// l'accepte — et n'a pas à être écartée.
+export function isUnusableAnswer(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (typeof value === "number" && !Number.isFinite(value))
+  )
+}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia"
 import dayjs from "dayjs"
 import { version } from "@lib/simulation.js"
+import { parametersList } from "@lib/openfisca-parameters.js"
 import { datesGenerator } from "@lib/dates.js"
 import { generateAllSteps } from "@lib/state/generator.js"
 import { getAnswer, isStepAnswered, storeAnswer } from "@lib/answers.js"
@@ -68,7 +69,12 @@ function defaultStore(): Store {
     title: null,
     modalState: null,
     saveSituationError: null,
-    openFiscaParameters: {},
+    // Les paramètres partent des valeurs de repli — celles-là mêmes que le
+    // serveur sert quand OpenFisca ne répond pas — et sont remplacés dès que la
+    // requête aboutit. Un dictionnaire vide n'est pas une absence sans
+    // conséquence : les options d'une question calculée à partir d'un paramètre
+    // vaudraient NaN, et cette valeur s'enregistrerait comme réponse.
+    openFiscaParameters: { ...parametersList },
     recapEmailState: undefined,
     recapPhoneState: undefined,
     external_id: undefined,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -579,7 +579,11 @@ export const useStore = defineStore("store", {
       return axios
         .get(`/api/openfisca/parameters/${date.toISOString()}`)
         .then((response) => {
-          this.openFiscaParameters = response.data
+          // Fusion, et non remplacement : un 200 au corps inattendu — page
+          // d'erreur d'un intermédiaire, réponse tronquée — laisserait sinon un
+          // paramètre indéfini, et les options qui s'en déduisent vaudraient
+          // NaN. Le repli est un plancher, pas seulement un état initial.
+          this.openFiscaParameters = { ...parametersList, ...response.data }
         })
         .catch(() => undefined) // Prevent unhandled promise rejection noise in Sentry on network hiccups.
     },

--- a/src/views/simulation/resultats/resultats-wrapper.vue
+++ b/src/views/simulation/resultats/resultats-wrapper.vue
@@ -92,8 +92,12 @@ const askUnusableAnswerAgain = (): boolean => {
 // une page qui ne sera jamais affichée pèse sur le service même dont la
 // saturation est en cause.
 const restoreLatestSimulation = async () => {
+  // Sans identifiant en cookie, la restauration renvoie vers l'accueil sans
+  // rien charger. `simulationId` peut pourtant survivre de la session
+  // précédente : s'y fier lancerait un calcul sur une page déjà quittée.
+  const restoredId = Simulation.getLatestId()
   await Simulation.restoreLatestSimulationWithoutResultsComputing()
-  if (!store.simulationId || store.simulationAnonymized) {
+  if (!restoredId || !store.simulationId || store.simulationAnonymized) {
     return
   }
   if (askUnusableAnswerAgain()) {

--- a/src/views/simulation/resultats/resultats-wrapper.vue
+++ b/src/views/simulation/resultats/resultats-wrapper.vue
@@ -8,8 +8,8 @@ import { daysSinceDate } from "@lib/utils.js"
 import { EventAction, EventCategory } from "@lib/enums/event.js"
 import Simulation from "@/lib/simulation.js"
 import MockResults from "@/lib/mock-results"
-import { fieldsToAnswerAgain } from "@lib/simulation.js"
-import { isStepAnswered } from "@lib/answers.js"
+import { fieldsToAnswerAgain, isUnusableAnswer } from "@lib/simulation.js"
+import { getStepAnswer } from "@lib/answers.js"
 import { computed, onMounted, onBeforeUnmount, ref } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import * as Sentry from "@sentry/vue"
@@ -36,15 +36,16 @@ onMounted(async () => {
     MockResults.mock(route.params.benefitId)
     return
   }
-  // Simulation déjà chargée — lien de relance, retour dans le parcours : la
-  // question est reposée avant tout calcul.
-  if (askUnusableAnswerAgain()) {
+  // Simulation déjà chargée — lien de relance, retour dans le parcours. La
+  // garde ne s'applique pas quand l'adresse en réclame une autre : le magasin
+  // porterait alors la précédente.
+  if (!route.query?.simulationId && askUnusableAnswerAgain()) {
     return
   }
   if (route.query?.simulationId) {
     await handleSimulationIdQuery()
   } else if (!store.passSanityCheck) {
-    await Simulation.restoreLatestSimulation()
+    await restoreLatestSimulation()
   } else if (store.calculs.dirty) {
     await saveSimulation()
   } else if (!store.hasResults) {
@@ -54,21 +55,22 @@ onMounted(async () => {
       store.computeResults()
     }
   }
-  // Simulation chargée à l'instant depuis `?simulationId=` ou le cookie : le
-  // magasin ne la portait pas encore au premier passage.
-  askUnusableAnswerAgain()
 })
 
-// Une réponse retirée par la migration v18 rend son étape à nouveau sans
-// réponse. Afficher les résultats sans elle ferait disparaître le droit qui en
-// dépend — plus de mille euros d'AAH par mois — sur une page d'apparence
-// complète. La question est donc reposée.
+// Une réponse manquante ou perdue rend son étape à nouveau sans réponse.
+// Afficher les résultats sans elle ferait disparaître le droit qui en dépend
+// — plus de mille euros d'AAH par mois — sur une page d'apparence complète. La
+// question est donc reposée, et le calcul n'est même pas lancé.
 //
 // Le renvoi vise ces seules réponses, et pas toute étape sans réponse : une
 // question ajoutée après coup en laisse aussi dans les anciennes simulations,
 // et renvoyer celles-là dans le parcours les priverait de leurs résultats.
 // L'étape est cherchée nommément, et non via la première étape sans réponse,
 // qu'un manque sans rapport suffirait à masquer.
+//
+// La valeur est examinée, pas seulement la présence de la réponse : une
+// simulation née après la migration v18 n'en bénéficie pas et porterait sa
+// valeur perdue jusqu'à OpenFisca, qui refuserait la requête entière.
 const askUnusableAnswerAgain = (): boolean => {
   if (store.simulationAnonymized || !store.passSanityCheck) {
     return false
@@ -77,13 +79,27 @@ const askUnusableAnswerAgain = (): boolean => {
     (step) =>
       fieldsToAnswerAgain.includes(step.variable) &&
       step.isActive &&
-      !isStepAnswered(store.simulation.answers.all, step),
+      isUnusableAnswer(getStepAnswer(store.simulation.answers.all, step)),
   )
   if (!step) {
     return false
   }
   router.replace(step.path)
   return true
+}
+
+// Le chargement est séparé du calcul : lancer un calcul OpenFisca complet pour
+// une page qui ne sera jamais affichée pèse sur le service même dont la
+// saturation est en cause.
+const restoreLatestSimulation = async () => {
+  await Simulation.restoreLatestSimulationWithoutResultsComputing()
+  if (!store.simulationId || store.simulationAnonymized) {
+    return
+  }
+  if (askUnusableAnswerAgain()) {
+    return
+  }
+  store.computeResults()
 }
 
 onBeforeUnmount(() => {
@@ -161,6 +177,11 @@ const handleSimulationIdQuery = async () => {
     sendAccessToAnonymizedResults()
     await store.retrieveResultsAlreadyComputed()
   } else {
+    // La question est reposée avant tout calcul, et l'adresse n'est pas
+    // réécrite : le renvoi vers l'étape a déjà eu lieu.
+    if (askUnusableAnswerAgain()) {
+      return
+    }
     store.computeResults()
   }
 

--- a/src/views/simulation/resultats/resultats-wrapper.vue
+++ b/src/views/simulation/resultats/resultats-wrapper.vue
@@ -8,6 +8,8 @@ import { daysSinceDate } from "@lib/utils.js"
 import { EventAction, EventCategory } from "@lib/enums/event.js"
 import Simulation from "@/lib/simulation.js"
 import MockResults from "@/lib/mock-results"
+import { fieldsToAnswerAgain } from "@lib/simulation.js"
+import { isStepAnswered } from "@lib/answers.js"
 import { computed, onMounted, onBeforeUnmount, ref } from "vue"
 import { useRoute, useRouter } from "vue-router"
 import * as Sentry from "@sentry/vue"
@@ -33,7 +35,13 @@ onMounted(async () => {
   if (MockResults.mockResultsNeeded()) {
     MockResults.mock(route.params.benefitId)
     return
-  } else if (route.query?.simulationId) {
+  }
+  // Simulation déjà chargée — lien de relance, retour dans le parcours : la
+  // question est reposée avant tout calcul.
+  if (askUnusableAnswerAgain()) {
+    return
+  }
+  if (route.query?.simulationId) {
     await handleSimulationIdQuery()
   } else if (!store.passSanityCheck) {
     await Simulation.restoreLatestSimulation()
@@ -46,7 +54,37 @@ onMounted(async () => {
       store.computeResults()
     }
   }
+  // Simulation chargée à l'instant depuis `?simulationId=` ou le cookie : le
+  // magasin ne la portait pas encore au premier passage.
+  askUnusableAnswerAgain()
 })
+
+// Une réponse retirée par la migration v18 rend son étape à nouveau sans
+// réponse. Afficher les résultats sans elle ferait disparaître le droit qui en
+// dépend — plus de mille euros d'AAH par mois — sur une page d'apparence
+// complète. La question est donc reposée.
+//
+// Le renvoi vise ces seules réponses, et pas toute étape sans réponse : une
+// question ajoutée après coup en laisse aussi dans les anciennes simulations,
+// et renvoyer celles-là dans le parcours les priverait de leurs résultats.
+// L'étape est cherchée nommément, et non via la première étape sans réponse,
+// qu'un manque sans rapport suffirait à masquer.
+const askUnusableAnswerAgain = (): boolean => {
+  if (store.simulationAnonymized || !store.passSanityCheck) {
+    return false
+  }
+  const step = store.getAllSteps.find(
+    (step) =>
+      fieldsToAnswerAgain.includes(step.variable) &&
+      step.isActive &&
+      !isStepAnswered(store.simulation.answers.all, step),
+  )
+  if (!step) {
+    return false
+  }
+  router.replace(step.path)
+  return true
+}
 
 onBeforeUnmount(() => {
   stopSubscription.value?.()

--- a/tests/unit/backend/migration-to-v18.spec.ts
+++ b/tests/unit/backend/migration-to-v18.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from "vitest"
+
+import Migration from "@backend/lib/migrations/simulations/to-v18.js"
+
+const reponse = (value: unknown) => ({
+  entityName: "individu",
+  id: "enfant_0",
+  fieldName: "taux_incapacite",
+  value,
+})
+const handicap = {
+  entityName: "individu",
+  id: "enfant_0",
+  fieldName: "handicap",
+  value: true,
+}
+
+const simulationAvec = (taux: unknown) => ({
+  answers: {
+    all: [handicap, reponse(taux)],
+    current: [handicap, reponse(taux)],
+  },
+})
+
+describe("Migration to-v18", () => {
+  it("retire un taux d'incapacité enregistré sans valeur exploitable", () => {
+    const result = Migration.apply(simulationAvec(null))
+
+    // La question redevient sans réponse, donc reposée ; le handicap déclaré
+    // reste acquis.
+    expect(result.answers.all).toEqual([handicap])
+    expect(result.answers.current).toEqual([handicap])
+  })
+
+  it("conserve un taux d'incapacité renseigné", () => {
+    const result = Migration.apply(simulationAvec(0.65))
+
+    expect(result.answers.all).toEqual([handicap, reponse(0.65)])
+    expect(result.answers.current).toEqual([handicap, reponse(0.65)])
+  })
+
+  it("conserve le taux le plus bas, qui vaut zéro à la lecture booléenne", () => {
+    const result = Migration.apply(simulationAvec(0))
+
+    expect(result.answers.all).toEqual([handicap, reponse(0)])
+  })
+
+  it("ne touche pas aux autres réponses nulles", () => {
+    const autre = {
+      entityName: "parents",
+      fieldName: "nbptr",
+      value: null,
+    }
+    const result = Migration.apply({
+      answers: { all: [autre], current: [autre] },
+    })
+
+    expect(result.answers.all).toEqual([autre])
+  })
+})

--- a/tests/unit/backend/migration-to-v18.spec.ts
+++ b/tests/unit/backend/migration-to-v18.spec.ts
@@ -45,6 +45,22 @@ describe("Migration to-v18", () => {
     expect(result.answers.all).toEqual([handicap, reponse(0)])
   })
 
+  it("retire un NaN, si jamais il atteint la base sans passer par JSON", () => {
+    const result = Migration.apply(simulationAvec(NaN))
+
+    expect(result.answers.all).toEqual([handicap])
+  })
+
+  // `POST /api/simulation` est public et le schéma déclare `value: Object` :
+  // une chaîne peut donc arriver d'une intégration partenaire. OpenFisca
+  // l'accepte — vérifié : « 0.9 » rend la même AAH que 0.9. La retirer priverait
+  // cette personne de son droit sans qu'il y ait eu de corruption.
+  it("conserve un taux transmis sous forme de chaîne", () => {
+    const result = Migration.apply(simulationAvec("0.9"))
+
+    expect(result.answers.all).toEqual([handicap, reponse("0.9")])
+  })
+
   it("ne touche pas aux autres réponses nulles", () => {
     const autre = {
       entityName: "parents",

--- a/tests/unit/backend/openfisca-parameters.spec.ts
+++ b/tests/unit/backend/openfisca-parameters.spec.ts
@@ -80,19 +80,30 @@ describe("paramètres OpenFisca", () => {
     expect(retabli[PARAMETRE_TAUX_MAX]).toBe(TAUX_SERVI_PAR_OPENFISCA)
   })
 
-  // `getParameters` est appelé une fois par droit calculé. Repartir sur le
-  // réseau à chaque appel multiplierait la charge sur un OpenFisca déjà saturé.
+  // `getParameters` est appelé une fois par droit calculé, donc en continu.
+  // Les appels sont entrelacés avec l'horloge : les grouper avant toute avance
+  // du temps rendrait le test insensible à la suppression du délai.
   it("ne relance pas la requête à chaque appel pendant le délai de reprise", async () => {
     vi.useFakeTimers()
     getPromise.mockRejectedValue(new Error("OF maybe offline"))
     const { getParameters, parametersList } = await importParameters()
+    const parAppel = Object.keys(parametersList).length
 
-    for (let i = 0; i < 20; i++) {
+    for (let seconde = 0; seconde < 29; seconde++) {
       getParameters(new Date("2026-08-15"))
+      await vi.advanceTimersByTimeAsync(1_000)
     }
+
+    // Une seule tentative en vingt-neuf secondes.
+    expect(getPromise).toHaveBeenCalledTimes(parAppel)
+
+    // Passé le délai, une nouvelle tentative — et une seule.
+    await vi.advanceTimersByTimeAsync(2_000)
+    getParameters(new Date("2026-08-15"))
+    await vi.advanceTimersByTimeAsync(1_000)
+    getParameters(new Date("2026-08-15"))
     await vi.advanceTimersByTimeAsync(1_000)
 
-    // Une seule tentative : un appel réseau par paramètre de la liste.
-    expect(getPromise).toHaveBeenCalledTimes(Object.keys(parametersList).length)
+    expect(getPromise).toHaveBeenCalledTimes(2 * parAppel)
   })
 })

--- a/tests/unit/backend/openfisca-parameters.spec.ts
+++ b/tests/unit/backend/openfisca-parameters.spec.ts
@@ -1,0 +1,98 @@
+import { expect, vi, beforeEach, afterEach } from "vitest"
+
+const getPromise = vi.fn()
+
+vi.mock("@backend/lib/openfisca/getter.js", () => ({
+  default: { get: vi.fn(), getPromise: (item) => getPromise(item) },
+}))
+
+const PARAMETRE_TAUX_MAX =
+  "prestations_sociales.prestations_etat_de_sante.invalidite.aah.taux_capacite.taux_incapacite"
+
+// Une valeur volontairement différente du repli codé en dur (0.8) : la
+// distinguer prouve que le paramètre vient bien d'OpenFisca.
+const TAUX_SERVI_PAR_OPENFISCA = 0.77
+
+function reponseOpenfisca(item: string) {
+  return {
+    id: item.replace("/parameter/", ""),
+    values: { "2019-01-01": TAUX_SERVI_PAR_OPENFISCA },
+  }
+}
+
+async function importParameters() {
+  return import("@backend/lib/openfisca/parameters.js")
+}
+
+describe("paramètres OpenFisca", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    getPromise.mockReset()
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  // Sans paramètres, la question du taux d'incapacité ne peut plus construire
+  // ses paliers : deux de ses trois options valent NaN.
+  it("sert des valeurs exploitables même quand OpenFisca est injoignable", async () => {
+    getPromise.mockRejectedValue(new Error("OF maybe offline"))
+    const { getParametersAsync, parametersList } = await importParameters()
+
+    const parameters = await getParametersAsync(new Date("2026-08-15"))
+
+    expect(Object.keys(parameters).sort()).toEqual(
+      Object.keys(parametersList).sort(),
+    )
+    expect(
+      Object.values(parameters).every((value) => Number.isFinite(value)),
+    ).toBe(true)
+  })
+
+  it("sert la valeur d'OpenFisca dès qu'elle est disponible", async () => {
+    getPromise.mockImplementation(async (item: string) =>
+      reponseOpenfisca(item),
+    )
+    const { getParametersAsync } = await importParameters()
+
+    const parameters = await getParametersAsync(new Date("2026-08-15"))
+
+    expect(parameters[PARAMETRE_TAUX_MAX]).toBe(TAUX_SERVI_PAR_OPENFISCA)
+  })
+
+  it("réessaie après le délai de reprise", async () => {
+    vi.useFakeTimers()
+    getPromise.mockRejectedValue(new Error("OF maybe offline"))
+    const { getParametersAsync } = await importParameters()
+
+    const enPanne = await getParametersAsync(new Date("2026-08-15"))
+    expect(enPanne[PARAMETRE_TAUX_MAX]).not.toBe(TAUX_SERVI_PAR_OPENFISCA)
+
+    getPromise.mockImplementation(async (item: string) =>
+      reponseOpenfisca(item),
+    )
+    await vi.advanceTimersByTimeAsync(30_000)
+    const retabli = await getParametersAsync(new Date("2026-08-15"))
+
+    expect(retabli[PARAMETRE_TAUX_MAX]).toBe(TAUX_SERVI_PAR_OPENFISCA)
+  })
+
+  // `getParameters` est appelé une fois par droit calculé. Repartir sur le
+  // réseau à chaque appel multiplierait la charge sur un OpenFisca déjà saturé.
+  it("ne relance pas la requête à chaque appel pendant le délai de reprise", async () => {
+    vi.useFakeTimers()
+    getPromise.mockRejectedValue(new Error("OF maybe offline"))
+    const { getParameters, parametersList } = await importParameters()
+
+    for (let i = 0; i < 20; i++) {
+      getParameters(new Date("2026-08-15"))
+    }
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    // Une seule tentative : un appel réseau par paramètre de la liste.
+    expect(getPromise).toHaveBeenCalledTimes(Object.keys(parametersList).length)
+  })
+})

--- a/tests/unit/openfisca/taux-incapacite-request.spec.ts
+++ b/tests/unit/openfisca/taux-incapacite-request.spec.ts
@@ -1,0 +1,112 @@
+import { expect } from "vitest"
+import Migration from "@backend/lib/migrations/simulations/to-v18.js"
+import subject from "@root/backend/lib/openfisca/mapping/index.js"
+import { generateSituation } from "@lib/situations.js"
+
+// Règle d'OpenFisca, telle qu'écrite dans openfisca-core
+// (`SimulationBuilder.init_variable_values`) : toute valeur de variable doit
+// être un objet indexé par période, sans quoi la requête *entière* est refusée
+// en 400 — « Can't deal with type: expected object ».
+//
+// Les listes d'identifiants (rôles d'entité) sont lues autrement ; `undefined`
+// disparaît à la sérialisation JSON et n'atteint jamais OpenFisca.
+function variablesRefuseesParOpenfisca(request: any): string[] {
+  const refusees: string[] = []
+  for (const [entityPlural, instances] of Object.entries<any>(request)) {
+    for (const [instanceId, instance] of Object.entries<any>(instances)) {
+      for (const [variableName, value] of Object.entries<any>(instance)) {
+        if (Array.isArray(value) || value === undefined) {
+          continue
+        }
+        if (typeof value !== "object" || value === null) {
+          refusees.push(`${entityPlural}.${instanceId}.${variableName}`)
+        }
+      }
+    }
+  }
+  return refusees
+}
+
+// Une simulation telle qu'elle est relue en base : `taux_incapacite` y vaut
+// `null`, ce que JSON écrit d'un NaN.
+function simulationEnregistree(taux: unknown) {
+  const answers = [
+    {
+      entityName: "individu",
+      id: "demandeur",
+      fieldName: "date_naissance",
+      value: "1995-01-01",
+    },
+    {
+      entityName: "individu",
+      id: "demandeur",
+      fieldName: "activite",
+      value: "salarie",
+    },
+    {
+      entityName: "individu",
+      id: "enfant_0",
+      fieldName: "date_naissance",
+      value: "2015-01-01",
+    },
+    {
+      entityName: "individu",
+      id: "enfant_0",
+      fieldName: "handicap",
+      value: true,
+    },
+    {
+      entityName: "individu",
+      id: "enfant_0",
+      fieldName: "taux_incapacite",
+      value: taux,
+    },
+    { entityName: "menage", fieldName: "loyer", value: { loyer: 700 } },
+  ]
+  return {
+    dateDeValeur: new Date("2026-08-15"),
+    version: 17,
+    enfants: [0],
+    answers: { all: answers, current: answers },
+  }
+}
+
+function requeteDepuis(simulation) {
+  return subject.buildOpenFiscaRequest(generateSituation(simulation))
+}
+
+describe("taux d'incapacité enregistré sans valeur exploitable", () => {
+  it("est refusé par OpenFisca tant qu'il figure dans la simulation", () => {
+    const request = requeteDepuis(simulationEnregistree(null))
+
+    expect(variablesRefuseesParOpenfisca(request)).toEqual([
+      "individus.enfant_0.taux_incapacite",
+    ])
+  })
+
+  it("disparaît de la requête une fois la simulation migrée", () => {
+    const request = requeteDepuis(Migration.apply(simulationEnregistree(null)))
+
+    expect(variablesRefuseesParOpenfisca(request)).toEqual([])
+    expect(request.individus.enfant_0).not.toHaveProperty("taux_incapacite")
+    // Le handicap déclaré reste transmis : périodes écrites en dur.
+    expect(request.individus.enfant_0.handicap).toEqual({
+      "2026-08": true,
+      "2026-07": true,
+      "2026-06": true,
+      "2026-05": true,
+    })
+  })
+
+  it("laisse intact un taux renseigné", () => {
+    const request = requeteDepuis(Migration.apply(simulationEnregistree(0.9)))
+
+    expect(variablesRefuseesParOpenfisca(request)).toEqual([])
+    expect(request.individus.enfant_0.taux_incapacite).toEqual({
+      "2026-08": 0.9,
+      "2026-07": 0.9,
+      "2026-06": 0.9,
+      "2026-05": 0.9,
+    })
+  })
+})

--- a/tests/unit/other/taux-incapacite-question.spec.ts
+++ b/tests/unit/other/taux-incapacite-question.spec.ts
@@ -1,6 +1,8 @@
-import { expect } from "vitest"
+import { expect, beforeEach } from "vitest"
+import { setActivePinia, createPinia } from "pinia"
 import Individu from "@lib/properties/individu-properties.js"
-import { parametersList } from "@backend/lib/openfisca/parameters.js"
+import { parametersList } from "@lib/openfisca-parameters.js"
+import { useStore } from "@/stores/index.js"
 
 const PARAMETRE_TAUX_MAX =
   "prestations_sociales.prestations_etat_de_sante.invalidite.aah.taux_capacite.taux_incapacite"
@@ -12,6 +14,22 @@ const propertyData = (openFiscaParameters) =>
   }) as any
 
 describe("question du taux d'incapacité", () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  // Le magasin est l'unique source de ces paramètres pour la question. Tant
+  // qu'il pouvait rester vide, deux des trois options valaient NaN, que JSON
+  // écrit `null` : la valeur choisie était perdue au moment même où elle était
+  // enregistrée. C'est le générateur de la panne, et il doit être fermé à la
+  // source, avant même que la moindre requête ait abouti.
+  it("ne peut pas proposer d'option NaN, aucune requête n'ayant abouti", () => {
+    const items = Individu.taux_incapacite.getItems(
+      propertyData(useStore().openFiscaParameters),
+    )
+
+    expect(items.every((item) => Number.isFinite(item.value))).toBe(true)
+    expect(items.every((item) => !item.label.includes("NaN"))).toBe(true)
+  })
+
   it("propose trois paliers exploitables", () => {
     const items = Individu.taux_incapacite.getItems(
       propertyData({ [PARAMETRE_TAUX_MAX]: 0.8 }),

--- a/tests/unit/other/taux-incapacite-question.spec.ts
+++ b/tests/unit/other/taux-incapacite-question.spec.ts
@@ -1,0 +1,69 @@
+import { expect } from "vitest"
+import Individu from "@lib/properties/individu-properties.js"
+import { parametersList } from "@backend/lib/openfisca/parameters.js"
+
+const PARAMETRE_TAUX_MAX =
+  "prestations_sociales.prestations_etat_de_sante.invalidite.aah.taux_capacite.taux_incapacite"
+
+const propertyData = (openFiscaParameters) =>
+  ({
+    openFiscaParameters,
+    individu: { _role: "enfant", _firstName: "votre 1ᵉʳ enfant" },
+  }) as any
+
+describe("question du taux d'incapacité", () => {
+  it("propose trois paliers exploitables", () => {
+    const items = Individu.taux_incapacite.getItems(
+      propertyData({ [PARAMETRE_TAUX_MAX]: 0.8 }),
+    )
+
+    // Valeurs écrites en dur : elles ne sont pas recalculées avec le code testé.
+    expect(items.map((item) => item.value)).toEqual([0.3, 0.65, 0.9])
+    expect(items.map((item) => item.label)).toEqual([
+      "Moins de 50%",
+      "De 50% à 79%",
+      "80% et plus",
+    ])
+  })
+
+  // Les paramètres servis quand OpenFisca est injoignable doivent produire une
+  // question utilisable : une option valant NaN s'enregistre `null` et rend le
+  // taux choisi irrécupérable.
+  it("reste utilisable avec les paramètres de repli du serveur", () => {
+    const items = Individu.taux_incapacite.getItems(
+      propertyData(parametersList),
+    )
+
+    expect(items.every((item) => Number.isFinite(item.value))).toBe(true)
+    expect(items.every((item) => !item.label.includes("NaN"))).toBe(true)
+  })
+
+  // Le récapitulatif relit les options pour afficher la réponse : il ne doit
+  // dépendre d'aucun paramètre chargé.
+  it("affiche la réponse au récapitulatif sans paramètres chargés", () => {
+    const step = {
+      entity: "individu",
+      variable: "taux_incapacite",
+      id: "enfant_0",
+    }
+    const simulation = {
+      answers: {
+        all: [
+          {
+            entityName: "individu",
+            id: "enfant_0",
+            fieldName: "taux_incapacite",
+            value: 0.9,
+          },
+        ],
+      },
+    }
+
+    expect(() =>
+      Individu.taux_incapacite.getRecap(
+        { ...propertyData({}), simulation } as any,
+        step as any,
+      ),
+    ).not.toThrow()
+  })
+})

--- a/tests/unit/other/taux-incapacite-question.spec.ts
+++ b/tests/unit/other/taux-incapacite-question.spec.ts
@@ -1,5 +1,6 @@
-import { expect, beforeEach } from "vitest"
+import { expect, vi, beforeEach } from "vitest"
 import { setActivePinia, createPinia } from "pinia"
+import axios from "axios"
 import Individu from "@lib/properties/individu-properties.js"
 import { parametersList } from "@lib/openfisca-parameters.js"
 import { useStore } from "@/stores/index.js"
@@ -28,6 +29,40 @@ describe("question du taux d'incapacité", () => {
 
     expect(items.every((item) => Number.isFinite(item.value))).toBe(true)
     expect(items.every((item) => !item.label.includes("NaN"))).toBe(true)
+  })
+
+  // Un intermédiaire — reverse-proxy, portail captif — peut répondre 200 avec
+  // tout autre chose que les paramètres. Le `.catch` ne voit rien : le statut
+  // est bon. Un remplacement en bloc rouvrirait alors la fabrique de NaN.
+  it.each([
+    ["une page HTML", "<html><body>502 Bad Gateway</body></html>"],
+    ["un corps vide", ""],
+    ["une réponse tronquée", { "marche_travail.salaire_minimum.smic": 12.31 }],
+  ])(
+    "garde des options exploitables face à un 200 portant %s",
+    async (_libelle, data) => {
+      vi.spyOn(axios, "get").mockResolvedValue({ data } as any)
+      const store = useStore()
+
+      await store.setOpenFiscaParameters()
+      const items = Individu.taux_incapacite.getItems(
+        propertyData(store.openFiscaParameters),
+      )
+
+      expect(items.every((item) => Number.isFinite(item.value))).toBe(true)
+      expect(items.every((item) => !item.label.includes("NaN"))).toBe(true)
+    },
+  )
+
+  it("laisse la valeur d'OpenFisca l'emporter sur le repli", async () => {
+    vi.spyOn(axios, "get").mockResolvedValue({
+      data: { [PARAMETRE_TAUX_MAX]: 0.75 },
+    } as any)
+    const store = useStore()
+
+    await store.setOpenFiscaParameters()
+
+    expect(store.openFiscaParameters[PARAMETRE_TAUX_MAX]).toBe(0.75)
   })
 
   it("propose trois paliers exploitables", () => {

--- a/tests/unit/other/taux-incapacite-reprise.spec.ts
+++ b/tests/unit/other/taux-incapacite-reprise.spec.ts
@@ -1,0 +1,69 @@
+import { expect } from "vitest"
+import Migration from "@backend/lib/migrations/simulations/to-v18.js"
+import { parametersList } from "@backend/lib/openfisca/parameters.js"
+import { generateSituation } from "@lib/situations.js"
+import { generateAllSteps } from "@lib/state/generator.js"
+import { isStepAnswered } from "@lib/answers.js"
+
+function simulationEnregistree(taux: unknown) {
+  const answers = [
+    {
+      entityName: "individu",
+      id: "demandeur",
+      fieldName: "date_naissance",
+      value: "1995-01-01",
+    },
+    {
+      entityName: "individu",
+      id: "demandeur",
+      fieldName: "activite",
+      value: "inactif",
+    },
+    {
+      entityName: "individu",
+      id: "demandeur",
+      fieldName: "handicap",
+      value: true,
+    },
+    {
+      entityName: "individu",
+      id: "demandeur",
+      fieldName: "taux_incapacite",
+      value: taux,
+    },
+  ]
+  return {
+    dateDeValeur: new Date("2026-08-15"),
+    version: 17,
+    answers: { all: answers, current: answers },
+  }
+}
+
+function etapeTauxIncapacite(simulation) {
+  const situation = generateSituation(simulation, true)
+  return generateAllSteps(situation, parametersList).find(
+    (step: any) =>
+      step.variable === "taux_incapacite" && step.id === "demandeur",
+  )
+}
+
+// Le récapitulatif propose « Continuer » vers la première étape sans réponse ;
+// c'est ce qui fait reposer la question au lieu d'amputer la personne de son
+// droit.
+describe("reprise du parcours après migration", () => {
+  it("laisse l'étape du taux d'incapacité active et sans réponse", () => {
+    const simulation: any = Migration.apply(simulationEnregistree(null))
+    const step: any = etapeTauxIncapacite(simulation)
+
+    expect(step?.isActive).toBe(true)
+    expect(isStepAnswered(simulation.answers.all, step)).toBe(false)
+  })
+
+  it("considère l'étape répondue quand le taux est exploitable", () => {
+    const simulation: any = Migration.apply(simulationEnregistree(0.9))
+    const step: any = etapeTauxIncapacite(simulation)
+
+    expect(step?.isActive).toBe(true)
+    expect(isStepAnswered(simulation.answers.all, step)).toBe(true)
+  })
+})

--- a/tests/unit/other/taux-incapacite-reprise.spec.ts
+++ b/tests/unit/other/taux-incapacite-reprise.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest"
 import Migration from "@backend/lib/migrations/simulations/to-v18.js"
-import { parametersList } from "@backend/lib/openfisca/parameters.js"
+import { parametersList } from "@lib/openfisca-parameters.js"
 import { generateSituation } from "@lib/situations.js"
 import { generateAllSteps } from "@lib/state/generator.js"
 import { isStepAnswered } from "@lib/answers.js"

--- a/tests/unit/views/resultats-reprise.spec.ts
+++ b/tests/unit/views/resultats-reprise.spec.ts
@@ -1,0 +1,161 @@
+import { expect, vi, beforeEach, afterEach } from "vitest"
+import { mount } from "@vue/test-utils"
+import { setActivePinia, createPinia } from "pinia"
+import axios from "axios"
+
+import { useStore } from "@/stores/index.js"
+import { SimulationStatus } from "@lib/enums/simulation.js"
+import ResultatsWrapper from "@/views/simulation/resultats/resultats-wrapper.vue"
+
+const { route, router } = vi.hoisted(() => ({
+  route: {
+    fullPath: "/simulation/resultats",
+    path: "/simulation/resultats",
+    query: {} as Record<string, string>,
+    params: {} as Record<string, string>,
+  },
+  router: {
+    currentRoute: {
+      value: {
+        fullPath: "/simulation/resultats",
+        name: "resultats",
+        meta: {},
+        query: {} as Record<string, string>,
+      },
+    },
+    push: vi.fn(),
+    go: vi.fn(),
+    replace: vi.fn(),
+  },
+}))
+
+vi.mock("vue-router", () => ({
+  useRouter: () => router,
+  useRoute: () => route,
+}))
+
+const ETAPE_TAUX = "/simulation/individu/demandeur/taux_incapacite"
+
+const reponse = (fieldName: string, value: unknown) => ({
+  entityName: "individu",
+  id: "demandeur",
+  fieldName,
+  value,
+})
+
+// Une simulation telle que le serveur la renvoie après la migration v18 : la
+// réponse au taux d'incapacité en a été retirée, le handicap déclaré demeure.
+function simulationMigree(avecTaux = false) {
+  const answers = [
+    reponse("date_naissance", "1995-01-01"),
+    reponse("activite", "inactif"),
+    reponse("handicap", true),
+    ...(avecTaux ? [reponse("taux_incapacite", 0.9)] : []),
+  ]
+  return {
+    _id: "sim-1",
+    token: "TOKEN",
+    dateDeValeur: new Date("2026-08-15"),
+    version: 18,
+    answers: { all: answers, current: answers },
+  }
+}
+
+function monter() {
+  return mount(ResultatsWrapper, {
+    global: {
+      stubs: { RouterView: true, LoadingModal: true, BackButton: true },
+    },
+  })
+}
+
+const attendreMontage = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe("résultats : reprise d'une réponse retirée", () => {
+  let get: any
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+    router.replace.mockClear()
+    route.query = {}
+    router.currentRoute.value.query = {}
+    document.cookie = "lastestSimulation=; max-age=0"
+    get = vi.spyOn(axios, "get").mockResolvedValue({ data: {} } as any)
+  })
+
+  afterEach(() => {
+    document.cookie = "lastestSimulation=; max-age=0"
+  })
+
+  // 1. Lien de relance par courriel : /simulation/redirect a déjà chargé la
+  //    simulation dans le magasin avant d'atteindre les résultats.
+  it("repose la question quand la simulation est déjà chargée", async () => {
+    const store = useStore()
+    store.reset(simulationMigree() as any)
+    store.setSimulationId("sim-1")
+
+    monter()
+    await attendreMontage()
+
+    expect(router.replace).toHaveBeenCalledWith(ETAPE_TAUX)
+    // Aucun calcul n'est lancé : les résultats ne doivent pas s'afficher amputés.
+    expect(
+      get.mock.calls.some(([url]) => String(url).includes("/results")),
+    ).toBe(false)
+  })
+
+  // 2. Cookie `lastestSimulation` : la simulation est chargée pendant le montage.
+  it("repose la question après restauration par le cookie", async () => {
+    document.cookie = "lastestSimulation=sim-1"
+    get.mockResolvedValue({ data: simulationMigree() } as any)
+
+    monter()
+    await attendreMontage()
+    await attendreMontage()
+
+    expect(router.replace).toHaveBeenCalledWith(ETAPE_TAUX)
+  })
+
+  // 3. `?simulationId=` dans l'adresse.
+  it("repose la question après chargement par ?simulationId=", async () => {
+    route.query = { simulationId: "sim-1" }
+    get.mockResolvedValue({ data: simulationMigree() } as any)
+
+    monter()
+    await attendreMontage()
+    await attendreMontage()
+
+    expect(router.replace).toHaveBeenCalledWith(ETAPE_TAUX)
+  })
+
+  it("n'interrompt pas une simulation dont le taux est renseigné", async () => {
+    const store = useStore()
+    store.reset(simulationMigree(true) as any)
+    store.setSimulationId("sim-1")
+
+    monter()
+    await attendreMontage()
+
+    expect(router.replace).not.toHaveBeenCalledWith(ETAPE_TAUX)
+    expect(
+      get.mock.calls.some(([url]) => String(url).includes("/results")),
+    ).toBe(true)
+  })
+
+  // Une simulation anonymisée n'a plus de réponses à reposer : ses résultats
+  // sont relus tels qu'ils ont été calculés.
+  it("n'interrompt pas une simulation anonymisée", async () => {
+    const store = useStore()
+    store.reset({
+      ...simulationMigree(),
+      status: SimulationStatus.Anonymized,
+    } as any)
+    store.setSimulationId("sim-1")
+
+    monter()
+    await attendreMontage()
+
+    expect(router.replace).not.toHaveBeenCalledWith(ETAPE_TAUX)
+  })
+})

--- a/tests/unit/views/resultats-reprise.spec.ts
+++ b/tests/unit/views/resultats-reprise.spec.ts
@@ -43,14 +43,12 @@ const reponse = (fieldName: string, value: unknown) => ({
   value,
 })
 
-// Une simulation telle que le serveur la renvoie après la migration v18 : la
-// réponse au taux d'incapacité en a été retirée, le handicap déclaré demeure.
-function simulationMigree(avecTaux = false) {
+function simulation(reponsesTaux: any[]) {
   const answers = [
     reponse("date_naissance", "1995-01-01"),
     reponse("activite", "inactif"),
     reponse("handicap", true),
-    ...(avecTaux ? [reponse("taux_incapacite", 0.9)] : []),
+    ...reponsesTaux,
   ]
   return {
     _id: "sim-1",
@@ -60,6 +58,16 @@ function simulationMigree(avecTaux = false) {
     answers: { all: answers, current: answers },
   }
 }
+
+// Simulation telle que le serveur la renvoie après la migration v18 : la
+// réponse au taux d'incapacité en a été retirée, le handicap déclaré demeure.
+const simulationMigree = (avecTaux = false) =>
+  simulation(avecTaux ? [reponse("taux_incapacite", 0.9)] : [])
+
+// Simulation née après la migration : la réponse est là, mais sa valeur est
+// perdue.
+const simulationAvecTaux = (taux: unknown) =>
+  simulation([reponse("taux_incapacite", taux)])
 
 function monter() {
   return mount(ResultatsWrapper, {
@@ -73,6 +81,11 @@ const attendreMontage = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 describe("résultats : reprise d'une réponse retirée", () => {
   let get: any
+
+  // Un calcul OpenFisca complet pour une page qui ne sera jamais affichée pèse
+  // sur le service même dont la saturation est en cause.
+  const aCalculeLesResultats = () =>
+    get.mock.calls.some(([url]) => String(url).includes("/results"))
 
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -99,10 +112,7 @@ describe("résultats : reprise d'une réponse retirée", () => {
     await attendreMontage()
 
     expect(router.replace).toHaveBeenCalledWith(ETAPE_TAUX)
-    // Aucun calcul n'est lancé : les résultats ne doivent pas s'afficher amputés.
-    expect(
-      get.mock.calls.some(([url]) => String(url).includes("/results")),
-    ).toBe(false)
+    expect(aCalculeLesResultats()).toBe(false)
   })
 
   // 2. Cookie `lastestSimulation` : la simulation est chargée pendant le montage.
@@ -115,6 +125,7 @@ describe("résultats : reprise d'une réponse retirée", () => {
     await attendreMontage()
 
     expect(router.replace).toHaveBeenCalledWith(ETAPE_TAUX)
+    expect(aCalculeLesResultats()).toBe(false)
   })
 
   // 3. `?simulationId=` dans l'adresse.
@@ -127,6 +138,21 @@ describe("résultats : reprise d'une réponse retirée", () => {
     await attendreMontage()
 
     expect(router.replace).toHaveBeenCalledWith(ETAPE_TAUX)
+    expect(aCalculeLesResultats()).toBe(false)
+  })
+
+  // Une simulation créée après la migration v18 ne repasse pas par elle : sa
+  // réponse perdue lui reste, et la garde doit la reconnaître à sa valeur.
+  it("repose la question quand la réponse existe mais a perdu sa valeur", async () => {
+    const store = useStore()
+    store.reset(simulationAvecTaux(null) as any)
+    store.setSimulationId("sim-1")
+
+    monter()
+    await attendreMontage()
+
+    expect(router.replace).toHaveBeenCalledWith(ETAPE_TAUX)
+    expect(aCalculeLesResultats()).toBe(false)
   })
 
   it("n'interrompt pas une simulation dont le taux est renseigné", async () => {
@@ -138,9 +164,7 @@ describe("résultats : reprise d'une réponse retirée", () => {
     await attendreMontage()
 
     expect(router.replace).not.toHaveBeenCalledWith(ETAPE_TAUX)
-    expect(
-      get.mock.calls.some(([url]) => String(url).includes("/results")),
-    ).toBe(true)
+    expect(aCalculeLesResultats()).toBe(true)
   })
 
   // Une simulation anonymisée n'a plus de réponses à reposer : ses résultats


### PR DESCRIPTION
## Constat

**511 réponses 500 sur `/api/simulation/:id/results` le 6 août**, soit 0,86 % des appels. Les victimes sont des usagers déclarant un taux d'incapacité, pour eux-mêmes ou pour un enfant. Ils n'obtiennent aucun résultat, et rien ne le leur dit.

Un message reçu à votre support en donne le déclencheur :

> J'ai tenté de sélectionner le taux d'incapacité, et **en cliquant sur 50 a NAN%** qui est remplacé par 80 ou 79%, j'ai rencontré l'erreur ci-dessous.

## La chaîne, démontrée de bout en bout

1. **`setOpenFiscaParameters()` échoue en silence** (`.catch(() => undefined)`) → `openFiscaParameters` reste `{}` pour toute la session.
2. Les paliers valent `(0.5 + tauxMax)/2` : avec `tauxMax === undefined`, **deux options sur trois valent `NaN`** — d'où « De 50% à NaN% ».
3. `requiredValueMissing` ne rejette que `undefined` : `NaN` est accepté.
4. `JSON.stringify(NaN) === "null"` → la réponse arrive **`null`** en base.
5. `last3-months-duplication.ts:52` teste `typeof value !== "object"` — et `typeof null === "object"`. **`null` est le seul scalaire qui échappe à l'enveloppement en périodes.**
6. OpenFisca rejette la requête entière en 400 → l'application répond 500.

Amplificateur : `parameters.ts` mémorisait la promesse **même rejetée**. Une seule indisponibilité d'OpenFisca condamnait `/api/openfisca/parameters` jusqu'au redémarrage du processus — d'où des centaines d'occurrences par journal plutôt qu'un incident isolé.

## Le correctif — à la racine, pas en garde-fou

- **`getParametersAsync` ne renvoie plus 500** : il sert le repli que `computeParameter` prévoyait déjà, en continuant d'alerter Sentry. Toute la chaîne meurt à la source.
- **Le magasin démarre avec ces mêmes valeurs**, et les fusionne au lieu de les remplacer : `{ ...parametersList, ...response.data }`. Un 200 portant une page HTML de passerelle ne peut plus rouvrir la fabrique de `NaN`. Vérifié en navigateur.
- **Mémorisation conservée, avec un délai de reprise de 30 s.** Sans lui, `compute.ts:136` appelle la version synchrone **dans la boucle sur les droits** : mesuré, 1 000 appels → 5 requêtes réseau, contre 500 sans plafond.
- **Migration `to-v18`** : retire la réponse inexploitable pour que la question soit **reposée**, plutôt que d'amputer silencieusement. Mesuré : une réponse retirée fait passer l'**AAH de 1 041,59 € à 0**, partiellement masquée par un RSA qui apparaît — page d'apparence normale, perte nette réelle.
- **Une garde sur la page de résultats** couvre les quatre chemins d'entrée (récapitulatif, lien courriel, cookie, `?simulationId=`), et n'engage pas de calcul avant de rediriger.

`lib/properties/individu-properties.ts` et `backend/lib/openfisca/mapping/index.ts` sont **hors diff** : aucune valeur n'est filtrée, aucun droit n'est amputé.

## Quatre tours de revue adversariale

Les trois premières versions ont été **rejetées**, chaque fois sur une preuve exécutée :

1. un `throw` transformait l'étape en impasse muette **et** rendait le récapitulatif blanc pour des usagers qui n'étaient pas victimes du bug ;
2. la promesse « la question est reposée » ne tenait que sur un chemin d'entrée sur quatre — ailleurs, résultats amputés de 1 041 €/mois sans un mot ;
3. la garde menait à l'écran qui **recrée** la corruption, et le passage à `version = 18` supprimait la seule passe de rattrapage ;
4. la graine de paramètres datait de 2022 — la légende du LEP affichait « au lieu de 0,5 % » là où la vérité est **1,5 %**.

Chaque test ajouté est **éprouvé contre `origin/main`** et contre le commit parent. Le test anti-amplification échoue bien avec `FAILURE_COOLDOWN_MS = 0` — il était inerte à un tour précédent.

## Portes de CI

`npx prettier --check .` ✓ · `npm run lint` ✓ · **`npm test` : 55 fichiers, 25 063 tests, exit 0** · `npm run build` ✓

L'erreur `OF maybe offline` qui faisait sortir votre suite en 1 **était ce même rejet non géré** : elle disparaît.

## ⚠️ Suites à donner

- **`fieldsToAnswerAgain` porte deux rayons d'action inégaux** : la migration ne touche que `version < 18`, la garde renvoie **toute** simulation à qui la réponse manque. Ajouter un nom sans écrire le `to-v19` correspondant y renverrait aussitôt des simulations qui n'ont jamais eu la question. Inoffensif aujourd'hui par héritage, pas par conception — le contraste avec `to-v15`, qui *fabrique* la réponse manquante, est instructif.
- **Séparer `PARAMETER_KEYS` de `SAFE_DEFAULTS`** : ne garder de repli que sur les seuils juridiques stables (`taux_incapacite`, `age_maximal`), et laisser `livret_a.taux` et `smic_b_horaire` échouer explicitement plutôt que de servir un chiffre plausible et faux. C'est la lecture stricte de « erreurs explicites, jamais de repli silencieux ». Non fait ici : changement de comportement serveur qui mérite son propre diff.
- **Depuis la question reposée, aucun retour direct aux résultats** : l'usager venu d'un lien courriel doit re-parcourir le questionnaire restant. `router.replace` est conservé à dessein — avec `push`, le retour arrière ramènerait sur les résultats, qui redirigeraient aussitôt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)