### PR TITLE
veille: mise à jour des conditions de l'aide stages à l'étranger infra-bac (Nouvelle-Aquitaine)

### DIFF
--- a/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
+++ b/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
@@ -1,10 +1,11 @@
 label: Aide régionale aux inscriptions aux concours
 institution: region_ile_de_france
-description: "La Région Ile-de-France soutient les élèves de 2ème année des
-  classes préparatoires aux grandes écoles (CPGE) pour le paiement des frais de
-  concours : inscription, hébergement, transport."
+description:
+  "La Région Ile-de-France soutient les élèves de 2ème année des classes
+  préparatoires aux grandes écoles (CPGE) pour le paiement des frais de concours :
+  inscription, hébergement, transport."
 conditions:
-  - Vous rapprocher de votre établissement qui vous indiquera la marche à suivre.
+  - Quotient familial régional annuel ≤ 10 140 €
 conditions_generales:
   - type: regions
     values:
@@ -27,4 +28,4 @@ type: float
 unit: €
 periodicite: ponctuelle
 legend: maximum
-montant: 846
+montant: 325

--- a/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
+++ b/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
@@ -1,11 +1,10 @@
-label: Aide régionale aux inscriptions aux concours
+label: Aide régionale aux inscriptions aux concours CPGE
 institution: region_ile_de_france
-description:
-  "La Région Ile-de-France soutient les élèves de 2ème année des classes
-  préparatoires aux grandes écoles (CPGE) pour le paiement des frais de concours :
-  inscription, hébergement, transport."
+description: "La Région Ile-de-France soutient les élèves de 2ème année des
+  classes préparatoires aux grandes écoles (CPGE) pour le paiement des frais de
+  concours : inscription, hébergement, transport."
 conditions:
-  - Quotient familial régional annuel ≤ 10 140 €
+  - Vous rapprocher de votre établissement qui vous indiquera la marche à suivre.
 conditions_generales:
   - type: regions
     values:
@@ -28,4 +27,4 @@ type: float
 unit: €
 periodicite: ponctuelle
 legend: maximum
-montant: 325
+montant: 846

--- a/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
+++ b/data/benefits/javascript/region_ile_de_france-aide-régionale-aux-inscriptions-aux-concours.yml
@@ -1,4 +1,4 @@
-label: Aide régionale aux inscriptions aux concours CPGE
+label: Aide régionale aux inscriptions aux concours
 institution: region_ile_de_france
 description: "La Région Ile-de-France soutient les élèves de 2ème année des
   classes préparatoires aux grandes écoles (CPGE) pour le paiement des frais de

--- a/data/benefits/javascript/region_nouvelle_aquitaine-stages-à-létranger-–-infra-bac.yml
+++ b/data/benefits/javascript/region_nouvelle_aquitaine-stages-à-létranger-–-infra-bac.yml
@@ -1,7 +1,9 @@
-label: stages à lʼétranger pour les lycéens, stagiaires et apprentis (public infra-bac)
+label: stages à lʼétranger pour les lycéens, stagiaires et apprentis (public
+  infra-bac)
 institution: region_nouvelle_aquitaine
 description: La Région finance une partie de votre stage à lʼétranger d'une
-  durée de 2 à 4 semaines. Cette aide est cumulable avec le dispositif Erasmus +.
+  durée de 2 à 4 semaines. Cette aide est cumulable avec le dispositif Erasmus
+  +.
 prefix: les
 conditions_generales:
   - type: regions
@@ -17,7 +19,16 @@ profils:
     conditions: []
   - type: stagiaire
     conditions: []
-conditions: []
+conditions:
+  - Âge maximum 30 ans à la date du début du stage
+  - "Nationalité étrangère : interdiction de faire le stage dans le pays d'origine"
+  - "Nationalité française avec double nationalité : contrat de location requis"
+  - Stage doit se dérouler à l'étranger (hors DOM/TOM)
+  - Durée minimum de 2 semaines consécutives
+  - Pas d’autre aide régionale ou financement OPCO pour le même stage
+  - Stage en télétravail depuis la France non éligible
+  - Si l’entreprise de stage est à moins de 100 km du domicile, contrat de
+    location requis
 interestFlag: _interetEtudesEtranger
 type: float
 unit: €

--- a/data/benefits/javascript/region_nouvelle_aquitaine-stages-à-létranger-–-infra-bac.yml
+++ b/data/benefits/javascript/region_nouvelle_aquitaine-stages-à-létranger-–-infra-bac.yml
@@ -20,15 +20,10 @@ profils:
   - type: stagiaire
     conditions: []
 conditions:
-  - Âge maximum 30 ans à la date du début du stage
-  - "Nationalité étrangère : interdiction de faire le stage dans le pays d'origine"
-  - "Nationalité française avec double nationalité : contrat de location requis"
-  - Stage doit se dérouler à l'étranger (hors DOM/TOM)
-  - Durée minimum de 2 semaines consécutives
-  - Pas d’autre aide régionale ou financement OPCO pour le même stage
-  - Stage en télétravail depuis la France non éligible
-  - Si l’entreprise de stage est à moins de 100 km du domicile, contrat de
-    location requis
+  - Ne pas effectuer le stage dans le pays d'origine en cas de nationalité étrangère.
+  - Disposer dʼun contrat de location en cas de nationalité française avec double nationalité ou si lʼentreprise de stage est à moins de 100 km du domicile.
+  - Effectuer le stage à lʼétranger (hors DOM/TOM) sur une durée minimum de 2 semaines consécutives.
+  - Ne pas bénéficier dʼune autre aide régionale ou dʼun financement OPCO pour le même stage.
 interestFlag: _interetEtudesEtranger
 type: float
 unit: €


### PR DESCRIPTION
## Dispositif : stages à lʼétranger pour les lycéens, stagiaires et apprentis (public infra-bac)
- Institution : region_nouvelle_aquitaine
- Lien source : https://les-aides.nouvelle-aquitaine.fr/amenagement-du-territoire/stages-letranger-infra-bac-annee-academique-2025-2026

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| conditions | [] | ['Ne pas effectuer le stage dans le pays d'origine en cas de nationalité étrangère.', 'Disposer dʼun contrat de location en cas de nationalité française avec double nationalité ou si lʼentreprise de stage est à moins de 100 km du domicile.', 'Effectuer le stage à lʼétranger (hors DOM/TOM) sur une durée minimum de 2 semaines consécutives.', 'Ne pas bénéficier dʼune autre aide régionale ou dʼun financement OPCO pour le même stage.'] |

### Extraits sources
- **conditions** :
  - > vous ne pouvez pas faire votre stage dans votre pays d'origine (nationalité étrangère)
  - > contrat de location à l'étranger exigé en cas de double nationalité, ou si l'entreprise de stage est à moins de 100 km du domicile
  - > le stage doit durer au minimum 2 semaines consécutives (stages en DOM/TOM exclus)
  - > aide non cumulable avec une autre aide régionale, ou avec un financement d'un Opérateur de Compétences (OPCO), pour le même stage

---

ℹ️ Cette PR portait initialement sur l'aide régionale aux inscriptions aux concours CPGE (IDF) (montant, conditions). Ce changement a été retiré du diff (voir commit « veille: suppr màj de l'aide régionale aux inscriptions aux concours »). Le diff actuel ne contient plus que la mise à jour des conditions de l'aide *stages à l'étranger infra-bac* (Nouvelle-Aquitaine) décrite ci-dessus.