### PR TITLE
veille: aide à la formation BAFA / BAFD dans le cadre du service civique — lien(s) rétabli(s), sortie du mode private

### DIFF
--- a/data/benefits/javascript/etat-aide-nationale-service-civique-bafa-bafd.yml
+++ b/data/benefits/javascript/etat-aide-nationale-service-civique-bafa-bafd.yml
@@ -1,7 +1,8 @@
 label: aide à la formation BAFA / BAFD dans le cadre du service civique
 institution: etat
 description: L’État propose une aide exceptionnelle pour aider le financement du
-  Brevet d’Aptitude aux Fonctions d’Animateurs (BAFA) et du Brevet d'Aptitude aux Fonctions de Directeur (BAFD).
+  Brevet d’Aptitude aux Fonctions d’Animateurs (BAFA) et du Brevet d'Aptitude
+  aux Fonctions de Directeur (BAFD).
 prefix: l’
 conditions_generales: []
 profils:
@@ -13,4 +14,3 @@ periodicite: ponctuelle
 montant: 100
 link: https://www.jeunes.gouv.fr/une-aide-financiere-de-100eu-pour-les-volontaires-en-service-civique-pour-passer-leur-bafa-bafd
 instructions: https://www.jeunes.gouv.fr/une-aide-financiere-de-100eu-pour-les-volontaires-en-service-civique-pour-passer-leur-bafa-bafd
-private: true


### PR DESCRIPTION
## Dispositif : aide à la formation BAFA / BAFD dans le cadre du service civique
- Institution : etat

### Lien(s) re-testé(s)

- [link / instructions] https://www.jeunes.gouv.fr/une-aide-financiere-de-100eu-pour-les-volontaires-en-service-civique-pour-passer-leur-bafa-bafd → **200** (OK)

### Action proposée
- `private` : `True` → retiré
- `montant` (maximum) : inchangé

> Le/les lien(s) de ce dispositif répondent à nouveau : la fiche sort du mode `private`. **À vérifier manuellement** : un lien vivant ne garantit pas que le dispositif existe encore (page d'accueil rétablie, dispositif clos, campagne terminée). Si l'aide n'existe plus, fermer cette PR — le dispositif ne sera plus reproposé.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.