### PR TITLE
veille: pass ZOU ! Études — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/region-provence-alpes-cote-azur-pass-zou-etudes.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-pass-zou-etudes.yml
@@ -1,11 +1,10 @@
 label: pass ZOU ! Études
 institution: region_provence_alpes_cote_azur
-description:
-  Avec la Région Sud, vous bénéficiez d’un abonnement de transport unique
-  valable du 1er septembre au 31 août. Il offre la possibilité de se déplacer en accès
-  illimité sur les bus et les trains de toute la région. Il permet non seulement d’effectuer
-  les trajets scolaires du quotidien mais aussi les déplacements de loisirs, y compris en périodes
-  de vacances scolaires.
+description: Avec la Région Sud, vous bénéficiez d’un abonnement de transport
+  unique valable du 1er septembre au 31 août. Il offre la possibilité de se
+  déplacer en accès illimité sur les bus et les trains de toute la région. Il
+  permet non seulement d’effectuer les trajets scolaires du quotidien mais aussi
+  les déplacements de loisirs, y compris en périodes de vacances scolaires.
 prefix: le
 conditions_generales:
   - type: age
@@ -31,11 +30,15 @@ profils:
   - type: service_civique
     conditions: []
 conditions:
-  - Étudier en région Provence-Alpes-Côte d’Azur (maternelle, primaire, collège, lycée, étudiant, apprenti, stagiaire, élève des formations sanitaires et sociales, service civique).
-  - Vous procurer le pass ZOU ! dont le prix varie de 45 €/an à 90 €/an, en fonction des revenus de votre famille.
+  - Étudier en région Provence-Alpes-Côte d’Azur (maternelle, primaire, collège,
+    lycée, étudiant, apprenti, stagiaire, élève des formations sanitaires et
+    sociales, service civique).
+  - Vous procurer le pass ZOU ! dont le prix varie de 45 €/an à 90 €/an, en
+    fonction des revenus de votre famille.
 type: bool
 unit: €
 periodicite: autre
 link: https://www.maregionsud.fr/vos-aides/detail/zou-etudes
 teleservice: https://zou.maregionsud.fr/acheter-un-pass-zou-etudes-2024-2025/
 instructions: ""
+private: true

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-pass-zou-etudes.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-pass-zou-etudes.yml
@@ -38,7 +38,6 @@ conditions:
 type: bool
 unit: €
 periodicite: autre
-link: https://www.maregionsud.fr/vos-aides/detail/zou-etudes
-teleservice: https://zou.maregionsud.fr/acheter-un-pass-zou-etudes-2024-2025/
+link: https://zou.maregionsud.fr/pass-zou-etudes
+teleservice: https://zou.maregionsud.fr/pass-zou-etudes
 instructions: ""
-private: true

--- a/data/benefits/javascript/region-provence-alpes-cote-azur-pass-zou-etudes.yml
+++ b/data/benefits/javascript/region-provence-alpes-cote-azur-pass-zou-etudes.yml
@@ -40,4 +40,5 @@ unit: €
 periodicite: autre
 link: https://zou.maregionsud.fr/pass-zou-etudes
 teleservice: https://zou.maregionsud.fr/pass-zou-etudes
+is_teleservice_need_register: true
 instructions: ""

--- a/data/benefits/openfisca/illkirch_graffenstaden_coupon_arts_et_sports.yml
+++ b/data/benefits/openfisca/illkirch_graffenstaden_coupon_arts_et_sports.yml
@@ -4,8 +4,8 @@ description: Le Coupon Arts et Sports favorise l’accès à une pratique sporti
   et/ou artistique pour les enfants mineurs illkirchois grâce à un allègement
   des frais d’inscription. La famille reçoit un ou plusieurs coupons en fonction
   de son quotient familial.
-link: http://www.illkirch.eu/solidarite-et-sante/ccas/
-instructions: http://www.illkirch.eu/wp-content/uploads/coupon-arts-et-sports-2021.pdf
+link: https://www.illkirch.eu/vos-demarches/actions-sociales/aides-sociales-du-ccas
+instructions: https://www.illkirch.eu/wp-content/uploads/2025/04/Coupon-Arts-et-Sport.pdf
 prefix: le
 floorAt: 1
 entity: familles
@@ -14,4 +14,3 @@ type: float
 unit: "€"
 legend: "en coupons"
 periodicite: ponctuelle
-private: true

--- a/data/benefits/openfisca/illkirch_graffenstaden_coupon_arts_et_sports.yml
+++ b/data/benefits/openfisca/illkirch_graffenstaden_coupon_arts_et_sports.yml
@@ -1,9 +1,9 @@
 label: coupon Arts et Sports
 institution: ville_illkirch_graffenstaden
