### PR TITLE
veille: Accompagnement à la VAE (Validation des Acquis de l'Expérience) — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/region-nouvelle-aquitaine-accompagnement-vae.yml
+++ b/data/benefits/javascript/region-nouvelle-aquitaine-accompagnement-vae.yml
@@ -20,3 +20,4 @@ legend: maximum
 montant: 2000
 link: https://les-aides.nouvelle-aquitaine.fr/economie-et-emploi/vae-accompagnement-de-la-validation-des-acquis-de-lexperience
 instructions: https://les-aides.nouvelle-aquitaine.fr/economie-et-emploi/vae-accompagnement-de-la-validation-des-acquis-de-lexperience
+private: true


### PR DESCRIPTION
## Dispositif : Accompagnement à la VAE (Validation des Acquis de l'Expérience)
- Institution : region_nouvelle_aquitaine

### Lien(s) cassé(s) détecté(s)

- [link / instructions] https://les-aides.nouvelle-aquitaine.fr/economie-et-emploi/vae-accompagnement-de-la-validation-des-acquis-de-lexperience → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.