### PR TITLE
veille: mise à jour Aide au BAFA, BAFD et BSB (conditions)

### DIFF
--- a/data/benefits/javascript/ville-de-vannes-aide-bafa-bafd-bsb.yml
+++ b/data/benefits/javascript/ville-de-vannes-aide-bafa-bafd-bsb.yml
@@ -3,9 +3,9 @@ prefix: l’
 institution: ville-de-vannes
 description: >-
   La Ville de Vannes apporte une aide financière aux jeunes qui souhaitent
-  suivre lʼune des formations suivantes : Brevet dʼAptitude aux Fonctions dʼAnimateurs (BAFA), 
-  Brevet dʼAptitude aux Fonctions de Directeurs (BAFD), 
-  Brevet de Surveillant de Baignade (BSB).
+  suivre lʼune des formations suivantes : Brevet dʼAptitude aux Fonctions dʼAnimateurs
+  (BAFA),  Brevet dʼAptitude aux Fonctions de Directeurs (BAFD),  Brevet de Surveillant
+  de Baignade (BSB).
 conditions_generales:
   - type: communes
     values:
@@ -15,8 +15,7 @@ conditions_generales:
     value: 25
 conditions:
   - Être domicilié fiscalement à Vannes depuis au moins 1 an.
-  - Contacter le BIJ (Bureau information jeunesse) par téléphone au <a href="tel:+33297016100">02 97 01 61 00</a>
-    ou par email à <a href="mailto:bij@mairie-vannes.fr">bij@mairie-vannes.fr</a>.
+  - Avoir moins de 25 ans révolus lors de la période de formation aidée.
 profils: []
 link: https://bij-vannes.fr/aides-au-bafa-bafd-bsb
 type: bool


### PR DESCRIPTION
## Dispositif : Aide au BAFA, BAFD et BSB
- Institution : ville-de-vannes
- Lien source : https://bij-vannes.fr/aides-au-bafa-bafd-bsb

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| conditions | ['Être domicilié fiscalement à Vannes depuis au moins 1 an.', 'Contacter le BIJ (Bureau information jeunesse) par téléphone au <a href="tel:+33297016100">02 97 01 61 00</a> ou par email à <a href="mailto:bij@mairie-vannes.fr">bij@mairie-vannes.fr</a>.'] | ['Être domicilié fiscalement à Vannes depuis au moins 1 an.', 'Avoir moins de 25 ans révolus lors de la période de formation aidée.'] |

### Extraits sources
- **conditions** : > Pour être éligible au versement de cette bourse, la personne qui sollicite doit avoir, lors de la période de formation aidée, moins de 25 ans révolus et être domiciliée fiscalement à Vannes depuis au moins 1 an.

_Confiance LLM : 0.98_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.