-description:
-  Le Coupon Arts et Sports favorise l’accès à une pratique sportive et/ou artistique
-  pour les enfants mineurs illkirchois grâce à un allègement des frais d’inscription.
-  La famille reçoit un ou plusieurs coupons en fonction de son quotient familial.
+description: Le Coupon Arts et Sports favorise l’accès à une pratique sportive
+  et/ou artistique pour les enfants mineurs illkirchois grâce à un allègement
+  des frais d’inscription. La famille reçoit un ou plusieurs coupons en fonction
+  de son quotient familial.
 link: http://www.illkirch.eu/solidarite-et-sante/ccas/
 instructions: http://www.illkirch.eu/wp-content/uploads/coupon-arts-et-sports-2021.pdf
 prefix: le
@@ -14,3 +14,4 @@ type: float
 unit: "€"
 legend: "en coupons"
 periodicite: ponctuelle
+private: true

--- a/data/benefits/openfisca/msa_midi_pyrenees_sud_aide_permis.yml
+++ b/data/benefits/openfisca/msa_midi_pyrenees_sud_aide_permis.yml
@@ -9,7 +9,7 @@ description: Cette aide est un coup de pouce de la Mutualité Sociale Agricole
 conditions:
   - Avoir obtenu le code de la route.
 link: https://mps.msa.fr/lfy/famille/aide-permis-de-conduire
-form: https://mps.msa.fr/lfy/documents/98775/99816930/Imprim%C3%A9+2021+-+Demande+pour+aide+au+permis+de+conduire+maj+2021+05.pdf
+form: https://mps.msa.fr/lfp/documents/98775/1699447/Imprim%C3%A9+-+Demande+pour+aide+au+permis+de+conduire.pdf
 prefix: l’
 type: float
 unit: "€"
@@ -18,4 +18,3 @@ entity: individus
 openfiscaPeriod: thisMonth
 periodicite: ponctuelle
 interestFlag: _interetPermisDeConduire
-private: true

--- a/data/benefits/openfisca/msa_midi_pyrenees_sud_aide_permis.yml
+++ b/data/benefits/openfisca/msa_midi_pyrenees_sud_aide_permis.yml
@@ -1,8 +1,11 @@
 label: aide au financement du permis
 institution: msa_midi_pyrenees_sud
-description:
-  Cette aide est un coup de pouce de la Mutualité Sociale Agricole (MSA) Midi-Pyrénées Sud pour favoriser l’autonomie et l’insertion des jeunes de 17 à 25 ans en finançant
-  <a target="_blank" rel="noopener" title="le permis voiture (B) - Nouvelle fenêtre" href="https://www.service-public.fr/particuliers/vosdroits/F2828">le permis voiture (B)</a>.
+description: Cette aide est un coup de pouce de la Mutualité Sociale Agricole
+  (MSA) Midi-Pyrénées Sud pour favoriser l’autonomie et l’insertion des jeunes
+  de 17 à 25 ans en finançant <a target="_blank" rel="noopener" title="le permis
+  voiture (B) - Nouvelle fenêtre"
+  href="https://www.service-public.fr/particuliers/vosdroits/F2828">le permis
+  voiture (B)</a>.
 conditions:
   - Avoir obtenu le code de la route.
 link: https://mps.msa.fr/lfy/famille/aide-permis-de-conduire
@@ -15,3 +18,4 @@ entity: individus
 openfiscaPeriod: thisMonth
 periodicite: ponctuelle
 interestFlag: _interetPermisDeConduire
+private: true

--- a/data/benefits/openfisca/nouvelle_aquitaine_carte_solidaire.yml
+++ b/data/benefits/openfisca/nouvelle_aquitaine_carte_solidaire.yml
@@ -6,11 +6,11 @@ description: La Carte Solidaire permet de bénéficier de 80% de réduction sur 
   prestations.
 prefix: la
 type: bool
-unit:
+unit: null
 periodicite: ponctuelle
 link: https://transports.nouvelle-aquitaine.fr/les-offres/la-carte-solidaire
-teleservice: https://cartesolidaire-nouvelle-aquitaine.cba.fr/
+teleservice: https://cartesolidaire-nouvelle-aquitaine.zecarte.fr/
 instructions: ""
 entity: individus
 openfiscaPeriod: thisMonth
-private: true
+is_teleservice_need_register: true

--- a/data/benefits/openfisca/nouvelle_aquitaine_carte_solidaire.yml
+++ b/data/benefits/openfisca/nouvelle_aquitaine_carte_solidaire.yml
@@ -6,10 +6,11 @@ description: La Carte Solidaire permet de bénéficier de 80% de réduction sur 
   prestations.
 prefix: la
 type: bool
-unit: null
+unit:
 periodicite: ponctuelle
 link: https://transports.nouvelle-aquitaine.fr/les-offres/la-carte-solidaire
 teleservice: https://cartesolidaire-nouvelle-aquitaine.cba.fr/
 instructions: ""
 entity: individus
 openfiscaPeriod: thisMonth
+private: true


### PR DESCRIPTION
## Dispositif : pass ZOU ! Études
- Institution : region_provence_alpes_cote_azur

### Lien(s) cassé(s) détecté(s)

- [teleservice] https://zou.maregionsud.fr/acheter-un-pass-zou-etudes-2024-2025/ → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.