### PR TITLE
fix(server): écoute la boucle locale par défaut, pilotée par HOST (YWH-PGM10356-254)

### DIFF
--- a/backend/configure.ts
+++ b/backend/configure.ts
@@ -14,6 +14,15 @@ configMongoose(mongoose, config)
 
 export default function (app: express.Application) {
   process.env.PORT = process.env.PORT || "8080"
+  // Interface d'écoute, boucle locale par défaut : nginx proxifie sur 127.0.0.1
+  // et reste le seul client légitime. Lié à toutes les interfaces, le port est
+  // joignable depuis Internet et court-circuite le vhost — les plafonds
+  // `limit_req`/`limit_conn` qui protègent le pool OpenFisca, et surtout la
+  // réécriture de `X-Forwarded-For` : atteint en direct, le client devient le
+  // premier saut, le `trust proxy` = 1 posé plus bas prend son en-tête au mot, et
+  // les `rateLimit()` clés sur `req.ip` se contournent en changeant de valeur.
+  // Un déploiement qui doit écouter ailleurs — un conteneur — pose HOST.
+  process.env.HOST = process.env.HOST || "127.0.0.1"
   process.env.MES_AIDES_ROOT_URL =
     process.env.MES_AIDES_ROOT_URL || `http://localhost:${process.env.PORT}`
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -52,10 +52,21 @@ const errorMiddleware: ErrorRequestHandler = (err, req, res, next) => {
 }
 app.use([errorMiddleware, morgan("combined", { stream: process.stderr })])
 
-const port = process.env.PORT
-app.listen(port, () => {
+// `configure` renseigne les deux, défauts compris. On échoue plutôt que de
+// laisser Node choisir : un port absent devient un port éphémère et un hôte
+// absent lie toutes les interfaces — deux pannes silencieuses, dont une fuite.
+// La borne basse compte autant que le typage : `Number("")` vaut 0, que
+// `listen` traduit justement par « choisis un port au hasard ».
+const port = Number(process.env.PORT)
+const host = process.env.HOST
+if (!Number.isInteger(port) || port <= 0 || port > 65535 || !host) {
+  throw new Error(
+    `Invalid listening configuration: PORT=${process.env.PORT} HOST=${process.env.HOST}`,
+  )
+}
+app.listen(port, host, () => {
   console.log(
-    `Aides Jeunes server listening on port ${port}, in ${app.get(
+    `Aides Jeunes server listening on ${host}:${port}, in ${app.get(
       "env",
     )} mode, expecting to be deployed on ${process.env.MES_AIDES_ROOT_URL}`,
   )


### PR DESCRIPTION
Volet applicatif de la fermeture de **YWH-PGM10356-254**. Le rapport portait sur la page de supervision ; en cherchant la classe plutôt que le site, on a trouvé que le serveur applicatif était lui aussi joignable en direct depuis Internet.

## Le constat

`app.listen(port)` sans hôte lie **toutes les interfaces**. Mesuré sur la production, sans authentification :

```
curl http://5.135.137.147:8001/   →  200   (Express production)
curl http://5.135.137.147:8002/   →  200   (Express préproduction)
```

Sur les deux machines de l'inventaire, et aucun pare-feu n'est actif. OpenFisca, lui, était déjà correctement bouclé (`OPENFISCA_BIND_HOST` vaut `127.0.0.1:` par défaut).

## Pourquoi ça compte plus qu'une URL de plus

Atteinte par son port, l'application perd **tout ce que son vhost lui apporte** :

- les plafonds `limit_conn simulation_concurrency` et `limit_req simulation_per_ip`, posés après l'incident de saturation pour protéger le pool OpenFisca ;
- le `proxy_read_timeout`, HSTS, le `noindex` de la préproduction ;
- et surtout la réécriture de `X-Forwarded-For`. C'est nginx qui rend `app.set("trust proxy", 1)` sain. Atteint en direct, **le client est le premier saut** : son en-tête devient `req.ip`, et les `rateLimit()` de `contributions` et `moncomptepro` — clés sur `req.ip` — se contournent en changeant de valeur.

Nous n'avons **pas** exploité ce dernier point : cela aurait demandé du trafic synthétique sur votre production. Le port ouvert et la configuration sont prouvés, l'enchaînement est lu dans le code.

## Le correctif

L'interface d'écoute rejoint `PORT` dans la configuration d'environnement, à côté d'elle et selon le même idiome, dans `configure.ts` :

```ts
process.env.HOST = process.env.HOST || "127.0.0.1"
```

Défaut sûr pour que l'absence de configuration ne soit pas une exposition ; un déploiement qui doit écouter ailleurs — un conteneur — pose `HOST`. La configuration pm2 le pose explicitement côté ops : c'est le déploiement qui décide de l'interface exposée, pas le code.

Le port et l'hôte sont validés avant d'écouter. Node accepte un port éphémère pour un `PORT` absent et toutes les interfaces pour un `HOST` absent — deux pannes silencieuses, dont une fuite. La surcharge `listen(handle: any)` masquait par ailleurs le typage : le port est maintenant un nombre.

## Vérifié

```
HOST absent          → écoute 127.0.0.1:18099
HOST=0.0.0.0         → écoute 0.0.0.0:18099        (l'environnement pilote)
PORT=abc | 0 | 99999 → Error: Invalid listening configuration (exit 1)
```

`prettier --check`, `eslint` et `build:server` verts sur les deux fichiers modifiés.

`dev.ts` garde volontairement son écoute par défaut : c'est le serveur de développement, il n'est jamais déployé par pm2.

## Ordre de déploiement — important

**À déployer APRÈS [betagouv/aides-jeunes-ops#247](https://github.com/betagouv/aides-jeunes-ops/pull/247).** Le rechargement roulant de pm2 en mode cluster ne survit pas à un changement d'adresse d'écoute : le primaire détient la socket indexée par `adresse:port`, le nouveau worker en demande une autre, `EADDRINUSE`. Reproduit sur pm2 5.2.2 : les quatre workers finissent `errored`, plus rien n'écoute, **et la commande rend 0** — déploiement vert sur site mort. La PR ops passe le déploiement en `startOrRestart`, ce qui rend la bascule sûre.

## Note de fusion

PR #5213 touche également `configure.ts`, mais en tête de fichier (imports et appel de `registerProcessErrorHandlers`) ; cette PR modifie le corps de la fonction exportée. Les hunks sont dans des régions disjointes ; GitHub rend encore `mergeable: UNKNOWN` sur #5213, donc la fusion propre est probable, pas prouvée.
