### PR TITLE
veille: Aide au financement du permis de conduire — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/plie-de-lens-lievin-aide-au-financement-du-permis-de-conduire.yml
+++ b/data/benefits/javascript/plie-de-lens-lievin-aide-au-financement-du-permis-de-conduire.yml
@@ -32,4 +32,4 @@ periodicite: autre
 legend: maximum
 montant: 800
 link: https://lens-henin.minedinfos.fr/aide/1056/16-je-souhaite-etre-aide-pour-financer-mon-permis-de-conduire.htm?show=389
-instructions: https://lens-henin.minedinfos.fr/aide/1056/16-je-souhaite-etre-aide-pour-financer-mon-permis-de-conduire.htm?show=389
+instructions: https://lens-henin.minedinfos.fr/actions/276/

--- a/data/benefits/javascript/plie-de-lens-lievin-aide-au-financement-du-permis-de-conduire.yml
+++ b/data/benefits/javascript/plie-de-lens-lievin-aide-au-financement-du-permis-de-conduire.yml
@@ -31,5 +31,5 @@ unit: €
 periodicite: autre
 legend: maximum
 montant: 800
-link: https://lens-henin.minedinfos.fr/aide/1056/16-je-souhaite-etre-aide-pour-financer-mon-permis-de-conduire.htm?show=389
+link: https://lens-henin.minedinfos.fr/actions/276/
 instructions: https://lens-henin.minedinfos.fr/actions/276/

--- a/data/benefits/javascript/plie-de-lens-lievin-aide-au-financement-du-permis-de-conduire.yml
+++ b/data/benefits/javascript/plie-de-lens-lievin-aide-au-financement-du-permis-de-conduire.yml
@@ -33,3 +33,4 @@ legend: maximum
 montant: 800
 link: https://lens-henin.minedinfos.fr/aide/1056/16-je-souhaite-etre-aide-pour-financer-mon-permis-de-conduire.htm?show=389
 instructions: https://lens-henin.minedinfos.fr/aide/1056/16-je-souhaite-etre-aide-pour-financer-mon-permis-de-conduire.htm?show=389
+private: true

--- a/data/benefits/javascript/plie-de-lens-lievin-aide-au-financement-du-permis-de-conduire.yml
+++ b/data/benefits/javascript/plie-de-lens-lievin-aide-au-financement-du-permis-de-conduire.yml
@@ -33,4 +33,3 @@ legend: maximum
 montant: 800
 link: https://lens-henin.minedinfos.fr/aide/1056/16-je-souhaite-etre-aide-pour-financer-mon-permis-de-conduire.htm?show=389
 instructions: https://lens-henin.minedinfos.fr/aide/1056/16-je-souhaite-etre-aide-pour-financer-mon-permis-de-conduire.htm?show=389
-private: true


### PR DESCRIPTION
## Dispositif : Aide au financement du permis de conduire
- Institution : plie-de-lens-lievin

### Lien(s) cassé(s) détecté(s)

- [link / instructions] https://lens-henin.minedinfos.fr/aide/1056/16-je-souhaite-etre-aide-pour-financer-mon-permis-de-conduire.htm?show=389 → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.