### PR TITLE
veille: mise à jour Aide au permis : Roulez Jeunesse (conditions)

### DIFF
--- a/data/benefits/javascript/ville_cholet_aide_permis.yml
+++ b/data/benefits/javascript/ville_cholet_aide_permis.yml
@@ -1,10 +1,10 @@
 label: "Aide au permis : Roulez Jeunesse"
 institution: ville_cholet
-description:
-  La Ville de Cholet soutient les jeunes Choletais et Puy-Saint-Bonnetais
-  de 15 à 25 ans, engagés bénévolement, à travers l’attribution d’une aide financière
-  à la formation à la conduite automobile auprès d’une école agréée et ce, quelle que
-  soit la formule d’apprentissage choisie.
+description: La Ville de Cholet soutient les jeunes Choletais et
+  Puy-Saint-Bonnetais de 15 à 25 ans, engagés bénévolement, à travers
+  l’attribution d’une aide financière à la formation à la conduite automobile
+  auprès d’une école agréée et ce, quelle que soit la formule d’apprentissage
+  choisie.
 prefix: l’
 conditions_generales:
   - type: communes
@@ -19,8 +19,11 @@ conditions_generales:
     value: 25
 profils: []
 conditions:
-  - Être inscrit auprès d’une auto-école agréée, quelle que soit la formule d’apprentissage choisie (formation traditionnelle, conduite accompagnée ou supervisée).
-  - Candidater chaque année avant le 15 septembre.
+  - Être inscrit auprès d’une auto-école agréée, quelle que soit la formule
+    d’apprentissage choisie (formation traditionnelle, conduite accompagnée ou
+    supervisée).
+  - Être âgé de 15 à 25 ans dans l'année civile en cours.
+  - Justifier d’un engagement bénévole.
 voluntary_conditions:
   - Faire état d’un engagement bénévole.
 interestFlag: _interetPermisDeConduire


### PR DESCRIPTION
## Dispositif : Aide au permis : Roulez Jeunesse
- Institution : ville_cholet
- Lien source : https://www.cholet.fr/dossiers/dossier_5487_roulez+jeunesse.html

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| conditions | ['Être inscrit auprès d’une auto-école agréée, quelle que soit la formule d’apprentissage choisie (formation traditionnelle, conduite accompagnée ou supervisée).', 'Candidater chaque année avant le 15 septembre.'] | ['Être inscrit auprès d’une auto-école agréée, quelle que soit la formule d’apprentissage choisie (formation traditionnelle, conduite accompagnée ou supervisée).', "Être âgé de 15 à 25 ans dans l'année civile en cours.", 'Justifier d’un engagement bénévole.'] |

### Extraits sources
- **conditions** : > Pour être éligible à cette aide, trois critères sont requis : être âgé de 15 à 25 ans dans l’année civile en cours ; être inscrit auprès d’une auto‑école agréée, quelle que soit la formule d’apprentissage choisie (formation traditionnelle, conduite accompagnée ou supervisée) ; justifier d’un engagement bénévole.
- **conditions** : > Pour être éligible à cette aide, trois critères sont requis : … ; justifier d’un engagement bénévole.

_Confiance LLM : 1.0_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.