### PR TITLE
veille: Aide covoiturage du quotidien — lien(s) rétabli(s), sortie du mode private

### DIFF
--- a/data/benefits/javascript/cohesion_territoires-aide-covoiturage-du-quotidien.yml
+++ b/data/benefits/javascript/cohesion_territoires-aide-covoiturage-du-quotidien.yml
@@ -18,4 +18,3 @@ periodicite: autre
 montant: 100
 link: https://www.ecologie.gouv.fr/covoiturage
 instructions: https://www.ecologie.gouv.fr/covoiturage-en-france-avantages-et-reglementation-en-vigueur#scroll-nav__3
-private: true


### PR DESCRIPTION
## Dispositif : Aide covoiturage du quotidien
- Institution : etat

### Lien(s) re-testé(s)

- [link] https://www.ecologie.gouv.fr/covoiturage → **200** (OK)
- [instructions] https://www.ecologie.gouv.fr/covoiturage-en-france-avantages-et-reglementation-en-vigueur#scroll-nav__3 → **200** (OK)

### Action proposée
- `private` : `True` → retiré
- `montant` (maximum) : inchangé

> Le/les lien(s) de ce dispositif répondent à nouveau : la fiche sort du mode `private`. **À vérifier manuellement** : un lien vivant ne garantit pas que le dispositif existe encore (page d'accueil rétablie, dispositif clos, campagne terminée). Si l'aide n'existe plus, fermer cette PR — le dispositif ne sera plus reproposé.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.