### PR TITLE
veille: Bourse communale pour le permis de conduire : permis citoyen — lien(s) cassé(s)

### DIFF
--- a/data/benefits/javascript/ville-angers-bourse-communale-pour-le-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/ville-angers-bourse-communale-pour-le-permis-de-conduire-permis-citoyen.yml
@@ -1,9 +1,11 @@
 label: "Bourse communale pour le permis de conduire : permis citoyen"
 institution: ville-angers
-description:
-  La ville d'Angers propose une aide financière au permis B pour les jeunes Angevin·e·s ne disposant pas de ressources suffisantes et qui s'inscrivent dans une démarche de formation ou
-  d’emploi. L'aide est conditionnée à un apport personnel d’au moins 20% du montant total du permis. L’instruction des demandes se fait au Centre
-  Communale d'Action Sociale de la ville.
+description: La ville d'Angers propose une aide financière au permis B pour les
+  jeunes Angevin·e·s ne disposant pas de ressources suffisantes et qui
+  s'inscrivent dans une démarche de formation ou d’emploi. L'aide est
+  conditionnée à un apport personnel d’au moins 20% du montant total du permis.
+  L’instruction des demandes se fait au Centre Communale d'Action Sociale de la
+  ville.
 prefix: la
 conditions_generales:
   - type: communes
@@ -34,10 +36,11 @@ profils:
 conditions:
   - Résider à Angers depuis au moins une année de manière continue.
   - Etre engagé·e dans un parcours d’insertion professionnelle.
-  - Etre inscrit·e dans une auto-école partenaire du CCAS et participer à une journée obligatoire de sécurité routière.
+  - Etre inscrit·e dans une auto-école partenaire du CCAS et participer à une
+    journée obligatoire de sécurité routière.
 voluntary_conditions:
-  - Vous engager à réaliser au moins 20 heures de bénévolat dans une association ou
-    une collectivité.
+  - Vous engager à réaliser au moins 20 heures de bénévolat dans une association
+    ou une collectivité.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €
@@ -46,3 +49,4 @@ legend: maximum
 montant: 1000
 link: https://www.angers.fr/vivre-a-angers/ccas/se-deplacer/beneficier-du-permis-citoyen/index.html
 instructions: https://www.angers.fr/fileadmin/user_upload/plaquette_permis_citoyen.pdf
+private: true


### PR DESCRIPTION
## Dispositif : Bourse communale pour le permis de conduire : permis citoyen
- Institution : ville-angers

### Lien(s) cassé(s) détecté(s)

- [instructions] https://www.angers.fr/fileadmin/user_upload/plaquette_permis_citoyen.pdf → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.

# Edit review Simon: lien des instructions modifié -> suppression du private