### PR TITLE
veille: mise à jour bourses d'études sanitaires et sociales (conditions)

### DIFF
--- a/data/benefits/javascript/region_bourgogne_franche_comte-bourses-détudes-sanitaires-et-sociales.yml
+++ b/data/benefits/javascript/region_bourgogne_franche_comte-bourses-détudes-sanitaires-et-sociales.yml
@@ -1,10 +1,14 @@
 label: bourses d'études sanitaires et sociales
 institution: region_bourgogne_franche_comte
 description: Une bourse d’études est accordée par la Région sur critères sociaux
-  aux étudiants et étudiantes en travail social et aux élèves et étudiants et étudiantes inscrits ou inscrites
-  dans les instituts et écoles de formation de certaines professions de santé.
+  aux étudiants et étudiantes en travail social et aux élèves et étudiants et
+  étudiantes inscrits ou inscrites dans les instituts et écoles de formation de
+  certaines professions de santé.
 conditions:
   - Être inscrit ou inscrite dans les instituts autorisés/agréés par la Région.
+  - Le niveau de ressources familiales ou personnelles doit être reconnu
+    insuffisant au regard des charges de la formation.
+  - Les préparations aux concours n’ouvrent pas droit aux bourses.
 conditions_generales:
   - type: regions
     values:


### PR DESCRIPTION
## Dispositif : bourses d'études sanitaires et sociales
- Institution : region_bourgogne_franche_comte
- Lien source : https://www.bourgognefranchecomte.fr/demande-de-bourse-sanitaire-et-sociale

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| conditions | ['Être inscrit ou inscrite dans les instituts autorisés/agréés par la Région.'] | ['Être inscrit ou inscrite dans les instituts autorisés/agréés par la Région.', 'Le niveau de ressources familiales ou personnelles doit être reconnu insuffisant au regard des charges de la formation.', 'Les préparations aux concours n’ouvrent pas droit aux bourses.'] |

### Extraits sources
- **conditions** : > une bourse d’études est accordée par la Région aux étudiants en travail social et aux élèves et étudiants inscrits dans les instituts et écoles de formation de certaines professions de santé, **dont le niveau de ressources familiales ou personnelles est reconnu insuffisant au regard des charges occasionnées par la formation entreprise**.
- **conditions** : > **Les préparations aux concours n’ouvrent pas droit aux bourses**.

_Confiance LLM : 1.0_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.