### PR TITLE
veille: QUALIF Sanitaire et Social — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/region-bretagne-qualif-sanitaire-social.yml
+++ b/data/benefits/javascript/region-bretagne-qualif-sanitaire-social.yml
@@ -25,3 +25,4 @@ montant: 5670
 link: https://www.bretagne.bzh/aides/fiches/copie-de-qualif-sanitaire-et-social/
 teleservice: https://extranets.region-bretagne.fr/Portail-Aides/jsp/nouveauContexte.action?codeAction=M42-CONNEXION
 instructions: https://www.bretagne.bzh/aides/fiches/copie-de-qualif-sanitaire-et-social/
+private: true


### PR DESCRIPTION
## Dispositif : QUALIF Sanitaire et Social
- Institution : region_bretagne

### Lien(s) cassé(s) détecté(s)

- [teleservice] https://extranets.region-bretagne.fr/Portail-Aides/jsp/nouveauContexte.action?codeAction=M42-CONNEXION → **503** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.