### PR TITLE
veille: mise à jour Bourse Aquisis - Études à l'étranger pour étudiants et étudiantes et apprentis ou apprenties post-bac (montant, conditions)

### DIFF
--- a/data/benefits/javascript/region-bourgogne-franche-comte-etudes-etranger-aquisis.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-etudes-etranger-aquisis.yml
@@ -1,13 +1,13 @@
-label: Bourse Aquisis - Études à l'étranger pour étudiants et étudiantes et apprentis ou apprenties post-bac
+label: Bourse Aquisis - Études à l'étranger pour étudiants et étudiantes et
+  apprentis ou apprenties post-bac
 institution: region_bourgogne_franche_comte
 description: Cette bourse vous permet d’effectuer des périodes d’études dans le
   monde entier (sauf France métropolitaine et DROM-COM), afin d’acquérir des
   compétences nouvelles et de vous perfectionner en langues étrangères.
 conditions:
-  - Être inscrits ou inscrites dans un établissement d’enseignement supérieur de
-    Bourgogne-Franche-Comté.
-  - Avoir une période d’études à réaliser à l’étranger dans le cadre de votre
-    cursus de formation.
+  - quotient familial inférieur à 25 830 €
+  - stage à plus de 150 km du lieu de résidence familiale et du lieu d’études en
+    France
 conditions_generales:
   - type: regions
     values:


### PR DESCRIPTION
## Dispositif : Bourse Aquisis - Études à l'étranger pour étudiants et étudiantes et apprentis ou apprenties post-bac
- Institution : region_bourgogne_franche_comte
- Lien source : https://www.bourgognefranchecomte.fr/node/382

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| montant | 2300 | 2300 |
| conditions | ['Être inscrits ou inscrites dans un établissement d’enseignement supérieur de Bourgogne-Franche-Comté.', 'Avoir une période d’études à réaliser à l’étranger dans le cadre de votre cursus de formation.'] | ['quotient familial inférieur à 25\u202f830 €', 'stage à plus de 150 km du lieu de résidence familiale et du lieu d’études en France'] |

### Extraits sources
- **conditions** : > Critères sociaux : quotient familial inférieur à 25 830 € (avis d’imposition année N-1 sur revenus N-2)
- **conditions** : > Stages à l’étranger, hors France et DROM-COM et à plus de 150 km du lieu de résidence familiale et du lieu d’études en France

_Confiance LLM : 1.0_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.