### PR TITLE
veille: mise à jour Aide aux séjours à l'étranger (montant)

### DIFF
--- a/data/benefits/javascript/ville-de-vannes-aide-aux-sejours-a-l-etranger.yml
+++ b/data/benefits/javascript/ville-de-vannes-aide-aux-sejours-a-l-etranger.yml
@@ -7,12 +7,8 @@ description: >-
   semaines) et de la destination. Contact: BIJ de Vannes (02 97 01 61 00,
   bij@mairie-vannes.fr).
 conditions:
-  - Avoir des parents domiciliés fiscalement à Vannes depuis au moins un an.
-  - Être inscrit au moins en 1ère année d'un cursus post-bac sanctionné par un
-    diplôme reconnu par le Ministère de l'Education Nationale.
-  - Justifier soit d'une attestation de l'université d'origine ou d'une
-    inscription dans une université à l'étranger pour complément de formation,
-    soit d'une attestation ou convention de stage.
+  - Être âgé de moins de 25 ans
+  - Séjour de 3 semaines au minimum
 conditions_generales:
   - type: communes
     values:
@@ -27,3 +23,4 @@ prefix: l’
 link: https://bij-vannes.fr/aide-aux-sejours-letranger
 type: bool
 periodicite: annuelle
+montant: 850

--- a/data/benefits/javascript/ville-de-vannes-aide-aux-sejours-a-l-etranger.yml
+++ b/data/benefits/javascript/ville-de-vannes-aide-aux-sejours-a-l-etranger.yml
@@ -7,8 +7,12 @@ description: >-
   semaines) et de la destination. Contact: BIJ de Vannes (02 97 01 61 00,
   bij@mairie-vannes.fr).
 conditions:
-  - Être âgé de moins de 25 ans
-  - Séjour de 3 semaines au minimum
+  - Avoir des parents domiciliés fiscalement à Vannes depuis au moins un an.
+  - Être inscrit au moins en 1ère année d'un cursus post-bac sanctionné par un
+    diplôme reconnu par le Ministère de l'Education Nationale.
+  - Justifier soit d'une attestation de l'université d'origine ou d'une
+    inscription dans une université à l'étranger pour complément de formation,
+    soit d'une attestation ou convention de stage.
 conditions_generales:
   - type: communes
     values:
@@ -23,4 +27,5 @@ prefix: l’
 link: https://bij-vannes.fr/aide-aux-sejours-letranger
 type: bool
 periodicite: annuelle
+legend: maximum
 montant: 850

--- a/data/benefits/javascript/ville-de-vannes-aide-aux-sejours-a-l-etranger.yml
+++ b/data/benefits/javascript/ville-de-vannes-aide-aux-sejours-a-l-etranger.yml
@@ -25,7 +25,8 @@ profils:
     conditions: []
 prefix: l’
 link: https://bij-vannes.fr/aide-aux-sejours-letranger
-type: bool
+type: float
+unit: €
 periodicite: annuelle
 legend: maximum
 montant: 850


### PR DESCRIPTION
## Dispositif : Aide aux séjours à l'étranger
- Institution : ville-de-vannes
- Lien source : https://bij-vannes.fr/aide-aux-sejours-letranger

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| montant | None | 850 |
| conditions | ['Avoir des parents domiciliés fiscalement à Vannes depuis au moins un an.', "Être inscrit au moins en 1ère année d'un cursus post-bac sanctionné par un diplôme reconnu par le Ministère de l'Education Nationale.", "Justifier soit d'une attestation de l'université d'origine ou d'une inscription dans une université à l'étranger pour complément de formation, soit d'une attestation ou convention de stage."] | ['Être âgé de moins de 25 ans', 'Séjour de 3 semaines au minimum'] |

### Extraits sources
- **montant** : > Autres pays ... 6 mois et + ... 850 €
- **conditions** : > Etre âgé de moins de 25 ans
- **conditions** : > Séjour de 3 semaines au minimum~~

_Confiance LLM : 1.0_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.

### Edit : Simon - montant max ok - conditions ajoutées superflues