### PR TITLE
veille: Bourse communale au permis de conduire — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/ville-vertou-bourse-communale-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-vertou-bourse-communale-permis-de-conduire.yml
@@ -1,8 +1,8 @@
 label: Bourse communale au permis de conduire
 institution: ville_vertou
-description: Les jeunes de 16 à 21 ans résidant à Vertou peuvent bénéficier
-  du financement d'une partie de leur permis B, en échange de 50 heures de
-  travail bénévole dans une association.
+description: Les jeunes de 16 à 21 ans résidant à Vertou peuvent bénéficier du
+  financement d'une partie de leur permis B, en échange de 50 heures de travail
+  bénévole dans une association.
 prefix: la
 conditions_generales:
   - type: communes
@@ -19,8 +19,7 @@ conditions:
   - Effectuer la demande de bourse avant le 20 novembre.
   - Effectuer la demande de bourse avant de commencer le permis.
 voluntary_conditions:
-  - Réaliser 50 heures d'action bénévole dans une association basée à
-    Vertou.
+  - Réaliser 50 heures d'action bénévole dans une association basée à Vertou.
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €
@@ -29,3 +28,4 @@ legend: maximum
 montant: 1000
 link: https://vertou.fr/vivre/famille-et-jeunesse/jeunesse-11-a-21-ans/soutien-a-lautonomie/mon-passeport-liberte/?hilite=permis
 form: https://vertou.fr/wp-content/uploads/2022/10/Dossier-inscription-mon-passeport-liberte-oct-nov-2022.pdf
+private: true

--- a/data/benefits/javascript/ville-vertou-bourse-communale-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-vertou-bourse-communale-permis-de-conduire.yml
@@ -27,4 +27,4 @@ periodicite: ponctuelle
 legend: maximum
 montant: 1000
 link: https://vertou.fr/vivre/famille-et-jeunesse/jeunesse-11-a-21-ans/soutien-a-lautonomie/mon-passeport-liberte/?hilite=permis
-form: https://vertou.fr/wp-content/uploads/2022/10/Dossier-inscription-mon-passeport-liberte-oct-nov-2022.pdf
+form: https://vertou.fr/vivre/famille-et-jeunesse/jeunesse-11-a-21-ans/soutien-a-lautonomie/mon-passeport-liberte/

--- a/data/benefits/javascript/ville-vertou-bourse-communale-permis-de-conduire.yml
+++ b/data/benefits/javascript/ville-vertou-bourse-communale-permis-de-conduire.yml
@@ -28,4 +28,3 @@ legend: maximum
 montant: 1000
 link: https://vertou.fr/vivre/famille-et-jeunesse/jeunesse-11-a-21-ans/soutien-a-lautonomie/mon-passeport-liberte/?hilite=permis
 form: https://vertou.fr/wp-content/uploads/2022/10/Dossier-inscription-mon-passeport-liberte-oct-nov-2022.pdf
-private: true


### PR DESCRIPTION
## Dispositif : Bourse communale au permis de conduire
- Institution : ville_vertou

### Lien(s) cassé(s) détecté(s)

- [link] https://vertou.fr/vivre/famille-et-jeunesse/jeunesse-11-a-21-ans/soutien-a-lautonomie/mon-passeport-liberte/?hilite=permis → **500** — à vérifier
- [form] https://vertou.fr/wp-content/uploads/2022/10/Dossier-inscription-mon-passeport-liberte-oct-nov-2022.pdf → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.