### PR TITLE
fix(server): écoute la boucle locale par défaut, pilotée par HOST (report sur dev)

### DIFF
--- a/backend/configure.ts
+++ b/backend/configure.ts
@@ -14,6 +14,15 @@ configMongoose(mongoose, config)
 
 export default function (app: express.Application) {
   process.env.PORT = process.env.PORT || "8080"
+  // Interface d'écoute, boucle locale par défaut : nginx proxifie sur 127.0.0.1
+  // et reste le seul client légitime. Lié à toutes les interfaces, le port est
+  // joignable depuis Internet et court-circuite le vhost — les plafonds
+  // `limit_req`/`limit_conn` qui protègent le pool OpenFisca, et surtout la
+  // réécriture de `X-Forwarded-For` : atteint en direct, le client devient le
+  // premier saut, le `trust proxy` = 1 posé plus bas prend son en-tête au mot, et
+  // les `rateLimit()` clés sur `req.ip` se contournent en changeant de valeur.
+  // Un déploiement qui doit écouter ailleurs — un conteneur — pose HOST.
+  process.env.HOST = process.env.HOST || "127.0.0.1"
   process.env.MES_AIDES_ROOT_URL =
     process.env.MES_AIDES_ROOT_URL || `http://localhost:${process.env.PORT}`
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -23,10 +23,21 @@ const errorMiddleware: ErrorRequestHandler = (err, req, res, next) => {
 }
 app.use([errorMiddleware, morgan("combined", { stream: process.stderr })])
 
-const port = process.env.PORT
-app.listen(port, () => {
+// `configure` renseigne les deux, défauts compris. On échoue plutôt que de
+// laisser Node choisir : un port absent devient un port éphémère et un hôte
+// absent lie toutes les interfaces — deux pannes silencieuses, dont une fuite.
+// La borne basse compte autant que le typage : `Number("")` vaut 0, que
+// `listen` traduit justement par « choisis un port au hasard ».
+const port = Number(process.env.PORT)
+const host = process.env.HOST
+if (!Number.isInteger(port) || port <= 0 || port > 65535 || !host) {
+  throw new Error(
+    `Invalid listening configuration: PORT=${process.env.PORT} HOST=${process.env.HOST}`,
+  )
+}
+app.listen(port, host, () => {
   console.log(
-    `Aides Jeunes server listening on port ${port}, in ${app.get(
+    `Aides Jeunes server listening on ${host}:${port}, in ${app.get(
       "env",
     )} mode, expecting to be deployed on ${process.env.MES_AIDES_ROOT_URL}`,
   )


### PR DESCRIPTION
Report sur `dev` du correctif mergé sur `main` dans #5276 — **cherry-pick à l'identique**, aucun conflit.

## Pourquoi cette PR existe

`aides_jeunes_preprod` suit la branche `dev` (`inventories/equinoxe.yaml` et `eclipse.yaml`). #5276 a fermé `*:8001` sur les deux machines ; `*:8002` reste ouvert sur Internet tant que `dev` n'a pas le correctif :

```
5.135.137.147:8002  →  OUVERT     (equinoxe, préproduction)
51.91.16.19:8002    →  OUVERT     (eclipse, préproduction)
```

C'est la même fuite que celle décrite dans #5276 : atteinte par son port, l'application perd les plafonds `limit_req`/`limit_conn`, le `noindex` de la préproduction, et surtout la réécriture de `X-Forwarded-For` qui rend `trust proxy` = 1 sain.

## Contenu

Cueillette de `df102e8b` : `configure.ts` pose le défaut `HOST=127.0.0.1` à côté de `PORT`, `server.ts` valide les deux et écoute dessus. Vérifié après cueillette sur cette base : `configure(app)` est bien appelé (l. 11) avant la lecture (l. 31-32).

## Déploiement

Le merge déploie les deux préproductions. Equinoxe a déjà `startOrRestart` (aides-jeunes-ops#247, déployé ce soir), la bascule d'adresse y est sûre. Eclipse tire son ops de `dev` et recharge donc encore en roulant — le même chemin a réussi ce soir pour son `aides_jeunes` de production, et eclipse ne sert aucun trafic public (`mes-aides.1jeune1solution.beta.gouv.fr` résout vers equinoxe seul).

## Contexte

Fuite signalée sur YesWeHack (YWH-PGM10356-254). Déjà fermé ce soir : `*:8887` (supervision) et `*:8001` sur les deux machines.
