### PR TITLE
veille: mise à jour Aide au permis de conduire (conditions)

### DIFF
--- a/data/benefits/javascript/ville_berre_l_etang_aide_au_permis.yml
+++ b/data/benefits/javascript/ville_berre_l_etang_aide_au_permis.yml
@@ -1,9 +1,9 @@
 label: Aide au permis de conduire
 institution: ville_berre_l_etang
-description:
-  La Ville de Berre l'Étang participe au financement du permis de conduire pour tous les
-  jeunes qui passent le permis de conduire B, sans conditions de ressources. Pour effectuer
-  une demande, rendez-vous au Centre Communale d'Action Sociale (CCAS).
+description: La Ville de Berre l'Étang participe au financement du permis de
+  conduire pour tous les jeunes qui passent le permis de conduire B, sans
+  conditions de ressources. Pour effectuer une demande, rendez-vous au Centre
+  Communale d'Action Sociale (CCAS).
 prefix: l’
 conditions_generales:
   - type: communes
@@ -18,6 +18,7 @@ conditions_generales:
 conditions:
   - Résider à Berre l'Étang depuis plus de trois ans.
   - Justifier d’une réussite au code de la route ou au permis de conduire.
+  - Être âgé de 15 à 25 ans
 interestFlag: _interetPermisDeConduire
 type: float
 unit: €


### PR DESCRIPTION
## Dispositif : Aide au permis de conduire
- Institution : ville_berre_l_etang
- Lien source : https://www.berreletang.fr/le-permis-de-conduire

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| conditions | ["Résider à Berre l'Étang depuis plus de trois ans.", 'Justifier d’une réussite au code de la route ou au permis de conduire.'] | ["Résider à Berre l'Étang depuis plus de trois ans.", 'Justifier d’une réussite au code de la route ou au permis de conduire.', 'Être âgé de 15 à 25 ans'] |

### Extraits sources
- **conditions** : > Être âgé de 15 à 25 ans

_Confiance LLM : 1.0_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.