### PR TITLE
veille: mise à jour aides à l'hébergement et la restauration des lycéens ou lycéennes (conditions)

### DIFF
--- a/data/benefits/javascript/region-bourgogne-franche-comte-restauration-familles-boursieres.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-restauration-familles-boursieres.yml
@@ -16,3 +16,9 @@ prefix: les
 type: bool
 unit: €
 periodicite: autre
+conditions:
+  - Être inscrit dans un établissement public ou privé sous contrat
+  - Être lycéen (3e, 4e, 3e découverte professionnelle ou 3e agricole)
+  - Être demi‑pensionnaire, interne ou interne‑externé
+  - Être bénéficiaire d’une bourse ou, le cas échéant, ne pas être bénéficiaire
+    d’une bourse (selon le dispositif)


### PR DESCRIPTION
## Dispositif : aides à l'hébergement et la restauration des lycéens ou lycéennes
- Institution : region_bourgogne_franche_comte
- Lien source : https://www.bourgognefranchecomte.fr/node/322

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| conditions | None | ['Être inscrit dans un établissement public ou privé sous contrat', 'Être lycéen (3e, 4e, 3e découverte professionnelle ou 3e agricole)', 'Être demi‑pensionnaire, interne ou interne‑externé', 'Être bénéficiaire d’une bourse ou, le cas échéant, ne pas être bénéficiaire d’une bourse (selon le dispositif)'] |

### Extraits sources
- **conditions** : > Vous êtes inscrit dans un établissement public ou privé sous contrat, en tant que lycéen, ou 3e découverte professionnelle, ou 4e ou 3e agricole scolarisé dans un lycée, demi‑pensionnaires au forfait, interne ou interne‑externé. … Deux dispositifs d’aide à la restauration et à l’hébergement : un dispositif à destination des familles boursières, un dispositif au bénéfice de familles non bénéficiaires d’une bourse.

_Confiance LLM : 0.95_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.