### PR TITLE
veille: Fonds social formation — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/region-nouvelle-aquitaine-fonds-social-formation.yml
+++ b/data/benefits/javascript/region-nouvelle-aquitaine-fonds-social-formation.yml
@@ -1,10 +1,10 @@
 label: Fonds social formation
 institution: region_nouvelle_aquitaine
-description:
-  Durant votre parcours de formation, vous faites face à un imprévu et
-  ne parvenez plus à régler vos dépenses de logement et/ou de transport ? Ce problème peut
-  remettre en cause la poursuite de votre formation. Avec le Fonds social formation, la Région
-  Nouvelle Aquitaine peut vous aider à surmonter cette épreuve.
+description: Durant votre parcours de formation, vous faites face à un imprévu
+  et ne parvenez plus à régler vos dépenses de logement et/ou de transport ? Ce
+  problème peut remettre en cause la poursuite de votre formation. Avec le Fonds
+  social formation, la Région Nouvelle Aquitaine peut vous aider à surmonter
+  cette épreuve.
 prefix: le
 conditions_generales:
   - type: regions
@@ -21,10 +21,15 @@ profils:
     conditions:
       - type: formation_sanitaire_social
 conditions:
-  - Être apprenti inscrit dans une structure de formation située en Nouvelle-Aquitaine, ou être apprenant inscrit dans une formation financée par la Région Nouvelle-Aquitaine (stagiaires de la formation professionnelle, apprenants des formations sanitaires et sociales et salariés en formation dans une structure d’insertion par l’activité économique - SIAE).
-  - Compléter <a target="_blank" rel="noopener" title="attestation - Nouvelle fenêtre"
-    href="https://les-aides.nouvelle-aquitaine.fr/sites/default/files/2021-05/Attestation_Structure-Formation_FSF.pdf">l'attestation de formation</a>
-    avec votre référent ou référente de formation.
+  - Être apprenti inscrit dans une structure de formation située en
+    Nouvelle-Aquitaine, ou être apprenant inscrit dans une formation financée par
+    la Région Nouvelle-Aquitaine (stagiaires de la formation professionnelle,
+    apprenants des formations sanitaires et sociales et salariés en formation dans
+    une structure d’insertion par l’activité économique - SIAE).
+  - Compléter <a target="_blank" rel="noopener" title="attestation - Nouvelle
+    fenêtre"
+    href="https://les-aides.nouvelle-aquitaine.fr/sites/default/files/2021-05/Attestation_Structure-Formation_FSF.pdf">l'attestation
+    de formation</a> avec votre référent ou référente de formation.
   - Créer votre compte sur la plateforme "Mes démarches en Nouvelle-Aquitaine".
 type: float
 unit: €
@@ -34,3 +39,4 @@ montant: 1000
 link: https://les-aides.nouvelle-aquitaine.fr/amenagement-du-territoire/fonds-social-formation
 teleservice: https://rnaconnect.nouvelle-aquitaine.pro/realms/external/protocol/openid-connect/auth?response_type=code&client_id=mes-demarches.nouvelle-aquitaine.fr&redirect_uri=https%3A%2F%2Fmes-demarches.nouvelle-aquitaine.fr%2FcraPortailFO%2Fsso%2Flogin?codeDispositif%3DFPC11-10&state=25f484d4-1581-44d9-ba51-505396455922&login=true&scope=openid
 instructions: https://les-aides.nouvelle-aquitaine.fr/system/files/specific_pj_files/Aide_RegionNA_FondsSocialFormation_CommentDeposerUneDemande.pdf
+private: true


### PR DESCRIPTION
## Dispositif : Fonds social formation
- Institution : region_nouvelle_aquitaine

### Lien(s) cassé(s) détecté(s)

- [link] https://les-aides.nouvelle-aquitaine.fr/amenagement-du-territoire/fonds-social-formation → **404** — à vérifier
- [instructions] https://les-aides.nouvelle-aquitaine.fr/system/files/specific_pj_files/Aide_RegionNA_FondsSocialFormation_CommentDeposerUneDemande.pdf → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.