### PR TITLE
chore (veille): mise à jour aide - rémunération des stagiaires de la formation professionnelle (description, conditions générales, conditions)

### DIFF
--- a/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
@@ -1,6 +1,5 @@
 label: rémunération des stagiaires de la formation professionnelle
 institution: region_provence_alpes_cote_azur
-description: La Région propose une rémunération à destination des stagiaires de
 description: La Région Sud peut vous verser une rémunération de stage, ainsi qu’une prise en charge de vos frais de transport et/ou d’hébergement selon votre situation dans le cadre d'une formation professionnelle.
 prefix: la
 conditions_generales:
@@ -8,8 +7,8 @@ conditions_generales:
     values:
       - "93"
   - type: age
-     operator: ">="
-     value: 16
+   operator: ">="
+   value: 16
 profils:
   - type: chomeur
     conditions: []

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
@@ -7,8 +7,8 @@ conditions_generales:
     values:
       - "93"
   - type: age
-   operator: ">="
-   value: 16
+    operator: ">="
+    value: 16
 profils:
   - type: chomeur
     conditions: []

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
@@ -12,8 +12,8 @@ profils:
   - type: chomeur
     conditions: []
 conditions:
-  - Être inscrit ou inscrite à France travail ou auprès d’une mission locale.
-  - Ne pas être en continuité de parcours scolaire.
+  - Être âgé(e) de plus de 16 ans
+  - Ne pas être indemnisé(e) par France Travail
 interestFlag: _interetAidesSanitaireSocial
 type: bool
 unit: €
@@ -21,3 +21,4 @@ periodicite: autre
 link: https://entreprises.maregionsud.fr/aides-et-appels-a-projet/detail/remuneration-des-stagiaires-de-la-formation-professionnelle
 teleservice: https://aidesformation.maregionsud.fr/SignIn?ReturnUrl=%2Fprofile%2F
 instructions: https://entreprises.maregionsud.fr/aides-et-appels-a-projet/detail/remuneration-des-stagiaires-de-la-formation-professionnelle
+montant: 2170.9

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
@@ -1,18 +1,28 @@
 label: rémunération des stagiaires de la formation professionnelle
 institution: region_provence_alpes_cote_azur
 description: La Région propose une rémunération à destination des stagiaires de
-  la formation professionnelle préparant une formation sanitaire de niveau V.
+description: La Région Sud peut vous verser une rémunération de stage, ainsi qu’une prise en charge de vos frais de transport et/ou d’hébergement selon votre situation dans le cadre d'une formation professionnelle.
 prefix: la
 conditions_generales:
   - type: regions
     values:
       - "93"
-  - type: formation_sanitaire_social
+  - type: age
+     operator: ">="
+     value: 16
 profils:
   - type: chomeur
     conditions: []
 conditions:
-  - Être âgé(e) de plus de 16 ans
+  - Être en recherche d’emploi ou relever d’un public spécifique (bénéficiaire du RSA, de l’ASS, de l’ATA, 
+    de l’AAH, personne en situation de handicap, personne placée sous main de justice…).
+  - Suivre une formation agréée par l’État ou la Région (formation sanitaire et
+    sociale, école de la 2ᵉ chance, enseignement supérieur, service militaire
+    volontaire…).
+  - Avoir fait valider son projet professionnel par un conseiller ou une
+    conseillère en évolution professionnelle (mission locale, France Travail,
+    Cap emploi, APEC, CIBC…) dans le cadre d’un Projet Personnalisé d’Accès à
+    l’Emploi (PPAE).
   - Ne pas être indemnisé(e) par France Travail
 interestFlag: _interetAidesSanitaireSocial
 type: bool
@@ -21,4 +31,4 @@ periodicite: autre
 link: https://entreprises.maregionsud.fr/aides-et-appels-a-projet/detail/remuneration-des-stagiaires-de-la-formation-professionnelle
 teleservice: https://aidesformation.maregionsud.fr/SignIn?ReturnUrl=%2Fprofile%2F
 instructions: https://entreprises.maregionsud.fr/aides-et-appels-a-projet/detail/remuneration-des-stagiaires-de-la-formation-professionnelle
-montant: 2170.9
+is_teleservice_need_register: true

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
@@ -22,7 +22,7 @@ conditions:
     conseillère en évolution professionnelle (mission locale, France Travail,
     Cap emploi, APEC, CIBC…) dans le cadre d’un Projet Personnalisé d’Accès à
     l’Emploi (PPAE).
-  - Ne pas être indemnisé(e) par France Travail
+  - Ne pas être indemnisé par France Travail.
 interestFlag: _interetAidesSanitaireSocial
 type: bool
 unit: €

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
@@ -13,7 +13,7 @@ profils:
   - type: chomeur
     conditions: []
 conditions:
-  - Être en recherche d’emploi ou relever d’un public spécifique (bénéficiaire du RSA, de l’ASS, de l’ATA, 
+  - Être en recherche d’emploi ou relever d’un public spécifique (bénéficiaire du RSA, de l’ASS, de l’ATA,
     de l’AAH, personne en situation de handicap, personne placée sous main de justice…).
   - Suivre une formation agréée par l’État ou la Région (formation sanitaire et
     sociale, école de la 2ᵉ chance, enseignement supérieur, service militaire

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-remuneration-stagiaires-formation-professionnelle.yml
@@ -23,7 +23,6 @@ conditions:
     Cap emploi, APEC, CIBC…) dans le cadre d’un Projet Personnalisé d’Accès à
     l’Emploi (PPAE).
   - Ne pas être indemnisé par France Travail.
-interestFlag: _interetAidesSanitaireSocial
 type: bool
 unit: €
 periodicite: autre


### PR DESCRIPTION
## Dispositif : rémunération des stagiaires de la formation professionnelle
- Institution : region_provence_alpes_cote_azur
- Lien source : https://entreprises.maregionsud.fr/aides-et-appels-a-projet/detail/remuneration-des-stagiaires-de-la-formation-professionnelle

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| montant | None | 2170.9 |
| conditions | ['Être inscrit ou inscrite à France travail ou auprès d’une mission locale.', 'Ne pas être en continuité de parcours scolaire.'] | ['Être âgé(e) de plus de 16 ans', 'Ne pas être indemnisé(e) par France Travail'] |

### Extraits sources
- **montant** : > Travailleurs handicapés en recherche d'emploi disposant d’une antériorité professionnelle : ... 769,49 à 2 170,90 euros/mois (ICCP en plus)
- **conditions** : > Les personnes en recherche d’emploi de plus de 16 ans non indemnisés par France Travail

_Confiance LLM : 0.98_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.