### PR TITLE
veille: mise à jour stages Monde - Jeunes titulaires d'un diplôme et en recherche d'emploi (montant)

### DIFF
--- a/data/benefits/javascript/region-bourgogne-franche-comte-stages-monde.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-stages-monde.yml
@@ -4,8 +4,7 @@ description: Cette aide vous permet de financer une expérience professionnelle 
   l’étranger sous la forme d'une bourse, et d'obtenir un accompagnement dans
   votre démarche.
 conditions:
-  - Âge de 18 à 30 ans
-  - Domicilié·e en Bourgogne‑Franche‑Comté
+  - Être inscrit ou inscrite à France travail avant le début du stage.
 conditions_generales:
   - type: regions
     values:

--- a/data/benefits/javascript/region-bourgogne-franche-comte-stages-monde.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-stages-monde.yml
@@ -1,10 +1,11 @@
 label: stages Monde - Jeunes titulaires d'un diplôme et en recherche d'emploi
 institution: region_bourgogne_franche_comte
 description: Cette aide vous permet de financer une expérience professionnelle à
-  l’étranger sous la forme d'une bourse, et d'obtenir un accompagnement dans votre
-  démarche.
+  l’étranger sous la forme d'une bourse, et d'obtenir un accompagnement dans
+  votre démarche.
 conditions:
-  - Être inscrit ou inscrite à France travail avant le début du stage.
+  - Âge de 18 à 30 ans
+  - Domicilié·e en Bourgogne‑Franche‑Comté
 conditions_generales:
   - type: regions
     values:
@@ -25,5 +26,5 @@ type: float
 unit: €
 periodicite: mensuelle
 legend: ""
-montant: 763
+montant: 900
 interestFlag: _interetEtudesEtranger

--- a/data/benefits/javascript/region-bourgogne-franche-comte-stages-monde.yml
+++ b/data/benefits/javascript/region-bourgogne-franche-comte-stages-monde.yml
@@ -26,5 +26,5 @@ type: float
 unit: €
 periodicite: mensuelle
 legend: ""
-montant: 900
+montant: 790
 interestFlag: _interetEtudesEtranger


### PR DESCRIPTION
## Dispositif : stages Monde - Jeunes titulaires d'un diplôme et en recherche d'emploi
- Institution : region_bourgogne_franche_comte
- Lien source : https://www.bourgognefranchecomte.fr/node/410

### Changements proposés

| Champ | Avant | Après |
|---|---|---|
| montant | 763 | 900 |
| conditions | ['Être inscrit ou inscrite à France travail avant le début du stage.'] | ['Âge de 18 à 30 ans', 'Domicilié·e en Bourgogne‑Franche‑Comté'] |

### Extraits sources
- **montant** : > bourse de 790 € à 900 € par mois de stage selon la destination
- **conditions** : > Vous êtes Jeunes diplômés, jeunes demandeurs d’emploi, âgés de 18 à 30 ans, domiciliés en Bourgogne‑Franche‑Comté
- **conditions** : > Vous êtes Jeunes diplômés, jeunes demandeurs d’emploi, âgés de 18 à 30 ans, domiciliés en Bourgogne‑Franche‑Comté

_Confiance LLM : 1.0_

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.