### PR TITLE
veille: Atouts Normandie - Avantages Loisirs — lien(s) cassé(s)

### DIFF
--- a/data/benefits/javascript/region_normandie-atouts-normandie-avantages-loisirs.yml
+++ b/data/benefits/javascript/region_normandie-atouts-normandie-avantages-loisirs.yml
@@ -4,8 +4,8 @@ description: La Région Normandie soutient la découverte de pratiques
   culturelles, sportives et liées à l'engagement des jeunes normands de 15 à 25
   ans.
 conditions:
-  - Créer un compte sur <a target="_blank" rel="noopener" title ="Créer un compte - Nouvelle fenêtre"
-    href="https://atouts.normandie.fr/">cette page</a>.
+  - Créer un compte sur <a target="_blank" rel="noopener" title ="Créer un compte
+    - Nouvelle fenêtre" href="https://atouts.normandie.fr/">cette page</a>.
   - Adhérer à Atouts Normandie pour 10 €.
 conditions_generales:
   - type: regions
@@ -26,3 +26,4 @@ unit: €
 periodicite: annuelle
 legend: maximum
 montant: 170
+private: true

--- a/data/benefits/javascript/region_normandie-atouts-normandie-avantages-loisirs.yml
+++ b/data/benefits/javascript/region_normandie-atouts-normandie-avantages-loisirs.yml
@@ -5,7 +5,7 @@ description: La Région Normandie soutient la découverte de pratiques
   ans.
 conditions:
   - Créer un compte sur <a target="_blank" rel="noopener" title ="Créer un compte
-    - Nouvelle fenêtre" href="https://atouts.normandie.fr/">cette page</a>.
+    - Nouvelle fenêtre" href="https://atouts.normandie.fr/beneficiary/register?targetUrl/my/dashboard">cette page</a>.
   - Adhérer à Atouts Normandie pour 10 €.
 conditions_generales:
   - type: regions

--- a/data/benefits/javascript/region_normandie-atouts-normandie-avantages-loisirs.yml
+++ b/data/benefits/javascript/region_normandie-atouts-normandie-avantages-loisirs.yml
@@ -26,4 +26,3 @@ unit: €
 periodicite: annuelle
 legend: maximum
 montant: 170
-private: true


### PR DESCRIPTION
## Dispositif : Atouts Normandie - Avantages Loisirs
- Institution : region_normandie

### Lien(s) cassé(s) détecté(s)

- [link] https://www.normandie.fr/sites/default/files/2021-07/Flyer%20Loisirs%20Atouts%20Normandie.pdf → **404** — à vérifier

### Action proposée
~~`private` : `None` → `true`
Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.~~

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.

Edit : Simon - lien cassé corrigé