### PR TITLE
veille: mise à jour Ticket Sport Culture et Nature (conditions, teleservice)

### DIFF
--- a/data/benefits/javascript/intercommunalite_golfe_du_morbihan_vannes_agglomeration-ticket-sport-culture-et-nature.yml
+++ b/data/benefits/javascript/intercommunalite_golfe_du_morbihan_vannes_agglomeration-ticket-sport-culture-et-nature.yml
@@ -28,4 +28,4 @@ is_teleservice_need_register: true
 legend: à 11,54 € par demi-journée
 montant: 2
 link: https://www.mairie-vannes.fr/ticket-sport-culture-et-nature
-teleservice: https://www.espace-citoyens.net/vannesetvous/espace-citoyens/
+teleservice: https://www.espace-citoyens.net/vannesetvous/espace-citoyens/CompteCitoyen/Creation

--- a/data/benefits/javascript/intercommunalite_golfe_du_morbihan_vannes_agglomeration-ticket-sport-culture-et-nature.yml
+++ b/data/benefits/javascript/intercommunalite_golfe_du_morbihan_vannes_agglomeration-ticket-sport-culture-et-nature.yml
@@ -16,16 +16,16 @@ conditions_generales:
 profils:
   - type: parent
 conditions:
-  - Vérifier votre tarif, compris entre 2 et 11,54€ pour une demi-journée en fonction de votre quotient familial sur  <a target="_blank" title="le site de la ville de Vannes - Nouvelle fenêtre" rel="noopener"
+  - Vérifier le montant éligible, compris entre 2 et 11,54€ pour une demi-journée en fonction de votre quotient familial sur  <a target="_blank" title="le site de la ville de Vannes - Nouvelle fenêtre" rel="noopener"
     href="https://www.mairie-vannes.fr/ticket-sport-culture-et-nature">le site de la ville de Vannes</a>.
-  - Créer votre compte sur le <a target="_blank" title="créer son espace sur Vannes et Vous -
+  - Créer son compte sur le <a target="_blank" title="créer son compte sur Vannes et Vous -
     Nouvelle fenêtre" rel="noopener"
     href="https://www.espace-citoyens.net/vannesetvous/espace-citoyens/CompteCitoyen/Creation">Vannes et vous</a>.
 type: float
 unit: €
 periodicite: ponctuelle
 is_teleservice_need_register: true
-legend: à 10 € par demi-journée
+legend: à 11,54 € par demi-journée
 montant: 2
 link: https://www.mairie-vannes.fr/ticket-sport-culture-et-nature
 teleservice: https://www.espace-citoyens.net/vannesetvous/espace-citoyens/

--- a/data/benefits/javascript/intercommunalite_golfe_du_morbihan_vannes_agglomeration-ticket-sport-culture-et-nature.yml
+++ b/data/benefits/javascript/intercommunalite_golfe_du_morbihan_vannes_agglomeration-ticket-sport-culture-et-nature.yml
@@ -1,6 +1,9 @@
 label: Ticket Sport Culture et Nature
 institution: ville-de-vannes
-description: La Ville de Vannes organise l’opération « Ticket Sport Culture Nature » pendant les vacances scolaires pour vos enfants de 7 à 16 ans. Il s’agit de stages culturels ou sportifs proposés à la journée, à la demi-journée ou à la semaine et encadrés par des Éducateurs Municipaux.
+description: La Ville de Vannes organise l’opération « Ticket Sport Culture
+  Nature » pendant les vacances scolaires pour vos enfants de 7 à 16 ans. Il
+  s’agit de stages culturels ou sportifs proposés à la journée, à la
+  demi-journée ou à la semaine et encadrés par des Éducateurs Municipaux.
 prefix: le
 conditions_generales:
   - type: communes
@@ -13,9 +16,7 @@ conditions_generales:
 profils:
   - type: parent
 conditions:
-  - Consulter sur le site de la ville, la liste et le calendrier des activités proposées ainsi que les dates d’inscription (attention, celles-ci sont assez courtes).
-  - Vérifier votre tarif, compris entre 2 € et 10 € pour une demi-journée en fonction de votre quotient familial, sur le simulateur de la ville de Vannes.
-  - Créer votre compte sur Vannes & vous.
+  - Enfants de 7 à 16 ans
 type: float
 unit: €
 periodicite: ponctuelle

--- a/data/benefits/javascript/intercommunalite_golfe_du_morbihan_vannes_agglomeration-ticket-sport-culture-et-nature.yml
+++ b/data/benefits/javascript/intercommunalite_golfe_du_morbihan_vannes_agglomeration-ticket-sport-culture-et-nature.yml
@@ -16,10 +16,15 @@ conditions_generales:
 profils:
   - type: parent
 conditions:
-  - Enfants de 7 à 16 ans
+  - Vérifier votre tarif, compris entre 2 et 11,54€ pour une demi-journée en fonction de votre quotient familial sur  <a target="_blank" title="le site de la ville de Vannes - Nouvelle fenêtre" rel="noopener"
+    href="https://www.mairie-vannes.fr/ticket-sport-culture-et-nature">le site de la ville de Vannes</a>.
+  - Créer votre compte sur le <a target="_blank" title="créer son espace sur Vannes et Vous -
+    Nouvelle fenêtre" rel="noopener"
+    href="https://www.espace-citoyens.net/vannesetvous/espace-citoyens/CompteCitoyen/Creation">Vannes et vous</a>.
 type: float
 unit: €
 periodicite: ponctuelle
+is_teleservice_need_register: true
 legend: à 10 € par demi-journée
 montant: 2
 link: https://www.mairie-vannes.fr/ticket-sport-culture-et-nature


### PR DESCRIPTION
## Dispositif : Ticket Sport Culture et Nature
- Institution : ville-de-vannes
- Lien source : https://www.mairie-vannes.fr/ticket-sport-culture-et-nature

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| conditions | ['Consulter sur le site de la ville, la liste et le calendrier des activités proposées ainsi que les dates d’inscription (attention, celles-ci sont assez courtes).', 'Vérifier votre tarif, compris entre 2 € et 10 € pour une demi-journée en fonction de votre quotient familial, sur le simulateur de la ville de Vannes.', 'Créer votre compte sur Vannes & vous.'] | ['Enfants de 7 à 16 ans'] |

### Extraits sources
- **conditions** : > Ticket Sport Culture et Nature ... pour vos enfants de 7 à 16 ans.

_Confiance LLM : 0.95_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.