### PR TITLE
veille: mise à jour Aide aux formations de secourisme PSC1, PSE1 et PSE2 (conditions)

### DIFF
--- a/data/benefits/javascript/ville-de-vannes-aides-aux-psc1-pse1-pse2.yml
+++ b/data/benefits/javascript/ville-de-vannes-aides-aux-psc1-pse1-pse2.yml
@@ -3,11 +3,14 @@ institution: ville-de-vannes
 description: >-
   La Ville de Vannes soutient les jeunes qui souhaitent
   suivre les formations de secourisme Prévention et Secours Civiques de niveau
-  1 (PSC1), Premiers Secours en Equipe niveau 1 ou 2 (PSE1, PSE2). Le montant pris en charge 
-  est variable selon la formation suivie et le quotient familial.
+  1 (PSC1), Premiers Secours en Equipe niveau 1 ou 2 (PSE1, PSE2). Le montant pris
+  en charge  est variable selon la formation suivie et le quotient familial.
 conditions:
   - Être domicilié fiscalement à Vannes depuis au moins 1 an.
-  - Faire une demande au BIJ (Bureau Information Jeunesse) par téléphone au <a href="tel:+33297016100">02 97 01 61 00</a> ou par email à <a href="mailto:bij@mairie-vannes.fr">bij@mairie-vannes.fr</a>.
+  - Faire une demande au BIJ (Bureau Information Jeunesse) par téléphone au <a
+    href="tel:+33297016100">02 97 01 61 00</a> ou par email à <a
+    href="mailto:bij@mairie-vannes.fr">bij@mairie-vannes.fr</a>.
+  - Être âgé de moins de 25 ans révolus
 conditions_generales:
   - type: communes
     values:


### PR DESCRIPTION
## Dispositif : Aide aux formations de secourisme PSC1, PSE1 et PSE2
- Institution : ville-de-vannes
- Lien source : https://bij-vannes.fr/aides-aux-psc1-pse1-et-pse2

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| conditions | ['Être domicilié fiscalement à Vannes depuis au moins 1 an.', 'Faire une demande au BIJ (Bureau Information Jeunesse) par téléphone au <a href="tel:+33297016100">02 97 01 61 00</a> ou par email à <a href="mailto:bij@mairie-vannes.fr">bij@mairie-vannes.fr</a>.'] | ['Être domicilié fiscalement à Vannes depuis au moins 1 an.', 'Faire une demande au BIJ (Bureau Information Jeunesse) par téléphone au <a href="tel:+33297016100">02 97 01 61 00</a> ou par email à <a href="mailto:bij@mairie-vannes.fr">bij@mairie-vannes.fr</a>.', 'Être âgé de moins de 25 ans révolus'] |

### Extraits sources
- **conditions** : > la personne qui sollicite doit avoir, lors de la période de formation aidée, moins de 25 ans révolus

_Confiance LLM : 1.0_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.