### PR TITLE
Mise à jour du lien des instructions - bourse permis de conduire (Ville d'Angers)

### DIFF
--- a/data/benefits/javascript/ville-angers-bourse-communale-pour-le-permis-de-conduire-permis-citoyen.yml
+++ b/data/benefits/javascript/ville-angers-bourse-communale-pour-le-permis-de-conduire-permis-citoyen.yml
@@ -48,5 +48,4 @@ periodicite: autre
 legend: maximum
 montant: 1000
 link: https://www.angers.fr/vivre-a-angers/ccas/se-deplacer/beneficier-du-permis-citoyen/index.html
-instructions: https://www.angers.fr/fileadmin/user_upload/plaquette_permis_citoyen.pdf
-private: true
+instructions: https://www.angers.fr/fileadmin/user_upload/plaquette_permis_citoyen_web.pdf


### PR DESCRIPTION
J'ai mergé la PR https://github.com/betagouv/aides-jeunes/pull/5217 un peu trop vite et j'ai oublié d'appliquer les suggestions, je remets le couvert ici