### PR TITLE
fix(backend): fait remonter les rejets de promesse qui disparaissaient en silence

### DIFF
--- a/backend/configure.ts
+++ b/backend/configure.ts
@@ -5,10 +5,13 @@ import mongoose from "mongoose"
 import configMongoose from "./config/mongoose.js"
 import { loadRoutes } from "./routes-loader/index.js"
 import config from "./config/index.js"
+import { registerProcessErrorHandlers } from "./lib/process-error-handlers.js"
 
 // Enable Sentry in production
 // https://docs.sentry.io/development/sdk-dev/overview/#usage-for-end-users
 Sentry.init(config.sentry)
+
+registerProcessErrorHandlers()
 
 configMongoose(mongoose, config)
 

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -13,7 +13,12 @@ import Request from "../types/express.d.js"
 import config from "../config/index.js"
 import { sendSimulationResultsEmail } from "../lib/messaging/email/email-service.js"
 import { sendSimulationResultsSms } from "../lib/messaging/sms/sms-service.js"
-import { ErrorType, ErrorStatus, ErrorName } from "../../lib/enums/error.js"
+import {
+  ErrorType,
+  ErrorStatus,
+  isRejectedDestination,
+  isUserInputError,
+} from "../../lib/enums/error.js"
 
 export async function followup(
   req: Request,
@@ -45,27 +50,16 @@ async function createSimulationRecapUrl(req: Request, res: Response) {
   return res.send({ simulationRecapUrl })
 }
 
-// Refus du fournisseur pour un numéro non joignable : l'usager qui réessaie
-// obtient le même refus. Le libellé du refus n'a pas de champ propre dans la
-// réponse du fournisseur — seul le corps entier le porte, d'où l'inclusion.
-export function isRejectedDestination(error: any): boolean {
-  if (error?.name !== ErrorName.SmsProviderError) {
-    return false
-  }
-  const message = typeof error?.message === "string" ? error.message : ""
-  return message.includes(ErrorType.InvalidDestinationAddress)
-}
+// Le message d'un `SmsProviderError` porte la réponse entière du fournisseur :
+// un contenu décidé par un tiers, de longueur non bornée, versé dans nos
+// journaux. `responseCode` en donne l'essentiel ; le reste est écourté.
+const LOGGED_MESSAGE_MAX = 300
 
-// Conditions dues à la saisie de l'usager : une entrée irrecevable, pas une
-// panne, et reproductible à chaque nouvelle tentative.
-export function isUserInputError(error: any): boolean {
-  if (error?.name === ErrorName.ValidationError) {
-    return true
+function forLog(message: unknown): unknown {
+  if (typeof message !== "string" || message.length <= LOGGED_MESSAGE_MAX) {
+    return message
   }
-  if (error?.message === ErrorType.UnsupportedPhoneNumberFormat) {
-    return true
-  }
-  return isRejectedDestination(error)
+  return `${message.slice(0, LOGGED_MESSAGE_MAX)}… (${message.length} caractères)`
 }
 
 export async function persist(req: Request, res: Response) {
@@ -100,7 +94,7 @@ export async function persist(req: Request, res: Response) {
       `POST /api/simulation/${simulation?._id}/followup → ${status}`,
       JSON.stringify({
         name: error?.name,
-        message: error?.message,
+        message: forLog(error?.message),
         code: error?.code,
         // Rend observables les codes de refus du fournisseur de SMS : sans
         // table de correspondance, seuls ceux constatés ici pourront un jour
@@ -121,7 +115,7 @@ export async function persist(req: Request, res: Response) {
 
     return res
       .status(status)
-      .send(error.message || ErrorType.PersistingFollowup)
+      .send(error?.message || ErrorType.PersistingFollowup)
   }
 }
 

--- a/backend/controllers/followups.ts
+++ b/backend/controllers/followups.ts
@@ -45,6 +45,29 @@ async function createSimulationRecapUrl(req: Request, res: Response) {
   return res.send({ simulationRecapUrl })
 }
 
+// Refus du fournisseur pour un numéro non joignable : l'usager qui réessaie
+// obtient le même refus. Le libellé du refus n'a pas de champ propre dans la
+// réponse du fournisseur — seul le corps entier le porte, d'où l'inclusion.
+export function isRejectedDestination(error: any): boolean {
+  if (error?.name !== ErrorName.SmsProviderError) {
+    return false
+  }
+  const message = typeof error?.message === "string" ? error.message : ""
+  return message.includes(ErrorType.InvalidDestinationAddress)
+}
+
+// Conditions dues à la saisie de l'usager : une entrée irrecevable, pas une
+// panne, et reproductible à chaque nouvelle tentative.
+export function isUserInputError(error: any): boolean {
+  if (error?.name === ErrorName.ValidationError) {
+    return true
+  }
+  if (error?.message === ErrorType.UnsupportedPhoneNumberFormat) {
+    return true
+  }
+  return isRejectedDestination(error)
+}
+
 export async function persist(req: Request, res: Response) {
   const { surveyOptin, email, phone } = req.body
   const simulation = req.simulation
@@ -62,17 +85,38 @@ export async function persist(req: Request, res: Response) {
       return res.send({ result: "OK" })
     }
 
-    return createSimulationRecapUrl(req, res)
+    // `return await` et non `return` : dans une fonction asynchrone, la promesse
+    // renvoyée est résolue hors du `try`, et son rejet échapperait au `catch`.
+    return await createSimulationRecapUrl(req, res)
   } catch (error: any) {
-    Sentry.captureException(error)
+    const userInputError = isUserInputError(error)
+    const status: number = userInputError
+      ? ErrorStatus.UnprocessableEntity
+      : ErrorStatus.InternalServerError
 
-    let status: number = ErrorStatus.InternalServerError
+    // Sans cette trace, la seule empreinte d'un échec ici est la ligne d'accès
+    // du serveur : le statut, jamais la cause.
+    console.error(
+      `POST /api/simulation/${simulation?._id}/followup → ${status}`,
+      JSON.stringify({
+        name: error?.name,
+        message: error?.message,
+        code: error?.code,
+        // Rend observables les codes de refus du fournisseur de SMS : sans
+        // table de correspondance, seuls ceux constatés ici pourront un jour
+        // être classés autrement que par le libellé.
+        responseCode: error?.responseCode,
+        upstreamStatus: error?.response?.status ?? error?.httpStatus,
+        channels: { email: Boolean(email), phone: Boolean(phone) },
+      }),
+      error?.stack,
+    )
 
-    if (
-      error.name === ErrorName.ValidationError ||
-      error.message === ErrorType.UnsupportedPhoneNumberFormat
-    ) {
-      status = ErrorStatus.UnprocessableEntity
+    // `sms-service` exclut délibérément ce refus de Sentry ; le signaler ici
+    // annulerait cette exclusion. Les autres 422 — validation du modèle — y
+    // restent : ils peuvent trahir un défaut de code, pas seulement une saisie.
+    if (!isRejectedDestination(error)) {
+      Sentry.captureException(error)
     }
 
     return res
@@ -118,7 +162,11 @@ export function showFollowup(req: Request, res: Response) {
     })
 }
 
-export function showSurveyResults(req: Request, res: Response) {
+export function showSurveyResults(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   Followups.find({
     surveyOptin: true,
     surveys: {
@@ -134,6 +182,7 @@ export function showSurveyResults(req: Request, res: Response) {
     .then((followup: Followup[]) => {
       res.send(followup)
     })
+    .catch(next)
 }
 
 export function showSurveyResultByEmail(req: Request, res: Response) {
@@ -155,19 +204,32 @@ export async function followupByAccessToken(
   next: NextFunction,
   accessToken: any,
 ) {
-  const followup: Followup | null = await Followups.findOne({
-    accessToken,
-  }).populate("simulation")
-  if (!followup) return res.sendStatus(ErrorStatus.NotFound)
-  req.followup = followup
-  next()
+  try {
+    const followup: Followup | null = await Followups.findOne({
+      accessToken,
+    }).populate("simulation")
+    if (!followup) return res.sendStatus(ErrorStatus.NotFound)
+    req.followup = followup
+    next()
+  } catch (error) {
+    next(error)
+  }
 }
 
-export function postSurvey(req: Request, res: Response) {
-  req.followup.updateSurvey(SurveyType.BenefitAction, req.body).then(() => {
-    res.sendStatus(201)
+export function postSurvey(req: Request, res: Response, next: NextFunction) {
+  req.followup
+    .updateSurvey(SurveyType.BenefitAction, req.body)
+    .then(() => {
+      res.sendStatus(201)
+    })
+    .catch(next)
+  // La notification Mattermost est accessoire : la réponse de l'usager est déjà
+  // enregistrée et le 201 déjà émis. Elle ne doit ni faire échouer la requête,
+  // ni disparaître si Mattermost est injoignable.
+  pollResult.postPollResult(req.followup, req.body).catch((error) => {
+    console.error("Échec de la notification Mattermost du sondage", error)
+    Sentry.captureException(error)
   })
-  pollResult.postPollResult(req.followup, req.body)
 }
 
 export async function updateWasUseful(req: Request) {

--- a/backend/controllers/moncomptepro.ts
+++ b/backend/controllers/moncomptepro.ts
@@ -35,10 +35,6 @@ const login = async (req, res) => {
   return res.redirect(redirectUrl.href)
 }
 
-// Monté directement sur une route, le rejet de `login` n'aurait personne pour le
-// recevoir : Express 4 ignore la promesse renvoyée par un gestionnaire.
-const loginRoute = (req, res, next) => login(req, res).catch(next)
-
 const retrieveMcpAccessToken = async (req) => {
   try {
     const mcpIssuer = await getMcpClient()
@@ -131,4 +127,4 @@ const logout = async (req, res, next) => {
   }
 }
 
-export default { access, login, loginRoute, loginCallbackRedirect, logout }
+export default { access, login, loginCallbackRedirect, logout }

--- a/backend/controllers/moncomptepro.ts
+++ b/backend/controllers/moncomptepro.ts
@@ -35,6 +35,10 @@ const login = async (req, res) => {
   return res.redirect(redirectUrl.href)
 }
 
+// Monté directement sur une route, le rejet de `login` n'aurait personne pour le
+// recevoir : Express 4 ignore la promesse renvoyée par un gestionnaire.
+const loginRoute = (req, res, next) => login(req, res).catch(next)
+
 const retrieveMcpAccessToken = async (req) => {
   try {
     const mcpIssuer = await getMcpClient()
@@ -91,7 +95,9 @@ const access = async (req, res, next) => {
       }
     }
 
-    return login(req, res)
+    // `return await` et non `return` : dans une fonction asynchrone, la promesse
+    // renvoyée est résolue hors du `try`, et son rejet échapperait au `catch`.
+    return await login(req, res)
   } catch (error) {
     Sentry.captureException(error)
     clearCookie(res)
@@ -125,4 +131,4 @@ const logout = async (req, res, next) => {
   }
 }
 
-export default { access, login, loginCallbackRedirect, logout }
+export default { access, login, loginRoute, loginCallbackRedirect, logout }

--- a/backend/controllers/simulation.ts
+++ b/backend/controllers/simulation.ts
@@ -25,17 +25,22 @@ async function simulation(
   next,
   simulationOrSimulationId: Simulation | Simulation["_id"] | string,
 ) {
-  if (
-    simulationOrSimulationId &&
-    typeof simulationOrSimulationId === "object" &&
-    "_id" in simulationOrSimulationId
-  ) {
-    const simulation = simulationOrSimulationId as Simulation
-    setSimulationOnRequest(req, simulation)
-    return next()
-  }
-
+  // Trois des appelants — `attachPayloadSituation`, `followup` et la route
+  // /support — invoquent cette fonction sans attendre la promesse. Tout ce
+  // qu'elle fait doit donc être couvert : hors du `try`, un jet de `apply()` ou
+  // de `generateSituation()` devient un rejet que personne ne reçoit, et la
+  // requête reste pendante. La charge est ici contrôlée par l'appelant, le
+  // payload du jeton n'étant vérifié qu'après.
   try {
+    if (
+      simulationOrSimulationId &&
+      typeof simulationOrSimulationId === "object" &&
+      "_id" in simulationOrSimulationId
+    ) {
+      setSimulationOnRequest(req, simulationOrSimulationId as Simulation)
+      return next()
+    }
+
     const simulation = await Simulations.findById(simulationOrSimulationId)
 
     if (!simulation) {

--- a/backend/controllers/simulation.ts
+++ b/backend/controllers/simulation.ts
@@ -229,19 +229,19 @@ function enrichBenefitsList(benefits) {
 }
 
 async function getLatestFollowup(req: Request, res) {
-  const followup = (await Followups.findOne(
-    {
-      simulation: req.simulation?._id,
-    },
-    null,
-    { sort: { createdAt: -1 } },
-  )) as Followup
-
-  if (!followup) {
-    return res.status(404).send({ error: "No followup found" })
-  }
-
   try {
+    const followup = (await Followups.findOne(
+      {
+        simulation: req.simulation?._id,
+      },
+      null,
+      { sort: { createdAt: -1 } },
+    )) as Followup
+
+    if (!followup) {
+      return res.status(404).send({ error: "No followup found" })
+    }
+
     followup.benefits = enrichBenefitsList(followup.benefits)
 
     return res.send(followup)

--- a/backend/controllers/teleservices/index.ts
+++ b/backend/controllers/teleservices/index.ts
@@ -130,7 +130,10 @@ function fail(res, msg) {
  * - the appropriate URL to third party teleservice.
  */
 function metadataResponseGenerator(teleservice) {
-  return function (req, res) {
+  // Express 4 ignore la promesse renvoyée par un gestionnaire : sans `.catch`,
+  // le rejet de `toInternal()` — indisponibilité du téléservice tiers — devient
+  // un `unhandledRejection` et laisse la requête pendante.
+  return function (req, res, next) {
     const payload = {
       id: req.simulation._id,
       scope: teleservice.name,
@@ -141,22 +144,24 @@ function metadataResponseGenerator(teleservice) {
     const token = jwt.sign(payload, req.simulation.token)
     return Promise.resolve(
       createClass(teleservice, req.simulation, req.query).toInternal(),
-    ).then(function (fields) {
-      return res.json({
-        fields,
-        destination: {
-          label: teleservice.destination.label,
-          url: Mustache.render(teleservice.destination.url, {
-            token,
-            baseURL: `${req.protocol}://${req.get("host")}`,
-            aideJeuneExperimentationURL: config.aideJeuneExperimentationURL,
-            openfiscaAxeURL: config.openfiscaAxeURL,
-            openFiscaURL: config.openfiscaPublicURL,
-            openfiscaTracerURL: config.openfiscaTracerURL,
-          }),
-        },
+    )
+      .then(function (fields) {
+        return res.json({
+          fields,
+          destination: {
+            label: teleservice.destination.label,
+            url: Mustache.render(teleservice.destination.url, {
+              token,
+              baseURL: `${req.protocol}://${req.get("host")}`,
+              aideJeuneExperimentationURL: config.aideJeuneExperimentationURL,
+              openfiscaAxeURL: config.openfiscaAxeURL,
+              openFiscaURL: config.openfiscaPublicURL,
+              openfiscaTracerURL: config.openfiscaTracerURL,
+            }),
+          },
+        })
       })
-    })
+      .catch(next)
   }
 }
 

--- a/backend/controllers/webhook.ts
+++ b/backend/controllers/webhook.ts
@@ -83,13 +83,18 @@ export const validateRequestPayload = (
 export async function postOnMattermost(
   req: Request,
   res: Response,
-): Promise<Response> {
+  next: NextFunction,
+): Promise<Response | void> {
   const { id: rdvId, organisation } = req.body.data || {}
   const { id: organisationId } = organisation || {}
 
   const message = `Une personne vient de prendre RDV.
 Plus d'informations ${config.rdvAideNumerique.baseUrl}/admin/organisations/${organisationId}/rdvs/${rdvId}`
 
-  await Mattermost.post(message)
+  try {
+    await Mattermost.post(message)
+  } catch (error) {
+    return next(error)
+  }
   return res.status(200).json({ message: "OK" })
 }

--- a/backend/controllers/webhook.ts
+++ b/backend/controllers/webhook.ts
@@ -5,6 +5,7 @@ import Mattermost from "../lib/mattermost-bot/mattermost.js"
 import { Request, Response, NextFunction } from "express"
 import { RequestBody, Data } from "../types/rdv-aide-numerique.js"
 import * as Sentry from "@sentry/node"
+import { ErrorName } from "../../lib/enums/error.js"
 
 export const verifyAuthentication = (
   req: Request,
@@ -93,7 +94,15 @@ Plus d'informations ${config.rdvAideNumerique.baseUrl}/admin/organisations/${org
 
   try {
     await Mattermost.post(message)
-  } catch (error) {
+  } catch (error: any) {
+    // Le tiers ne peut rien pour une configuration manquante de notre côté :
+    // lui répondre en erreur ne ferait que déclencher des rappels stériles.
+    // L'échec reste explicite, par le journal et par Sentry.
+    if (error?.name === ErrorName.MattermostNotConfiguredError) {
+      console.error("Notification RDV non envoyée", error.message)
+      Sentry.captureException(error)
+      return res.status(200).json({ message: "OK" })
+    }
     return next(error)
   }
   return res.status(200).json({ message: "OK" })

--- a/backend/lib/async-handler.ts
+++ b/backend/lib/async-handler.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, RequestHandler, Response } from "express"
+
+/*
+ * Express 4 ignore la promesse renvoyée par un gestionnaire : le rejet d'un
+ * gestionnaire `async` monté nu n'a personne pour le recevoir. La requête reste
+ * pendante jusqu'au délai du client, et le processus signale un
+ * `unhandledRejection`. Ce montage rend le rejet à la chaîne d'erreur d'Express.
+ */
+export function asyncHandler(
+  handler: (req: Request, res: Response, next: NextFunction) => unknown,
+): RequestHandler {
+  return (req, res, next) => {
+    try {
+      return Promise.resolve(handler(req, res, next)).catch(next)
+    } catch (error) {
+      // Un gestionnaire non asynchrone peut lever avant d'avoir rien renvoyé.
+      next(error)
+    }
+  }
+}

--- a/backend/lib/async-handler.ts
+++ b/backend/lib/async-handler.ts
@@ -1,17 +1,40 @@
-import { NextFunction, Request, RequestHandler, Response } from "express"
+import { NextFunction, Request, Response } from "express"
 
 /*
  * Express 4 ignore la promesse renvoyée par un gestionnaire : le rejet d'un
  * gestionnaire `async` monté nu n'a personne pour le recevoir. La requête reste
  * pendante jusqu'au délai du client, et le processus signale un
  * `unhandledRejection`. Ce montage rend le rejet à la chaîne d'erreur d'Express.
+ *
+ * La signature est variadique : un gestionnaire `param` reçoit deux arguments
+ * de plus — la valeur du paramètre et son nom. Ne propager que les trois
+ * premiers les lui retirerait sans que rien ne le signale, ni au typage ni à
+ * l'exécution. Les paramètres du reste ne comptent pas dans `length`, qui vaut
+ * 3 : Express ne prendra donc pas l'enveloppe pour un middleware d'erreur.
+ *
+ * Ne couvre qu'un gestionnaire qui *renvoie* sa promesse. Celui qui en lance une
+ * sans la rendre reste à découvert : c'est à lui, ou à ce qu'il appelle, de
+ * rattraper.
  */
 export function asyncHandler(
-  handler: (req: Request, res: Response, next: NextFunction) => unknown,
-): RequestHandler {
-  return (req, res, next) => {
+  handler: (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+    ...rest: unknown[]
+  ) => unknown,
+) {
+  return (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+    ...rest: unknown[]
+  ) => {
     try {
-      return Promise.resolve(handler(req, res, next)).catch(next)
+      // Express ignore cette promesse, mais la rendre permet d'attendre le
+      // passage à `next` — sans quoi seul un appelant qui draine la file peut
+      // observer l'issue. Elle ne rejette jamais : `.catch` la termine.
+      return Promise.resolve(handler(req, res, next, ...rest)).catch(next)
     } catch (error) {
       // Un gestionnaire non asynchrone peut lever avant d'avoir rien renvoyé.
       next(error)

--- a/backend/lib/mattermost-bot/mattermost.ts
+++ b/backend/lib/mattermost-bot/mattermost.ts
@@ -2,15 +2,15 @@ import axios from "axios"
 import config from "../../config/index.js"
 
 async function post(text: string, postUrl?: string) {
-  await axios
-    .post(postUrl || config.mattermost_post_url, JSON.stringify({ text }), {
+  await axios.post(
+    postUrl || config.mattermost_post_url,
+    JSON.stringify({ text }),
+    {
       headers: {
         "Content-Type": "application/json",
       },
-    })
-    .catch(function (error) {
-      console.log(`Failed to send post to mattermost ${error}`)
-    })
+    },
+  )
 }
 
 export default { post }

--- a/backend/lib/mattermost-bot/mattermost.ts
+++ b/backend/lib/mattermost-bot/mattermost.ts
@@ -1,16 +1,29 @@
 import axios from "axios"
 import config from "../../config/index.js"
+import { ErrorName } from "../../../lib/enums/error.js"
+
+// Une configuration absente n'est pas une panne passagère : la distinguer évite
+// d'inviter un appelant à réessayer ce qu'aucune tentative ne réparera.
+export class MattermostNotConfiguredError extends Error {
+  constructor() {
+    super(
+      "MATTERMOST_POST_URL n'est pas renseignée : notification non envoyée.",
+    )
+    this.name = ErrorName.MattermostNotConfiguredError
+  }
+}
 
 async function post(text: string, postUrl?: string) {
-  await axios.post(
-    postUrl || config.mattermost_post_url,
-    JSON.stringify({ text }),
-    {
-      headers: {
-        "Content-Type": "application/json",
-      },
+  const url = postUrl || config.mattermost_post_url
+  if (!url) {
+    throw new MattermostNotConfiguredError()
+  }
+
+  await axios.post(url, JSON.stringify({ text }), {
+    headers: {
+      "Content-Type": "application/json",
     },
-  )
+  })
 }
 
 export default { post }

--- a/backend/lib/mattermost-bot/poll-result.ts
+++ b/backend/lib/mattermost-bot/poll-result.ts
@@ -10,7 +10,7 @@ function parseCurrentDate() {
   })} à ${isoDateTime.toLocaleTimeString("fr-FR")}`
 }
 
-function postPollResult(simulation, answers) {
+async function postPollResult(simulation, answers) {
   if (answers.length == 0 || !simulation?.benefits) {
     return
   }
@@ -50,7 +50,7 @@ function postPollResult(simulation, answers) {
     )
   }
 
-  mattermost.post(result.join("\n"))
+  await mattermost.post(result.join("\n"))
 }
 
 export default {

--- a/backend/lib/messaging/sms/sms-service.ts
+++ b/backend/lib/messaging/sms/sms-service.ts
@@ -8,7 +8,7 @@ import { SmsType } from "../../../../lib/enums/messaging.js"
 import { Followup } from "../../../../lib/types/followup.js"
 import { Survey } from "../../../../lib/types/survey.d.js"
 import { SurveyType } from "../../../../lib/enums/survey.js"
-import { ErrorType } from "../../../../lib/enums/error.js"
+import { ErrorName, ErrorType } from "../../../../lib/enums/error.js"
 import dayjs from "dayjs"
 import * as Sentry from "@sentry/node"
 
@@ -22,6 +22,21 @@ async function getSMSConfig() {
   return { username, password }
 }
 
+// Le fournisseur répond 200 avec un `responseCode` non nul pour signaler un
+// refus. Le porter en champ propre le rend classable et observable ; le message
+// garde le corps entier, seul endroit où figure le libellé du refus.
+export class SmsProviderError extends Error {
+  readonly responseCode?: number
+  readonly httpStatus: number
+
+  constructor(data: any, httpStatus: number) {
+    super(`SMS request failed. Body: ${JSON.stringify(data)}`)
+    this.name = ErrorName.SmsProviderError
+    this.responseCode = data?.responseCode
+    this.httpStatus = httpStatus
+  }
+}
+
 async function createAxiosInstance() {
   const instance = create({
     timeout: 10000,
@@ -30,7 +45,7 @@ async function createAxiosInstance() {
     (response) => {
       const { data, status } = response
       if (status !== 200 || data.responseCode !== 0) {
-        throw new Error(`SMS request failed. Body: ${JSON.stringify(data)}`)
+        throw new SmsProviderError(data, status)
       }
       return response
     },
@@ -105,7 +120,7 @@ export async function sendSimulationResultsSms(
     return await followup.save()
   } catch (error: any) {
     // Avoid sending invalid destination address error to sentry
-    if (!error?.message?.includes("Invalid destination address")) {
+    if (!error?.message?.includes(ErrorType.InvalidDestinationAddress)) {
       Sentry.captureException(error)
     }
     followup.smsError = error?.message

--- a/backend/lib/messaging/sms/sms-service.ts
+++ b/backend/lib/messaging/sms/sms-service.ts
@@ -8,7 +8,11 @@ import { SmsType } from "../../../../lib/enums/messaging.js"
 import { Followup } from "../../../../lib/types/followup.js"
 import { Survey } from "../../../../lib/types/survey.d.js"
 import { SurveyType } from "../../../../lib/enums/survey.js"
-import { ErrorName, ErrorType } from "../../../../lib/enums/error.js"
+import {
+  ErrorName,
+  ErrorType,
+  isRejectedDestination,
+} from "../../../../lib/enums/error.js"
 import dayjs from "dayjs"
 import * as Sentry from "@sentry/node"
 
@@ -119,8 +123,9 @@ export async function sendSimulationResultsSms(
     followup.smsMessageId = data.messageIds[0]
     return await followup.save()
   } catch (error: any) {
-    // Avoid sending invalid destination address error to sentry
-    if (!error?.message?.includes(ErrorType.InvalidDestinationAddress)) {
+    // Un numéro refusé par le fournisseur est une saisie à corriger, affichée à
+    // l'usager : la signaler noierait les vraies pannes.
+    if (!isRejectedDestination(error)) {
       Sentry.captureException(error)
     }
     followup.smsError = error?.message

--- a/backend/lib/process-error-handlers.ts
+++ b/backend/lib/process-error-handlers.ts
@@ -58,12 +58,20 @@ function jsonSafe(_key: string, value: unknown): unknown {
     : value
 }
 
+// Sérialisation clé par clé : une seule valeur fautive — référence circulaire
+// dans `code`, accesseur piégé — ne doit pas emporter `name` et `message`, qui
+// sont l'essentiel du diagnostic.
 export function formatRejection(reason: unknown): string {
-  try {
-    return JSON.stringify(summarize(reason), jsonSafe)
-  } catch (error) {
-    return `<résumé non sérialisable : ${safeString(error)}>`
-  }
+  const entries = Object.entries(summarize(reason)).map(([key, value]) => {
+    let encoded: string | undefined
+    try {
+      encoded = JSON.stringify(value, jsonSafe)
+    } catch (error) {
+      encoded = JSON.stringify(`<non sérialisable : ${safeString(error)}>`)
+    }
+    return `${JSON.stringify(key)}:${encoded ?? '"<non sérialisable>"'}`
+  })
+  return `{${entries.join(",")}}`
 }
 
 /*
@@ -89,7 +97,8 @@ export function registerProcessErrorHandlers(
     try {
       logger("unhandledRejection", formatRejection(reason))
     } catch {
-      logger("unhandledRejection", "<résumé impossible>")
+      // Rien : le seul moyen de journaliser vient d'échouer, et rappeler
+      // `logger` ici relèverait la même erreur — donc une `uncaughtException`.
     }
   })
 }

--- a/backend/lib/process-error-handlers.ts
+++ b/backend/lib/process-error-handlers.ts
@@ -1,0 +1,95 @@
+// Les erreurs des bibliothèques HTTP portent le `ClientRequest` et l'
+// `IncomingMessage` sous-jacents, qui se référencent l'un l'autre. Une copie
+// superficielle d'un tel objet perd le `toJSON` d'axios et expose la boucle :
+// c'est ce que fait pm2 avant de diffuser l'erreur au processus maître, d'où le
+// « Converting circular structure to JSON » qui remplace la trace attendue.
+// On n'en journalise donc qu'un résumé plat.
+const REPORTED_KEYS = ["name", "message", "code", "status"]
+
+function safeString(value: unknown): string {
+  try {
+    return String(value)
+  } catch {
+    // Objet sans prototype, `Symbol.toPrimitive` qui lève, accesseur piégé…
+    return "<valeur non convertible en chaîne>"
+  }
+}
+
+function safeRead(source: Record<string, unknown>, key: string): unknown {
+  try {
+    return source[key]
+  } catch (error) {
+    // `message` et `status` peuvent être des accesseurs, et lever à la lecture.
+    return `<lecture impossible : ${safeString(error)}>`
+  }
+}
+
+export function summarize(reason: unknown): Record<string, unknown> {
+  if (!(reason instanceof Error)) {
+    return { name: typeof reason, message: safeString(reason) }
+  }
+
+  const error = reason as unknown as Record<string, unknown>
+  const summary: Record<string, unknown> = {}
+  for (const key of REPORTED_KEYS) {
+    const value = safeRead(error, key)
+    if (value !== undefined) {
+      summary[key] = value
+    }
+  }
+  // `response.status` est le seul champ d'un AxiosError qui explique le rejet ;
+  // le reste de `response` porte la référence circulaire.
+  const response = safeRead(error, "response")
+  const upstreamStatus =
+    response && typeof response === "object"
+      ? safeRead(response as Record<string, unknown>, "status")
+      : undefined
+  if (upstreamStatus !== undefined) {
+    summary.upstreamStatus = upstreamStatus
+  }
+  return summary
+}
+
+// `JSON.stringify` lève sur un BigInt, et laisse tomber symboles et fonctions.
+function jsonSafe(_key: string, value: unknown): unknown {
+  const type = typeof value
+  return type === "bigint" || type === "symbol" || type === "function"
+    ? safeString(value)
+    : value
+}
+
+export function formatRejection(reason: unknown): string {
+  try {
+    return JSON.stringify(summarize(reason), jsonSafe)
+  } catch (error) {
+    return `<résumé non sérialisable : ${safeString(error)}>`
+  }
+}
+
+/*
+ * `Sentry.init` installe par défaut `onUnhandledRejectionIntegration` en mode
+ * « warn » : elle signale déjà le rejet et imprime `reason.stack`. Cet écouteur
+ * n'y ajoute qu'une ligne plate et greppable — nom, code, statut amont — que la
+ * pile seule ne donne pas et qui survit à la recopie. Il ne signale rien à
+ * Sentry : ce serait un doublon.
+ *
+ * Pas d'écouteur `uncaughtException` : Sentry installe
+ * `onUncaughtExceptionIntegration`, qui avec son défaut
+ * `exitEvenIfOtherHandlersAreRegistered: false` renonce à arrêter le processus
+ * dès qu'un écouteur étranger existe. En poser un désarmerait cet arrêt et
+ * laisserait tourner un processus dans un état corrompu.
+ */
+export function registerProcessErrorHandlers(
+  processLike: NodeJS.EventEmitter = process,
+  logger: (...args: unknown[]) => void = console.error,
+): void {
+  processLike.on("unhandledRejection", (reason: unknown) => {
+    // Un garde-fou qui lève détruit ce qu'il existe pour préserver : le rejet
+    // deviendrait une exception non rattrapée, et le résumé ne paraîtrait pas.
+    try {
+      logger("unhandledRejection", formatRejection(reason))
+    } catch {
+      logger("unhandledRejection", "<résumé impossible>")
+    }
+  })
+}

--- a/backend/lib/process-error-handlers.ts
+++ b/backend/lib/process-error-handlers.ts
@@ -94,8 +94,17 @@ export function registerProcessErrorHandlers(
   processLike.on("unhandledRejection", (reason: unknown) => {
     // Un garde-fou qui lève détruit ce qu'il existe pour préserver : le rejet
     // deviendrait une exception non rattrapée, et le résumé ne paraîtrait pas.
+    // Les deux étapes sont distinguées : un résumé impossible — `instanceof` sur
+    // un Proxy révoqué — ne doit pas passer pour un journal hors service.
+    let resume: string
     try {
-      logger("unhandledRejection", formatRejection(reason))
+      resume = formatRejection(reason)
+    } catch {
+      resume = "<résumé impossible>"
+    }
+
+    try {
+      logger("unhandledRejection", resume)
     } catch {
       // Rien : le seul moyen de journaliser vient d'échouer, et rappeler
       // `logger` ici relèverait la même erreur — donc une `uncaughtException`.

--- a/backend/lib/teleservices/demarches-simplifiees.ts
+++ b/backend/lib/teleservices/demarches-simplifiees.ts
@@ -260,10 +260,47 @@ function DemarchesSimplifiees(simulation, query) {
   this.query = query
 }
 
+// Un `AxiosError` porte le `ClientRequest` et l'`IncomingMessage` sous-jacents,
+// qui se référencent l'un l'autre : toute sérialisation JSON du rejet — celle de
+// l'IPC de pm2 comme celle du corps de réponse — lève « circular structure ».
+// L'erreur ne retient donc que ce qui est diagnosticable et sérialisable.
+export class TeleserviceMetadataError extends Error {
+  // Lu par le middleware d'erreur, qui en fait le statut de la réponse.
+  readonly code = 502
+  readonly procedure: string
+  readonly upstreamStatus?: number
+  readonly upstreamUrl: string
+
+  constructor(
+    procedure: string,
+    upstreamUrl: string,
+    upstreamStatus: number | undefined,
+    upstreamMessage: string,
+  ) {
+    super(
+      `Métadonnées du téléservice indisponibles pour la démarche « ${procedure} » : ` +
+        `GET ${upstreamUrl} a répondu ${upstreamStatus ?? "aucun statut"} (${upstreamMessage})`,
+    )
+    this.name = "TeleserviceMetadataError"
+    this.procedure = procedure
+    this.upstreamUrl = upstreamUrl
+    this.upstreamStatus = upstreamStatus
+  }
+}
+
 async function getMetaData(procedure) {
   const url = `https://www.demarches-simplifiees.fr/preremplir/${procedure}/schema`
-  const response = await axios.get(url)
-  return response.data
+  try {
+    const response = await axios.get(url)
+    return response.data
+  } catch (error: any) {
+    throw new TeleserviceMetadataError(
+      procedure,
+      url,
+      error?.response?.status,
+      error?.message || String(error),
+    )
+  }
 }
 
 function generateData(simulation, benefit) {

--- a/backend/mock.ts
+++ b/backend/mock.ts
@@ -112,7 +112,9 @@ function mock(app: express.Application) {
   })
 
   app.post("/api/followups/surveys/:id/answers", function (req, res) {
-    pollResult.postPollResult({ _id: "mock-id" }, req.body)
+    pollResult
+      .postPollResult({ _id: "mock-id" }, req.body)
+      .catch((error) => console.error("Notification Mattermost", error))
     res.sendStatus(201)
   })
 

--- a/backend/routes/france-connect.ts
+++ b/backend/routes/france-connect.ts
@@ -1,9 +1,12 @@
 import cookieParser from "cookie-parser"
 import * as franceConnectController from "../controllers/france-connect.js"
 import { Express } from "express"
+import { asyncHandler } from "../lib/async-handler.js"
 
 export default function (api: Express) {
-  api.route("/france-connect/login").get(franceConnectController.login)
+  api
+    .route("/france-connect/login")
+    .get(asyncHandler(franceConnectController.login))
 
   api
     .route("/france-connect/callback")
@@ -15,7 +18,7 @@ export default function (api: Express) {
 
   api
     .route("/france-connect/logout")
-    .get(cookieParser(), franceConnectController.logout)
+    .get(cookieParser(), asyncHandler(franceConnectController.logout))
 
   api
     .route("/france-connect/logout-callback")

--- a/backend/routes/moncomptepro.ts
+++ b/backend/routes/moncomptepro.ts
@@ -2,6 +2,7 @@ import cookieParser from "cookie-parser"
 import moncompteproController from "../controllers/moncomptepro.js"
 import { Express } from "express"
 import { rateLimit } from "express-rate-limit"
+import { asyncHandler } from "../lib/async-handler.js"
 
 const moncompteproRoutes = function (api: Express) {
   const loginRateLimiter = rateLimit({
@@ -11,7 +12,7 @@ const moncompteproRoutes = function (api: Express) {
     "/login",
     cookieParser(),
     loginRateLimiter,
-    moncompteproController.loginRoute,
+    asyncHandler(moncompteproController.login),
   )
   api.get(
     "/auth/redirect",

--- a/backend/routes/moncomptepro.ts
+++ b/backend/routes/moncomptepro.ts
@@ -11,7 +11,7 @@ const moncompteproRoutes = function (api: Express) {
     "/login",
     cookieParser(),
     loginRateLimiter,
-    moncompteproController.login,
+    moncompteproController.loginRoute,
   )
   api.get(
     "/auth/redirect",

--- a/backend/routes/proxy.ts
+++ b/backend/routes/proxy.ts
@@ -2,17 +2,24 @@ import axios from "axios"
 import { Express } from "express"
 
 export default function (api: Express) {
-  api.route("/proxy/ds").get(async (req, res) => {
-    const dataURL = `${process.env.MES_AIDES_ROOT_URL}/api/simulation/via/${req.query.token}`
-    const dataResponse = await axios.get(dataURL)
-    const { data, teleservice } = dataResponse.data
+  // Express 4 ignore la promesse renvoyée par un gestionnaire : sans `next`, un
+  // échec de démarches-simplifiées.fr devient un `unhandledRejection` et laisse
+  // la requête pendante.
+  api.route("/proxy/ds").get(async (req, res, next) => {
+    try {
+      const dataURL = `${process.env.MES_AIDES_ROOT_URL}/api/simulation/via/${req.query.token}`
+      const dataResponse = await axios.get(dataURL)
+      const { data, teleservice } = dataResponse.data
 
-    const postResponse = await axios.post(
-      `https://www.demarches-simplifiees.fr/api/public/v1/demarches/${teleservice.id}/dossiers`,
-      data,
-    )
-    const postData = postResponse.data
+      const postResponse = await axios.post(
+        `https://www.demarches-simplifiees.fr/api/public/v1/demarches/${teleservice.id}/dossiers`,
+        data,
+      )
+      const postData = postResponse.data
 
-    res.redirect(postData.dossier_url)
+      res.redirect(postData.dossier_url)
+    } catch (error) {
+      next(error)
+    }
   })
 }

--- a/backend/routes/proxy.ts
+++ b/backend/routes/proxy.ts
@@ -1,12 +1,10 @@
 import axios from "axios"
 import { Express } from "express"
+import { asyncHandler } from "../lib/async-handler.js"
 
 export default function (api: Express) {
-  // Express 4 ignore la promesse renvoyée par un gestionnaire : sans `next`, un
-  // échec de démarches-simplifiées.fr devient un `unhandledRejection` et laisse
-  // la requête pendante.
-  api.route("/proxy/ds").get(async (req, res, next) => {
-    try {
+  api.route("/proxy/ds").get(
+    asyncHandler(async (req, res) => {
       const dataURL = `${process.env.MES_AIDES_ROOT_URL}/api/simulation/via/${req.query.token}`
       const dataResponse = await axios.get(dataURL)
       const { data, teleservice } = dataResponse.data
@@ -18,8 +16,6 @@ export default function (api: Express) {
       const postData = postResponse.data
 
       res.redirect(postData.dossier_url)
-    } catch (error) {
-      next(error)
-    }
-  })
+    }),
+  )
 }

--- a/backend/routes/simulation.ts
+++ b/backend/routes/simulation.ts
@@ -6,6 +6,7 @@ import { persist } from "../controllers/followups.js"
 import simulationController from "../controllers/simulation.js"
 import simulationDemo from "../controllers/simulation-demo.js"
 import teleservices from "../controllers/teleservices/index.js"
+import { asyncHandler } from "../lib/async-handler.js"
 
 export default function (api: Express) {
   api.options("/simulation", cors())
@@ -71,7 +72,11 @@ export default function (api: Express) {
     teleservices.exportRepresentation,
   )
 
-  api.get("/simulation/demo", cors({ origin: "*" }), simulationDemo.get)
+  api.get(
+    "/simulation/demo",
+    cors({ origin: "*" }),
+    asyncHandler(simulationDemo.get),
+  )
 
   const specificSimulationRoutes = express.Router({ mergeParams: true })
   api.use("/simulation/", specificSimulationRoutes)

--- a/lib/enums/error.ts
+++ b/lib/enums/error.ts
@@ -1,5 +1,9 @@
 export enum ErrorType {
   UnsupportedPhoneNumberFormat = "Unsupported phone number format",
+  // Refus du fournisseur de SMS pour un numéro au format accepté mais non
+  // joignable. Le libellé vient du fournisseur et arrive imbriqué dans le corps
+  // de sa réponse : il se reconnaît par inclusion, pas par égalité.
+  InvalidDestinationAddress = "Invalid destination address",
   PersistingFollowup = "Persisting followup error",
   MissingFollowupPhone = "Missing followup phone",
   MissingFollowupEmail = "Missing followup email",
@@ -17,4 +21,5 @@ export enum ErrorStatus {
 
 export enum ErrorName {
   ValidationError = "ValidationError",
+  SmsProviderError = "SmsProviderError",
 }

--- a/lib/enums/error.ts
+++ b/lib/enums/error.ts
@@ -22,4 +22,26 @@ export enum ErrorStatus {
 export enum ErrorName {
   ValidationError = "ValidationError",
   SmsProviderError = "SmsProviderError",
+  MattermostNotConfiguredError = "MattermostNotConfiguredError",
+}
+
+// Refus du fournisseur pour un numéro non joignable : l'usager qui réessaie
+// obtient le même refus. Partagé par le service et le contrôleur, qui sans cela
+// en donnent deux définitions divergentes.
+export function isRejectedDestination(error: any): boolean {
+  if (error?.name !== ErrorName.SmsProviderError) {
+    return false
+  }
+  const message = typeof error?.message === "string" ? error.message : ""
+  return message.includes(ErrorType.InvalidDestinationAddress)
+}
+
+// Conditions dues à la saisie de l'usager : une entrée irrecevable, pas une
+// panne, et reproductible à chaque nouvelle tentative.
+export function isUserInputError(error: any): boolean {
+  return (
+    error?.name === ErrorName.ValidationError ||
+    error?.message === ErrorType.UnsupportedPhoneNumberFormat ||
+    isRejectedDestination(error)
+  )
 }

--- a/src/components/recap-email-and-sms-form.vue
+++ b/src/components/recap-email-and-sms-form.vue
@@ -7,6 +7,7 @@ import { useRouter } from "vue-router"
 import * as Sentry from "@sentry/vue"
 import StatisticsMixin from "@/mixins/statistics.js"
 import { EventCategory, EventAction } from "@lib/enums/event.js"
+import { ErrorType } from "@lib/enums/error.js"
 
 const router = useRouter()
 const store = useStore()
@@ -38,6 +39,14 @@ const inputPhonePattern = computed(() => {
 
 const showSms = process.env.VITE_SHOW_SMS_TAB
 
+// Un numéro refusé par le fournisseur est une saisie à corriger, affichée à
+// l'usager : la signaler à Sentry noierait les vraies pannes. Le serveur répond
+// 422 et conserve le libellé du fournisseur dans le corps.
+const isRejectedDestination = (error: any) =>
+  (error?.response?.data?.toString() || "").includes(
+    ErrorType.InvalidDestinationAddress,
+  )
+
 const sendRecap = async () => {
   const optin = surveyOptin.value
   try {
@@ -60,11 +69,10 @@ const sendRecap = async () => {
       emailInputErrorMessage.value = true
     }
   } catch (error: any) {
-    const errorMessage = error?.response?.data?.toString() || ""
-    if (!errorMessage.includes("Invalid destination address")) {
-      Sentry.captureException(error)
-    } else {
+    if (isRejectedDestination(error)) {
       store.setFormRecapPhoneState("invalid-address")
+    } else {
+      Sentry.captureException(error)
     }
   }
 }
@@ -124,7 +132,9 @@ const sendRecapByEmailAndSms = async (surveyOptin) => {
     store.setModalState(undefined)
     await postFollowup(surveyOptin, emailValue.value, phoneValue.value)
   } catch (error) {
-    Sentry.captureException(error)
+    if (!isRejectedDestination(error)) {
+      Sentry.captureException(error)
+    }
     store.setFormRecapState("error")
     throw error
   }
@@ -144,7 +154,9 @@ const sendRecapBySms = async (surveyOptin) => {
     store.setModalState(undefined)
     await postFollowup(surveyOptin, undefined, phoneValue.value)
   } catch (error) {
-    Sentry.captureException(error)
+    if (!isRejectedDestination(error)) {
+      Sentry.captureException(error)
+    }
     store.setFormRecapPhoneState("error")
     throw error
   }

--- a/tests/unit/backend/followup-persist.spec.ts
+++ b/tests/unit/backend/followup-persist.spec.ts
@@ -1,0 +1,284 @@
+import { expect, vi } from "vitest"
+
+// Le chargement du module lit le système de fichiers, ce que l'environnement
+// de test ne permet pas ; seul `apply` est utilisé par le contrôleur.
+vi.mock("@backend/lib/migrations/index.js", () => ({
+  apply: (simulation) => simulation,
+}))
+
+vi.mock("@backend/lib/followup-factory.js", () => ({
+  FollowupFactory: { create: vi.fn(), createWithResults: vi.fn() },
+}))
+
+vi.mock("@backend/lib/messaging/email/email-service.js", () => ({
+  sendSimulationResultsEmail: vi.fn(),
+}))
+
+// Seul l'envoi est simulé : `SmsProviderError` reste la vraie classe, pour que
+// les cas ci-dessous rejettent l'objet que le service produit réellement.
+vi.mock(
+  "@backend/lib/messaging/sms/sms-service.js",
+  async (importOriginal) => ({
+    ...((await importOriginal()) as object),
+    sendSimulationResultsSms: vi.fn(),
+  }),
+)
+
+vi.mock("@backend/lib/mattermost-bot/poll-result.js", () => ({
+  default: { postPollResult: vi.fn() },
+}))
+
+vi.mock("@sentry/node", () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  setupExpressErrorHandler: vi.fn(),
+}))
+
+import * as Sentry from "@sentry/node"
+import pollResult from "@backend/lib/mattermost-bot/poll-result.js"
+import { persist, postSurvey } from "@backend/controllers/followups.js"
+import { FollowupFactory } from "@backend/lib/followup-factory.js"
+import { sendSimulationResultsEmail } from "@backend/lib/messaging/email/email-service.js"
+import {
+  sendSimulationResultsSms,
+  SmsProviderError,
+} from "@backend/lib/messaging/sms/sms-service.js"
+
+const SIMULATION_ID = "6a76a643e1ed9101a793e122"
+
+// Corps que le fournisseur renvoie sous un HTTP 200 pour refuser le numéro ;
+// l'intercepteur de `sms-service` le transforme en `SmsProviderError`.
+const PROVIDER_REJECTION_BODY = {
+  responseCode: 3,
+  responseMessage: "Invalid destination address",
+}
+
+function mockResponse() {
+  const res: any = { statusCode: undefined, body: undefined }
+  res.status = vi.fn((code) => {
+    res.statusCode = code
+    return res
+  })
+  res.send = vi.fn((body) => {
+    res.body = body
+    return res
+  })
+  return res
+}
+
+function request(body) {
+  return {
+    body,
+    simulation: { _id: SIMULATION_ID },
+  } as any
+}
+
+describe("persist", () => {
+  let consoleSpy
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    vi.mocked(FollowupFactory.createWithResults).mockResolvedValue({} as any)
+    vi.mocked(sendSimulationResultsEmail).mockResolvedValue({} as any)
+    vi.mocked(sendSimulationResultsSms).mockResolvedValue({} as any)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("répond 200 quand les deux envois aboutissent", async () => {
+    const res = mockResponse()
+
+    await persist(
+      request({ email: "usager@exemple.fr", phone: "0600000000" }),
+      res,
+    )
+
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.send).toHaveBeenCalledWith({ result: "OK" })
+  })
+
+  describe("refus du numéro par le fournisseur de SMS", () => {
+    beforeEach(() => {
+      vi.mocked(sendSimulationResultsSms).mockRejectedValue(
+        new SmsProviderError(PROVIDER_REJECTION_BODY, 200),
+      )
+    })
+
+    // Un numéro au bon format mais non joignable est une entrée irrecevable :
+    // l'usager qui réessaie obtient le même refus, indéfiniment.
+    it("répond 422 et non 500", async () => {
+      const res = mockResponse()
+
+      await persist(request({ phone: "0600000000" }), res)
+
+      expect(res.status).toHaveBeenCalledWith(422)
+    })
+
+    // `sms-service` exclut délibérément ce refus de Sentry ; le signaler ici
+    // annulerait cette exclusion.
+    it("ne le signale pas à Sentry", async () => {
+      await persist(request({ phone: "0600000000" }), mockResponse())
+
+      expect(Sentry.captureException).not.toHaveBeenCalled()
+    })
+
+    // Sans table de correspondance des codes du fournisseur, `responseCode` ne
+    // sert pas encore à classer ; le journaliser rend observables ceux qui
+    // arrivent réellement, seule voie vers une classification exacte.
+    it("journalise le code de refus du fournisseur", async () => {
+      await persist(request({ phone: "0600000000" }), mockResponse())
+
+      const logged = consoleSpy.mock.calls
+        .map((call) => call.map(String).join(" "))
+        .join("\n")
+
+      expect(logged).toContain('"responseCode":3')
+      expect(logged).toContain("422")
+    })
+
+    // Le formulaire de récapitulatif distingue ce cas sur le corps de la
+    // réponse pour afficher un message dédié.
+    it("conserve le libellé du fournisseur dans le corps", async () => {
+      const res = mockResponse()
+
+      await persist(request({ phone: "0600000000" }), res)
+
+      expect(res.body).toContain("Invalid destination address")
+    })
+  })
+
+  describe("panne réelle", () => {
+    const openfiscaFailure = Object.assign(
+      new Error("Request failed with status code 502"),
+      {
+        name: "AxiosError",
+        code: "ERR_BAD_RESPONSE",
+        response: { status: 502 },
+      },
+    )
+
+    beforeEach(() => {
+      vi.mocked(FollowupFactory.createWithResults).mockRejectedValue(
+        openfiscaFailure,
+      )
+    })
+
+    it("répond 500 et le signale à Sentry", async () => {
+      const res = mockResponse()
+
+      await persist(request({ email: "usager@exemple.fr" }), res)
+
+      expect(res.status).toHaveBeenCalledWith(500)
+      expect(Sentry.captureException).toHaveBeenCalledWith(openfiscaFailure)
+    })
+
+    // Sans trace applicative, un 500 sur cette route ne laisse dans les
+    // journaux du serveur que la ligne d'accès : le statut, jamais la cause.
+    it("journalise la route, la simulation et la cause", async () => {
+      await persist(request({ email: "usager@exemple.fr" }), mockResponse())
+
+      const logged = consoleSpy.mock.calls
+        .map((call) => call.map(String).join(" "))
+        .join("\n")
+
+      expect(logged).toContain(`/api/simulation/${SIMULATION_ID}/followup`)
+      expect(logged).toContain("500")
+      expect(logged).toContain("AxiosError")
+      expect(logged).toContain("ERR_BAD_RESPONSE")
+      expect(logged).toContain("Request failed with status code 502")
+      expect(logged).toContain('"upstreamStatus":502')
+      expect(logged).toContain('"channels":{"email":true,"phone":false}')
+    })
+  })
+
+  describe("erreur de validation du modèle", () => {
+    const validationError = Object.assign(
+      new Error("Followup validation failed: email"),
+      { name: "ValidationError" },
+    )
+
+    beforeEach(() => {
+      vi.mocked(FollowupFactory.createWithResults).mockRejectedValue(
+        validationError,
+      )
+    })
+
+    it("répond 422", async () => {
+      const res = mockResponse()
+
+      await persist(request({ email: "pas-une-adresse" }), res)
+
+      expect(res.status).toHaveBeenCalledWith(422)
+    })
+
+    // Une `ValidationError` peut trahir un défaut de code, pas seulement une
+    // saisie : la taire priverait Sentry du seul signal disponible.
+    it("reste signalée à Sentry", async () => {
+      await persist(request({ email: "pas-une-adresse" }), mockResponse())
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(validationError)
+    })
+  })
+
+  // Chemin « obtenir un lien de récapitulatif » : POST sans courriel ni
+  // téléphone. `createSimulationRecapUrl` étant asynchrone, son rejet doit
+  // atteindre le `catch` de `persist` au lieu de le contourner.
+  describe("lien de récapitulatif", () => {
+    it("répond au lieu de rejeter quand la création du followup échoue", async () => {
+      const failure = new Error("MongoNetworkError: connexion perdue")
+      vi.mocked(FollowupFactory.create).mockRejectedValue(failure)
+      const res = mockResponse()
+
+      const settled = await persist(request({ surveyOptin: false }), res).then(
+        () => "resolue",
+        () => "rejetee",
+      )
+
+      expect(settled).toBe("resolue")
+      expect(res.status).toHaveBeenCalledWith(500)
+      expect(Sentry.captureException).toHaveBeenCalledWith(failure)
+    })
+  })
+
+  it("répond 422 sur un format de numéro refusé en amont", async () => {
+    vi.mocked(sendSimulationResultsSms).mockRejectedValue(
+      new Error("Unsupported phone number format"),
+    )
+    const res = mockResponse()
+
+    await persist(request({ phone: "12" }), res)
+
+    expect(res.status).toHaveBeenCalledWith(422)
+  })
+})
+
+// La notification Mattermost part sans être attendue : depuis que
+// `Mattermost.post` propage ses échecs, son rejet doit être rattrapé sur place,
+// sous peine de redevenir un `unhandledRejection`.
+describe("postSurvey", () => {
+  it("rattrape l'échec de la notification sans faire échouer la requête", async () => {
+    vi.clearAllMocks()
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+    const failure = new Error("connect ECONNREFUSED")
+    vi.mocked(pollResult.postPollResult).mockRejectedValue(failure)
+
+    const res: any = { sendStatus: vi.fn() }
+    const req: any = {
+      followup: { updateSurvey: vi.fn().mockResolvedValue(undefined) },
+      body: [{ id: "aide", value: "asked" }],
+    }
+
+    postSurvey(req, res, vi.fn())
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(res.sendStatus).toHaveBeenCalledWith(201)
+    expect(Sentry.captureException).toHaveBeenCalledWith(failure)
+    expect(consoleSpy).toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+})

--- a/tests/unit/backend/unhandled-rejections.spec.ts
+++ b/tests/unit/backend/unhandled-rejections.spec.ts
@@ -1,0 +1,277 @@
+import { expect, vi } from "vitest"
+
+vi.mock("axios", () => ({
+  default: { get: vi.fn(), post: vi.fn(), defaults: {} },
+}))
+
+vi.mock("openid-client", () => ({
+  discovery: vi.fn(),
+  buildAuthorizationUrl: vi.fn(),
+  buildEndSessionUrl: vi.fn(),
+  authorizationCodeGrant: vi.fn(),
+  fetchUserInfo: vi.fn(),
+}))
+
+// Le chargement du module lit le système de fichiers, ce que l'environnement
+// de test ne permet pas ; seul `apply` est utilisé par le contrôleur.
+vi.mock("@backend/lib/migrations/index.js", () => ({
+  apply: (simulation) => simulation,
+}))
+
+import axios from "axios"
+import { discovery } from "openid-client"
+import config from "@backend/config/index.js"
+import moncompteproController from "@backend/controllers/moncomptepro.js"
+import teleservices from "@backend/controllers/teleservices/index.js"
+import DemarchesSimplifiees, {
+  TeleserviceMetadataError,
+} from "@backend/lib/teleservices/demarches-simplifiees.js"
+import {
+  formatRejection,
+  registerProcessErrorHandlers,
+  summarize,
+} from "@backend/lib/process-error-handlers.js"
+
+// Un AxiosError de production : `request.res` et `response.request` se
+// référencent l'un l'autre. C'est cette boucle qui fait échouer la
+// sérialisation du rejet par l'IPC de pm2.
+function circularAxios404() {
+  const request: any = { path: "/preremplir/cd53-bafa/schema" }
+  const response: any = { status: 404, data: "<html>404</html>", request }
+  request.res = response
+  return Object.assign(new Error("Request failed with status code 404"), {
+    name: "AxiosError",
+    isAxiosError: true,
+    code: "ERR_BAD_REQUEST",
+    request,
+    response,
+  })
+}
+
+function metadataRequest() {
+  return {
+    simulation: { _id: "6a7680b4dce0e73de131d0e1", token: "jeton-simulation" },
+    query: { procedure: "cd53-bafa" },
+    protocol: "https",
+    get: () => "mes-aides.exemple",
+  }
+}
+
+describe("metadataResponseGenerator", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("passe le rejet de toInternal() à next() au lieu de laisser la requête pendante", async () => {
+    const failure = new Error("téléservice injoignable")
+    function FailingTeleservice() {}
+    FailingTeleservice.prototype.toInternal = () => Promise.reject(failure)
+
+    const handler = teleservices.metadataResponseGenerator({
+      name: "ds",
+      class: FailingTeleservice,
+      destination: { label: "Aller sur le téléservice", url: "/api/proxy/ds" },
+    })
+
+    const next = vi.fn()
+    const res: any = { json: vi.fn() }
+
+    // Express 4 n'attend pas la promesse renvoyée par un gestionnaire ; on la
+    // neutralise ici pour observer le gestionnaire, pas le harnais de test.
+    await Promise.resolve(handler(metadataRequest() as any, res, next)).catch(
+      () => undefined,
+    )
+
+    expect(res.json).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledWith(failure)
+  })
+
+  it("répond quand le téléservice est joignable", async () => {
+    function WorkingTeleservice() {}
+    WorkingTeleservice.prototype.toInternal = async () => [
+      { label: "Date de naissance", value: "2001-02-03" },
+    ]
+
+    const handler = teleservices.metadataResponseGenerator({
+      name: "ds",
+      class: WorkingTeleservice,
+      destination: { label: "Aller sur le téléservice", url: "/api/proxy/ds" },
+    })
+
+    const next = vi.fn()
+    const res: any = { json: vi.fn() }
+
+    await handler(metadataRequest() as any, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.json.mock.calls[0][0].fields).toEqual([
+      { label: "Date de naissance", value: "2001-02-03" },
+    ])
+  })
+})
+
+describe("getMetaData", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("convertit un 404 du téléservice en erreur nommée et diffusable", async () => {
+    vi.mocked(axios.get).mockRejectedValue(circularAxios404())
+
+    const teleservice = new (DemarchesSimplifiees as any)(
+      { answers: { current: [] }, enfants: [] },
+      { procedure: "cd53-bafa" },
+    )
+    const error: any = await teleservice.toInternal().then(
+      () => null,
+      (rejection) => rejection,
+    )
+
+    expect(error).toBeInstanceOf(TeleserviceMetadataError)
+    expect(error.name).toBe("TeleserviceMetadataError")
+    expect(error.procedure).toBe("cd53-bafa")
+    expect(error.upstreamStatus).toBe(404)
+    // Statut renvoyé au client par le middleware d'erreur : la démarche visée
+    // n'existe plus côté tiers, la page de consentement est inconstructible.
+    expect(error.code).toBe(502)
+    expect(error.message).toContain("cd53-bafa")
+    expect(error.message).toContain("404")
+
+    // pm2 recopie l'erreur avant de la diffuser au processus maître. Une copie
+    // superficielle perd le `toJSON` d'axios et expose la boucle req/res : la
+    // sérialisation lève, et l'erreur d'origine disparaît sans laisser de trace.
+    expect(() => JSON.stringify({ ...error })).not.toThrow()
+    expect(JSON.parse(JSON.stringify({ ...error }))).toMatchObject({
+      name: "TeleserviceMetadataError",
+      procedure: "cd53-bafa",
+      upstreamStatus: 404,
+      code: 502,
+    })
+  })
+
+  it("laisse passer les métadonnées quand le téléservice répond", async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: {
+        revision: {
+          champDescriptors: [{ id: "Q2hhbXAtMzc2NDE0", label: "Naissance" }],
+        },
+      },
+    })
+
+    const teleservice = new (DemarchesSimplifiees as any)(
+      {
+        answers: {
+          current: [
+            {
+              id: "demandeur",
+              entityName: "individu",
+              fieldName: "date_naissance",
+              value: "2001-02-03",
+            },
+          ],
+        },
+        enfants: [],
+      },
+      { procedure: "cd53-bafa" },
+    )
+
+    await expect(teleservice.toInternal()).resolves.toEqual([
+      { label: "Naissance", value: "2001-02-03" },
+    ])
+  })
+})
+
+// `access` protège cinq groupes de routes : /api/followups/surveys,
+// /api/followups/id/:surveyId, /api/followups/email/:email, /auth/redirect et
+// /support. Un fournisseur d'identité injoignable y laissait la requête pendre.
+describe("moncomptepro.access", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("redirige au lieu de rejeter quand le fournisseur d'identité est injoignable", async () => {
+    const failure = new Error("only requests to HTTPS are allowed")
+    vi.mocked(discovery).mockRejectedValue(failure)
+
+    const res: any = { redirect: vi.fn(), clearCookie: vi.fn() }
+    const next = vi.fn()
+
+    const settled = await moncompteproController
+      .access({ cookies: {}, query: {} } as any, res, next)
+      .then(
+        () => "resolue",
+        () => "rejetee",
+      )
+
+    expect(settled).toBe("resolue")
+    expect(res.redirect).toHaveBeenCalledWith(config.accompagnement.errorPath)
+    expect(next).not.toHaveBeenCalled()
+  })
+})
+
+describe("registerProcessErrorHandlers", () => {
+  it("journalise un rejet non rattrapé sous une forme sérialisable", () => {
+    const listeners: Record<string, ((reason: unknown) => void)[]> = {}
+    const processLike: any = {
+      on: (event: string, listener: (reason: unknown) => void) => {
+        listeners[event] = listeners[event] || []
+        listeners[event].push(listener)
+      },
+    }
+    const logger = vi.fn()
+
+    registerProcessErrorHandlers(processLike, logger)
+    expect(listeners.unhandledRejection).toHaveLength(1)
+
+    listeners.unhandledRejection[0](circularAxios404())
+
+    const [label, payload] = logger.mock.calls[0]
+    expect(label).toBe("unhandledRejection")
+    expect(JSON.parse(payload as string)).toEqual({
+      name: "AxiosError",
+      message: "Request failed with status code 404",
+      code: "ERR_BAD_REQUEST",
+      upstreamStatus: 404,
+    })
+  })
+
+  it("résume un rejet qui n'est pas une erreur", () => {
+    expect(summarize("boom")).toEqual({ name: "string", message: "boom" })
+  })
+
+  // Un garde-fou qui lève détruit ce qu'il existe pour préserver : le rejet
+  // deviendrait une exception non rattrapée, et rien ne serait journalisé.
+  describe("charges hostiles", () => {
+    function messageQuiLeve() {
+      const error = new Error("remplacé")
+      Object.defineProperty(error, "message", {
+        get() {
+          throw new Error("getter explose")
+        },
+      })
+      return error
+    }
+
+    it.each([
+      ["un code BigInt", () => Object.assign(new Error("b"), { code: 1n })],
+      ["un message qui lève à la lecture", messageQuiLeve],
+      ["un objet sans prototype", () => Object.create(null)],
+      ["un symbole", () => Symbol("boom")],
+      ["undefined", () => undefined],
+    ])("journalise malgré %s", (_libelle, build) => {
+      const listeners: ((reason: unknown) => void)[] = []
+      const processLike: any = {
+        on: (_event: string, listener: (reason: unknown) => void) =>
+          listeners.push(listener),
+      }
+      const logger = vi.fn()
+      registerProcessErrorHandlers(processLike, logger)
+
+      expect(() => listeners[0](build())).not.toThrow()
+      expect(logger).toHaveBeenCalledTimes(1)
+      expect(logger.mock.calls[0][0]).toBe("unhandledRejection")
+      expect(typeof logger.mock.calls[0][1]).toBe("string")
+      expect(logger.mock.calls[0][1]).not.toBe("")
+    })
+
+    it("conserve la valeur du code BigInt dans le résumé", () => {
+      expect(
+        formatRejection(Object.assign(new Error("b"), { code: 1n })),
+      ).toContain('"code":"1"')
+    })
+  })
+})

--- a/tests/unit/backend/unhandled-rejections.spec.ts
+++ b/tests/unit/backend/unhandled-rejections.spec.ts
@@ -15,15 +15,17 @@ vi.mock("openid-client", () => ({
 // Le chargement du module lit le système de fichiers, ce que l'environnement
 // de test ne permet pas ; seul `apply` est utilisé par le contrôleur.
 vi.mock("@backend/lib/migrations/index.js", () => ({
-  apply: (simulation) => simulation,
+  apply: vi.fn((simulation) => simulation),
 }))
 
 import axios from "axios"
 import { discovery } from "openid-client"
 import config from "@backend/config/index.js"
+import { apply } from "@backend/lib/migrations/index.js"
 import moncompteproController from "@backend/controllers/moncomptepro.js"
 import teleservices from "@backend/controllers/teleservices/index.js"
 import franceConnectRoutes from "@backend/routes/france-connect.js"
+import { asyncHandler } from "@backend/lib/async-handler.js"
 import DemarchesSimplifiees, {
   TeleserviceMetadataError,
 } from "@backend/lib/teleservices/demarches-simplifiees.js"
@@ -363,10 +365,140 @@ describe("routes france-connect", () => {
     }
     const req: any = { cookies: {}, query: {} }
 
-    await Promise.resolve(handler(req, res, next)).catch(() => undefined)
+    // Express n'attend pas la promesse renvoyée : on draine la file plutôt que
+    // de dépendre de ce que le gestionnaire rend.
+    handler(req, res, next)
+    await new Promise((resolve) => setImmediate(resolve))
 
     expect(res.redirect).not.toHaveBeenCalled()
     expect(next).toHaveBeenCalledTimes(1)
     expect(next.mock.calls[0][0]).toBeInstanceOf(TypeError)
+  })
+})
+
+// `/api/simulation/via/:signedPayload` est atteignable sans authentification :
+// `decodePayload` décode le jeton sans en vérifier la signature, `ds` est un
+// téléservice public, et `verifyRequest` n'intervient qu'après avoir chargé la
+// simulation. Le `payload.id` est donc entièrement choisi par l'appelant.
+describe("/api/simulation/via/:signedPayload avec un jeton non signé", () => {
+  function unsignedToken(payload: object) {
+    const encode = (value: object) =>
+      Buffer.from(JSON.stringify(value)).toString("base64url")
+    return [
+      encode({ alg: "HS256", typ: "JWT" }),
+      encode(payload),
+      "signature-bidon",
+    ].join(".")
+  }
+
+  afterEach(() => {
+    vi.mocked(apply).mockImplementation((simulation) => simulation)
+  })
+
+  it("répond au lieu de retenir le socket quand la charge fait lever apply()", async () => {
+    // Ce que la revue a observé en production sur un `id` objet.
+    vi.mocked(apply).mockImplementation(() => {
+      throw new TypeError(
+        "Cannot read properties of undefined (reading 'toLowerCase')",
+      )
+    })
+
+    const req: any = {}
+    const res: any = { status: vi.fn().mockReturnThis(), send: vi.fn() }
+
+    // Le jeton n'est pas signé : `decodePayload` l'accepte tout de même.
+    const decoded = vi.fn()
+    teleservices.decodePayload(
+      req,
+      res,
+      decoded,
+      unsignedToken({
+        id: { _id: "charge-choisie-par-l-appelant" },
+        scope: "ds",
+      }),
+    )
+    expect(decoded).toHaveBeenCalledTimes(1)
+    expect(req.payload.id).toEqual({ _id: "charge-choisie-par-l-appelant" })
+
+    // `checkCredentials` laisse passer : `ds` est public.
+    const authorised = vi.fn()
+    teleservices.checkCredentials(req, res, authorised)
+    expect(authorised).toHaveBeenCalledTimes(1)
+
+    // `attachPayloadSituation` appelle `simulation()` sans rendre la promesse :
+    // si le jet n'est pas rattrapé dedans, plus rien ne répond.
+    const next = vi.fn()
+    teleservices.attachPayloadSituation(req, res, next)
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(next.mock.calls[0][0]).toBeInstanceOf(TypeError)
+  })
+})
+
+describe("asyncHandler", () => {
+  // Un gestionnaire `param` reçoit `(req, res, next, valeur, nom)`. Une
+  // enveloppe à trois arguments les lui retire en silence : ni le typage ni
+  // l'exécution ne le signalent, et le paramètre devient `undefined`.
+  it("propage les arguments d'un gestionnaire param", async () => {
+    const handler = vi.fn(async () => undefined)
+    const next = vi.fn()
+
+    await asyncHandler(handler)(
+      {} as any,
+      {} as any,
+      next,
+      "valeur42",
+      "accessToken",
+    )
+
+    expect(handler).toHaveBeenCalledWith(
+      {},
+      {},
+      next,
+      "valeur42",
+      "accessToken",
+    )
+  })
+
+  // Express distingue un middleware d'erreur par l'arité : 4 le convertirait
+  // en gestionnaire d'erreur et le sortirait de la chaîne normale.
+  it("garde une arité de 3", () => {
+    expect(asyncHandler(async () => undefined).length).toBe(3)
+  })
+
+  it("rend à next() le jet synchrone d'un gestionnaire non asynchrone", async () => {
+    const failure = new TypeError("Invalid URL")
+    const next = vi.fn()
+
+    await asyncHandler(() => {
+      throw failure
+    })({} as any, {} as any, next)
+
+    expect(next).toHaveBeenCalledWith(failure)
+  })
+})
+
+// Deux modes d'échec distincts : un résumé impossible n'est pas un journal hors
+// service, et confondre les deux fait tout perdre dans le premier cas.
+describe("registerProcessErrorHandlers, résumé impossible", () => {
+  it("journalise un repli quand summarize lève mais que le journal est sain", () => {
+    const listeners: ((reason: unknown) => void)[] = []
+    const processLike: any = {
+      on: (_event: string, listener: (reason: unknown) => void) =>
+        listeners.push(listener),
+    }
+    const logger = vi.fn()
+    registerProcessErrorHandlers(processLike, logger)
+
+    // `summarize` teste `reason instanceof Error`, ce qui lève ici.
+    const { proxy, revoke } = Proxy.revocable({}, {})
+    revoke()
+
+    expect(() => listeners[0](proxy)).not.toThrow()
+    expect(logger).toHaveBeenCalledWith(
+      "unhandledRejection",
+      "<résumé impossible>",
+    )
   })
 })

--- a/tests/unit/backend/unhandled-rejections.spec.ts
+++ b/tests/unit/backend/unhandled-rejections.spec.ts
@@ -23,6 +23,7 @@ import { discovery } from "openid-client"
 import config from "@backend/config/index.js"
 import moncompteproController from "@backend/controllers/moncomptepro.js"
 import teleservices from "@backend/controllers/teleservices/index.js"
+import franceConnectRoutes from "@backend/routes/france-connect.js"
 import DemarchesSimplifiees, {
   TeleserviceMetadataError,
 } from "@backend/lib/teleservices/demarches-simplifiees.js"
@@ -32,20 +33,25 @@ import {
   summarize,
 } from "@backend/lib/process-error-handlers.js"
 
-// Un AxiosError de production : `request.res` et `response.request` se
+// `axios` est simulé pour le reste du fichier ; l'oracle de sérialisation, lui,
+// exige la vraie classe : un objet approchant serait plus facile à résumer que
+// ce qui arrive réellement en production.
+const { AxiosError } = await vi.importActual<typeof import("axios")>("axios")
+
+// Un AxiosError de production : le `ClientRequest` et l'`IncomingMessage` se
 // référencent l'un l'autre. C'est cette boucle qui fait échouer la
-// sérialisation du rejet par l'IPC de pm2.
+// sérialisation du rejet une fois recopié.
 function circularAxios404() {
   const request: any = { path: "/preremplir/cd53-bafa/schema" }
   const response: any = { status: 404, data: "<html>404</html>", request }
   request.res = response
-  return Object.assign(new Error("Request failed with status code 404"), {
-    name: "AxiosError",
-    isAxiosError: true,
-    code: "ERR_BAD_REQUEST",
+  return new AxiosError(
+    "Request failed with status code 404",
+    AxiosError.ERR_BAD_REQUEST,
+    { url: "https://www.demarches-simplifiees.fr" } as any,
     request,
     response,
-  })
+  )
 }
 
 function metadataRequest() {
@@ -225,8 +231,53 @@ describe("registerProcessErrorHandlers", () => {
       name: "AxiosError",
       message: "Request failed with status code 404",
       code: "ERR_BAD_REQUEST",
+      status: 404,
       upstreamStatus: 404,
     })
+  })
+
+  // La recopie que subit l'erreur avant diffusion lui ôte le `toJSON` d'axios
+  // et expose la boucle req/res : c'est ce que le résumé doit remplacer.
+  it("résume une erreur que la recopie rend insérialisable", () => {
+    expect(() => JSON.stringify({ ...circularAxios404() })).toThrow(
+      /circular structure/i,
+    )
+    expect(() => JSON.parse(formatRejection(circularAxios404()))).not.toThrow()
+  })
+
+  // Une valeur fautive ne doit pas emporter les champs voisins, qui portent
+  // l'essentiel du diagnostic.
+  it("conserve name et message quand une autre clé est insérialisable", () => {
+    const boucle: any = {}
+    boucle.soi = boucle
+    const resume = JSON.parse(
+      formatRejection(
+        Object.assign(new Error("panne amont"), {
+          name: "AxiosError",
+          code: boucle,
+        }),
+      ),
+    )
+
+    expect(resume.name).toBe("AxiosError")
+    expect(resume.message).toBe("panne amont")
+    expect(resume.code).toContain("non sérialisable")
+  })
+
+  it("ne relance pas un logger qui vient d'échouer", () => {
+    const listeners: ((reason: unknown) => void)[] = []
+    const processLike: any = {
+      on: (_event: string, listener: (reason: unknown) => void) =>
+        listeners.push(listener),
+    }
+    const logger = vi.fn(() => {
+      throw new Error("stderr fermé")
+    })
+
+    registerProcessErrorHandlers(processLike, logger)
+
+    expect(() => listeners[0](new Error("peu importe"))).not.toThrow()
+    expect(logger).toHaveBeenCalledTimes(1)
   })
 
   it("résume un rejet qui n'est pas une erreur", () => {
@@ -273,5 +324,49 @@ describe("registerProcessErrorHandlers", () => {
         formatRejection(Object.assign(new Error("b"), { code: 1n })),
       ).toContain('"code":"1"')
     })
+  })
+})
+
+// `/api/france-connect/login` et `/logout` sont montés nus : leur rejet n'a
+// personne pour le recevoir. En production `FRANCE_CONNECT_ROOT_URL` est
+// absente, donc `new URL("undefined/api/v1/authorize")` lève à chaque appel et
+// la requête pend jusqu'au délai du client.
+describe("routes france-connect", () => {
+  // Enregistre les gestionnaires montés, pour éprouver le câblage réel et non
+  // le seul contrôleur.
+  function mountedHandlers(path: string) {
+    const routes: Record<string, any[]> = {}
+    const api: any = {
+      route: (p: string) => ({
+        get: (...handlers: any[]) => {
+          routes[p] = handlers
+          return api
+        },
+      }),
+    }
+    franceConnectRoutes(api)
+    return routes[path]
+  }
+
+  it.each([
+    ["/france-connect/login", "/france-connect/login"],
+    ["/france-connect/logout", "/france-connect/logout"],
+  ])("passe à next() le jet de %s", async (_libelle, path) => {
+    const handlers = mountedHandlers(path)
+    const handler = handlers[handlers.length - 1]
+
+    const next = vi.fn()
+    const res: any = {
+      cookie: vi.fn(),
+      clearCookie: vi.fn(),
+      redirect: vi.fn(),
+    }
+    const req: any = { cookies: {}, query: {} }
+
+    await Promise.resolve(handler(req, res, next)).catch(() => undefined)
+
+    expect(res.redirect).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(next.mock.calls[0][0]).toBeInstanceOf(TypeError)
   })
 })

--- a/tests/unit/backend/webhook.spec.ts
+++ b/tests/unit/backend/webhook.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../backend/controllers/webhook.js"
 import Mattermost from "../../../backend/lib/mattermost-bot/mattermost.js"
 import config from "../../../backend/config/index.js"
+import axios from "axios"
 
 type MockRequest = {
   body: any
@@ -197,10 +198,43 @@ describe("postOnMattermost", () => {
     await postOnMattermost(
       req as unknown as Request,
       res as unknown as Response,
+      vi.fn(),
     )
 
     expect(mattermostSpy).toHaveBeenCalledWith(expectedMessage)
     expect(res.status).toHaveBeenCalledWith(200)
     expect(res.json).toHaveBeenCalledWith({ message: "OK" })
+  })
+
+  it("passe l'échec de Mattermost à next() au lieu de rejeter la promesse", async () => {
+    const failure = new Error("connect ECONNREFUSED")
+    mattermostSpy.mockRejectedValue(failure)
+    const next = vi.fn()
+
+    await postOnMattermost(
+      req as unknown as Request,
+      res as unknown as Response,
+      next,
+    )
+
+    expect(next).toHaveBeenCalledWith(failure)
+    expect(res.status).not.toHaveBeenCalled()
+  })
+})
+
+// Le rattrapage de `postOnMattermost` ne vaut que si le collaborateur peut
+// échouer : tant que `Mattermost.post` avalait l'erreur d'axios, le webhook
+// répondait 200 « OK » alors que la notification n'était jamais partie.
+describe("Mattermost.post", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("propage l'échec du POST au lieu de l'avaler", async () => {
+    vi.restoreAllMocks()
+    const failure = new Error("connect ECONNREFUSED")
+    vi.spyOn(axios, "post").mockRejectedValue(failure)
+
+    await expect(Mattermost.post("coucou")).rejects.toBe(failure)
   })
 })

--- a/tests/unit/backend/webhook.spec.ts
+++ b/tests/unit/backend/webhook.spec.ts
@@ -1,4 +1,10 @@
 import { expect, vi } from "vitest"
+
+vi.mock("@sentry/node", () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  setupExpressErrorHandler: vi.fn(),
+}))
 import { Request, Response } from "express"
 import crypto from "node:crypto"
 import {
@@ -9,6 +15,8 @@ import {
 import Mattermost from "../../../backend/lib/mattermost-bot/mattermost.js"
 import config from "../../../backend/config/index.js"
 import axios from "axios"
+import * as Sentry from "@sentry/node"
+import { MattermostNotConfiguredError } from "../../../backend/lib/mattermost-bot/mattermost.js"
 
 type MockRequest = {
   body: any
@@ -235,6 +243,52 @@ describe("Mattermost.post", () => {
     const failure = new Error("connect ECONNREFUSED")
     vi.spyOn(axios, "post").mockRejectedValue(failure)
 
-    await expect(Mattermost.post("coucou")).rejects.toBe(failure)
+    await expect(
+      Mattermost.post("coucou", "https://mattermost.test/hook"),
+    ).rejects.toBe(failure)
+  })
+
+  // Sans MATTERMOST_POST_URL — préproduction, review app, poste de
+  // développement — axios posterait sur une URL vide.
+  it("distingue l'absence de configuration d'une panne", async () => {
+    vi.restoreAllMocks()
+    const axiosPost = vi.spyOn(axios, "post")
+
+    await expect(Mattermost.post("coucou", "")).rejects.toMatchObject({
+      name: "MattermostNotConfiguredError",
+    })
+    expect(axiosPost).not.toHaveBeenCalled()
+  })
+})
+
+// Un webhook ne doit pas être invité à réessayer une erreur de configuration :
+// aucune tentative ne la réparera, et le tiers rappellerait indéfiniment.
+describe("postOnMattermost sans configuration Mattermost", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("répond 200 et signale, au lieu de renvoyer une erreur au tiers", async () => {
+    vi.restoreAllMocks()
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+    vi.mocked(Sentry.captureException).mockClear()
+    vi.spyOn(Mattermost, "post").mockRejectedValue(
+      new MattermostNotConfiguredError(),
+    )
+
+    const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() }
+    const next = vi.fn()
+
+    await postOnMattermost(
+      {
+        body: { data: { id: "rdv123", organisation: { id: "org456" } } },
+      } as unknown as Request,
+      res as unknown as Response,
+      next,
+    )
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(next).not.toHaveBeenCalled()
+    expect(Sentry.captureException).toHaveBeenCalled()
   })
 })

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -9,6 +9,8 @@ import {
 } from "../lib/types/link-validity.js"
 import { Grist } from "../lib/grist.js"
 import Mattermost from "../backend/lib/mattermost-bot/mattermost.js"
+import { formatRejection } from "../backend/lib/process-error-handlers.js"
+import { ErrorName } from "../lib/enums/error.js"
 
 import axios from "axios"
 import https from "https"
@@ -276,13 +278,25 @@ async function main() {
       `Ajout: ${recordsByOperationTypes.add.length}`,
       `Mise à jour: ${recordsByOperationTypes.update.length}`,
     ].join("\n")
-    // La mise à jour Grist est déjà faite à ce stade : une notification qui
-    // n'aboutit pas ne doit pas faire échouer le compte rendu de l'outil. Aucun
-    // gestionnaire de processus n'est installé ici, donc un rejet laissé libre
-    // arrêterait le programme après coup.
-    await Mattermost.post(text, process.env.MATTERMOST_ALERTING_URL).catch(
-      (error) => console.error("Notification Mattermost", error),
-    )
+    // La mise à jour Grist est déjà tentée à ce stade : une notification qui
+    // n'aboutit pas ne doit pas emporter le compte rendu de l'outil. Ce module
+    // n'installe aucun écouteur `unhandledRejection`, donc un rejet laissé
+    // libre arrêterait le programme après coup.
+    try {
+      await Mattermost.post(text, process.env.MATTERMOST_ALERTING_URL)
+    } catch (error: any) {
+      // Résumé plat, jamais l'objet brut : une erreur axios porte l'URL
+      // appelée dans `path`, `pathname` et `_header`, et le journal d'Actions
+      // est public. Le masquage de GitHub ne couvre que la valeur exacte du
+      // secret, pas ses fragments.
+      console.error("Notification Mattermost", formatRejection(error))
+      // Une URL absente ne se répare pas en réessayant : la veille resterait
+      // muette sans que rien ne le dise. Seul ce cas fait échouer le compte
+      // rendu ; une panne passagère du service, non.
+      if (error?.name === ErrorName.MattermostNotConfiguredError) {
+        process.exitCode = 1
+      }
+    }
   }
 }
 

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -285,14 +285,16 @@ async function main() {
     try {
       await Mattermost.post(text, process.env.MATTERMOST_ALERTING_URL)
     } catch (error: any) {
-      // Résumé plat, jamais l'objet brut : une erreur axios porte l'URL
+      // Résumé plat, jamais l'objet brut ici : une erreur axios porte l'URL
       // appelée dans `path`, `pathname` et `_header`, et le journal d'Actions
       // est public. Le masquage de GitHub ne couvre que la valeur exacte du
       // secret, pas ses fragments.
       console.error("Notification Mattermost", formatRejection(error))
       // Une URL absente ne se répare pas en réessayant : la veille resterait
       // muette sans que rien ne le dise. Seul ce cas fait échouer le compte
-      // rendu ; une panne passagère du service, non.
+      // rendu ; une panne passagère du service, non — au prix, assumé, de
+      // l'alerte de cette nuit-là : un lien déjà consigné dans Grist ne
+      // produit plus d'`add` les nuits suivantes, donc plus de notification.
       if (error?.name === ErrorName.MattermostNotConfiguredError) {
         process.exitCode = 1
       }

--- a/tools/check-links-validity.ts
+++ b/tools/check-links-validity.ts
@@ -276,7 +276,13 @@ async function main() {
       `Ajout: ${recordsByOperationTypes.add.length}`,
       `Mise à jour: ${recordsByOperationTypes.update.length}`,
     ].join("\n")
-    Mattermost.post(text, process.env.MATTERMOST_ALERTING_URL)
+    // La mise à jour Grist est déjà faite à ce stade : une notification qui
+    // n'aboutit pas ne doit pas faire échouer le compte rendu de l'outil. Aucun
+    // gestionnaire de processus n'est installé ici, donc un rejet laissé libre
+    // arrêterait le programme après coup.
+    await Mattermost.post(text, process.env.MATTERMOST_ALERTING_URL).catch(
+      (error) => console.error("Notification Mattermost", error),
+    )
   }
 }
 


### PR DESCRIPTION
Ouverte en brouillon : revue adversariale en cours.

## Constat, relevé en production

```
AxiosError: Request failed with status code 404
    at getMetaData (backend/lib/teleservices/demarches-simplifiees.ts:265:20)
    at DemarchesSimplifiees.toInternal (…:281:16)
→ unhandledRejection
→ pm2 tente de le diffuser et échoue : Converting circular structure to JSON
```

**L'erreur disparaît entièrement.** Le processus survit (211 redémarrages inchangés sur 7 h, 2 réponses 502 sur la journée toutes deux imputables à un déploiement), mais rien n'arrive dans Sentry et rien d'exploitable n'est journalisé.

## Cause — l'appelant, pas le téléservice

`backend/controllers/teleservices/index.ts:132` :

```js
return function (req, res) {                    // ← pas de `next`
  return Promise.resolve(createClass(…).toInternal())
    .then(function (fields) { … })              // ← pas de `.catch`
}
```

Express 4.21 **ignore la promesse renvoyée par un gestionnaire**. Le rejet n'a aucun receveur. Effet secondaire : **la requête reste pendante**, aucune réponse n'est jamais émise.

La preuve que c'est bien ce chemin : `getMetaData` est appelé par `toInternal` **et** `toExternal`, mais `toExternal` passe par `exportRepresentation` (`:233`), qui a déjà `.catch(next)`. La trace nomme `toInternal:281`. Les deux sœurs avaient divergé.

**Sur la structure circulaire** : une vraie `AxiosError` définit `toJSON()`, donc `JSON.stringify(err)` ne lève pas. Vérifié avec l'axios du dépôt :

```
stringify(err)    → OK (toJSON utilisé)
stringify({...e}) → LÈVE : Converting circular structure to JSON
```

pm2 **recopie** l'erreur avant `process.send` ; la copie superficielle perd le `toJSON` et expose la boucle `req`/`res`.

## La classe, pas seulement l'instance

Rattrapés au même titre : `routes/proxy.ts:5`, `controllers/simulation.ts:231` (`await` hors du `try`), `controllers/followups.ts:152/166/121`, `controllers/webhook.ts:83`, `controllers/moncomptepro.ts`.

Déjà corrects, et instructifs : `routes/openfisca.ts` porte le commentaire « Express 4 ne rattrape pas les rejets d'un gestionnaire asynchrone ». **Le projet connaissait la classe** ; elle avait seulement été oubliée ailleurs.

## Dégrader ou échouer ? — échouer, en 502

`toInternal` n'existe que pour montrer à l'usager **les champs exacts** transmis au tiers avant son consentement. Sans le schéma, les libellés sont inconnus : dégrader afficherait un écran de consentement vide ou faux, et le `POST` échouerait de toute façon ensuite. C'est le repli silencieux que la règle du dépôt interdit.

`getMetaData` lève donc une `TeleserviceMetadataError` — nommée, plate, copiable, portant `procedure`, `upstreamUrl`, `upstreamStatus`, et un `code = 502` que `httpStatusOf` traduit en statut de réponse.

## Le garde-fou qui manquait

Nouveau `backend/lib/process-error-handlers.ts`, monté depuis `configure.ts` (donc `server.ts` **et** `dev.ts`) : journalise un résumé plat puis remonte à Sentry, sans dépendre de la sérialisation de pm2.

**Volontairement pas de `uncaughtException`** : y poser un écouteur neutralise l'arrêt par défaut de Node et ferait tourner le processus dans un état corrompu. Ce serait le repli silencieux, pas son contraire.

## Le 500 récurrent sur `POST /followup`

**Il n'était pas identifiable depuis les journaux, et c'est là le défaut** : `persist` appelait `Sentry.captureException` **sans un seul `console.error`**. La seule empreinte serveur est la ligne d'accès de morgan. La cause n'a jamais existé côté machine.

Deux défauts réels en sont sortis :

1. **La classification manquait les 4xx.** Le test était `error.message === ErrorType.UnsupportedPhoneNumberFormat`, en égalité stricte. Le refus du fournisseur arrive imbriqué — `SMS request failed. Body: {…"Invalid destination address"…}` — donc jamais reconnu, donc **500**. Or c'est une erreur d'entrée, déterministe : le même numéro donne le même refus. C'est exactement la forme observée cette nuit, `05:49:04` puis `05:52:57` sur la **même** simulation.
2. **`persist` annulait une exclusion Sentry délibérée.** `sms-service.ts:107` porte « Avoid sending invalid destination address error to sentry », puis relance ; `persist` rattrapait et le signalait quand même. Le front traite déjà ce cas par un message dédié. Trois couches d'accord, une qui contredisait.

Corrigé en 422, avec `console.error` structuré, et Sentry réservé aux vraies pannes. Le corps de réponse est inchangé : la détection `invalid-address` du front continue de fonctionner.

**Restant, non corrigé** — si l'usager donne courriel *et* téléphone et que le SMS échoue, le courriel est déjà parti et le suivi créé, mais la réponse est un échec ; il réessaie, et obtient un second suivi et un second courriel. Corriger demande de changer la forme de la réponse et le front : à trancher avec vous.

## Vérification

Fichiers de production remis à `origin/main` **un par un**, tests conservés :

| fichier restauré | résultat |
|---|---|
| `controllers/teleservices/index.ts` | 1 échec — `next` jamais appelé |
| `lib/teleservices/demarches-simplifiees.ts` | 1 échec — pas une `TeleserviceMetadataError` |
| `controllers/followups.ts` | 3 échecs — 422 attendu, Sentry appelé à tort, rien journalisé |

Aucun attendu n'est calculé par la fonction testée. `JSON.stringify({ ...error })` reproduit littéralement ce que fait pm2.

`npx prettier --check .` ✓ · `npm run lint` ✓ · **`npm test` exit 0 — 57 fichiers, 25 082 tests** ✓ · `npm run build` ✓

## Deux changements de comportement assumés, à connaître avant de merger

Un harnais différentiel local a envoyé 54 requêtes identiques aux deux
révisions, sur de vrais serveurs, mêmes stubs et même base : **45 réponses
identiques**, 4 écarts voulus (les requêtes qui pendaient répondent désormais),
5 artefacts de construction. Il a mis au jour deux effets de bord qui ne se
lisent pas dans le diff.

**1. `POST /api/webhook/rdv` répond 500 quand Mattermost est en panne.**
`MATTERMOST_POST_URL` est renseignée en production, donc le cas est réel.
Signature valide, Mattermost injoignable :

| révision | réponse |
|---|---|
| `main` | `200 {"message":"OK"}` |
| cette branche | `500 {"code":"ECONNREFUSED", …}` |

`rdv-aide-numerique` lira ce 500 comme « réessaie plus tard » et **renverra
l'événement**. Le 200 précédent mentait — la notification ne partait pas — mais
c'est bien un contrat inter-services qui change. **C'est assumé** : mieux vaut
un rappel qu'une notification perdue en silence. Signalé ici pour que l'équipe
RDV le sache plutôt que de le découvrir pendant une panne.

À noter : une panne Mattermost prolongée produira des rappels répétés, et des
messages en double dans le canal une fois le service revenu, chaque rappel
republiant.

**2. La veille nocturne des liens ne tombe plus sur une notification ratée.**
`Mattermost.post` propage désormais ses erreurs ; `tools/check-links-validity.ts`
l'appelait sans `await` ni `.catch`, et ce module n'installe aucun gestionnaire
de processus — le rejet arrêtait le programme **après** « Terminé », donc après
une mise à jour Grist réussie, et le cron passait au rouge. Corrigé au dernier
commit. Mesuré, URL vide et URL injoignable :

| révision | sortie |
|---|---|
| `main` | 0 |
| avant le correctif | **1** |
| après le correctif | 0, la cause restant journalisée |

Le premier jet de ce correctif journalisait l'objet d'erreur brut — 186 lignes,
dont **six occurrences de l'URL du webhook**, portée par `path`, `pathname` et
`_header`. Cette URL est le moyen d'authentification du webhook, et les journaux
Actions de ce dépôt sont publics : GitHub ne masque que la valeur *exacte* d'un
secret, pas ses fragments. Le journal passe donc par `formatRejection`, éprouvé
sur 17 formes d'erreur — DNS, TLS, redirections, proxy, corps d'erreur reprenant
l'URL : aucune ne fait ressortir le jeton.

Le partage est délibéré : une panne passagère laisse le compte rendu vert, une
URL absente le fait échouer — aucun réessai ne répare une configuration
manquante. Le prix du vert est écrit dans le code : un lien déjà consigné dans
Grist ne produit plus d'`add` les nuits suivantes, donc l'alerte manquée n'est
pas rejouée.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

