### PR TITLE
veille: aides aux formations BAFA et BAFD — lien(s) rétabli(s), sortie du mode private

### DIFF
--- a/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-bafd.yml
+++ b/data/benefits/javascript/caf-meurthe-et-moselle-aide-bafa-bafd.yml
@@ -1,12 +1,14 @@
 label: aides aux formations BAFA et BAFD
 institution: caf_meurthe_et_moselle
 description: Les aides aux formations BAFA et BAFD sont mises à disposition par
-  la CAF de Meurthe-et-Moselle pour aider les jeunes à financer une partie de leurs stages,
-  en complément de l'aide nationale apportée par la CAF. Seuls les stagiaires qui suivent
-  une formation complète, du stage de base au stage d'approfondissement, reçoivent une aide.
+  la CAF de Meurthe-et-Moselle pour aider les jeunes à financer une partie de
+  leurs stages, en complément de l'aide nationale apportée par la CAF. Seuls les
+  stagiaires qui suivent une formation complète, du stage de base au stage
+  d'approfondissement, reçoivent une aide.
 conditions:
   - Être allocataire ou rattaché au dossier allocataire de vos parents.
-  - Se rapprocher de l'un des organismes de formation listés par la Caf de Meurthe-et-Moselle.
+  - Se rapprocher de l'un des organismes de formation listés par la Caf de
+    Meurthe-et-Moselle.
 conditions_generales:
   - type: age
     operator: ">="
@@ -24,4 +26,3 @@ prefix: les
 type: bool
 periodicite: ponctuelle
 interestFlag: _interetBafa
-private: true


### PR DESCRIPTION
## Dispositif : aides aux formations BAFA et BAFD
- Institution : caf_meurthe_et_moselle

### Lien(s) re-testé(s)

- [link / instructions] https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/vie-personnelle/les-aides-aux-formations-bafa-et-bafd → **200** (OK)

### Action proposée
- `private` : `True` → retiré
- `montant` (maximum) : inchangé

> Le/les lien(s) de ce dispositif répondent à nouveau : la fiche sort du mode `private`. **À vérifier manuellement** : un lien vivant ne garantit pas que le dispositif existe encore (page d'accueil rétablie, dispositif clos, campagne terminée). Si l'aide n'existe plus, fermer cette PR — le dispositif ne sera plus reproposé.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.