### PR TITLE
veille: mise à jour aide au financement du BAFA et BAFD (conditions)

### DIFF
--- a/data/benefits/javascript/ville_villefranche_sur_saone_bafa_bafd.yml
+++ b/data/benefits/javascript/ville_villefranche_sur_saone_bafa_bafd.yml
@@ -11,7 +11,7 @@ conditions_generales:
     value: 16
 profils: []
 conditions:
-  - Récupérer le dossier d'inscription au Pôle Ressources Jeunesse Numérique du Service Jeunesse.
+  - Récupérer le dossier d'inscription au Pôle Ressources Jeunesse Numérique du Service Jeunesse - <address>230 rue de la quarantaine - Ligne 4 / arrêt quarantaine</address>.
 interestFlag: _interetBafa
 type: bool
 unit: €

--- a/data/benefits/javascript/ville_villefranche_sur_saone_bafa_bafd.yml
+++ b/data/benefits/javascript/ville_villefranche_sur_saone_bafa_bafd.yml
@@ -1,6 +1,8 @@
 label: aide au financement du BAFA et BAFD
 institution: ville_villefranche_sur_saone
-description: La Ville de Villefranche finance à hauteur de 50% le Brevet d’Aptitude aux Fonctions d’Animateur (BAFA) et au Brevet d’Aptitude aux Fonctions de Directeurs (BAFD).
+description: La Ville de Villefranche finance à hauteur de 50% le Brevet
+  d’Aptitude aux Fonctions d’Animateur (BAFA) et au Brevet d’Aptitude aux
+  Fonctions de Directeurs (BAFD).
 prefix: l’
 conditions_generales:
   - type: attached_to_institution
@@ -9,7 +11,8 @@ conditions_generales:
     value: 16
 profils: []
 conditions:
-  - "Remplir un dossier à récupérer au Pôle Ressources Jeunesse Numérique du Service Jeunesse - <address>230 rue de la quarantaine - Ligne 4 / arrêt quarantaine</address> ou envoyer un mail à <a href='mailto:prjn@villefranche.net'>prjn@villefranche.net</a>."
+  - Avoir 16 ans
+  - Être résident de Villefranche
 interestFlag: _interetBafa
 type: bool
 unit: €

--- a/data/benefits/javascript/ville_villefranche_sur_saone_bafa_bafd.yml
+++ b/data/benefits/javascript/ville_villefranche_sur_saone_bafa_bafd.yml
@@ -11,8 +11,7 @@ conditions_generales:
     value: 16
 profils: []
 conditions:
-  - Avoir 16 ans
-  - Être résident de Villefranche
+  - Récupérer le dossier d'inscription au Pôle Ressources Jeunesse Numérique du Service Jeunesse.
 interestFlag: _interetBafa
 type: bool
 unit: €


### PR DESCRIPTION
## Dispositif : aide au financement du BAFA et BAFD
- Institution : ville_villefranche_sur_saone
- Lien source : https://www.villefranche.net/vie-quotidienne/enfance-jeunesse/jeunesse/aide-a-lemploi-des-jeunes/aides-au-financement-bafa-et-bafd/

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| conditions | ["Remplir un dossier à récupérer au Pôle Ressources Jeunesse Numérique du Service Jeunesse - <address>230 rue de la quarantaine - Ligne 4 / arrêt quarantaine</address> ou envoyer un mail à <a href='mailto:prjn@villefranche.net'>prjn@villefranche.net</a>."] | ['Avoir 16 ans', 'Être résident de Villefranche'] |

### Extraits sources
- **conditions** : > Conditions Avoir 16 ans Être résident de Villefranche
- **conditions** : > Conditions Avoir 16 ans Être résident de Villefranche

_Confiance LLM : 1.0_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.