### PR TITLE
veille: erasmus+ Stage - Étudiants — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/centre-val-de-loire-aide-depot-garantie.yml
+++ b/data/benefits/javascript/centre-val-de-loire-aide-depot-garantie.yml
@@ -1,6 +1,9 @@
 label: avance remboursable au dépôt de garantie pour son premier logement
 institution: region_centre_val_de_loire
-description: Vous êtes étudiant, étudiante, jeune actif ou active. Vous êtes à la recherche d’un logement en Centre-Val de Loire ? La Région peut vous octroyer une avance remboursable au dépôt de garantie qui permet de financer la caution demandée par le propriétaire.
+description: Vous êtes étudiant, étudiante, jeune actif ou active. Vous êtes à
+  la recherche d’un logement en Centre-Val de Loire ? La Région peut vous
+  octroyer une avance remboursable au dépôt de garantie qui permet de financer
+  la caution demandée par le propriétaire.
 prefix: l’
 conditions_generales:
   - type: age
@@ -25,7 +28,8 @@ profils:
 conditions:
   - Vous installer dans votre premier logement.
   - Constituer un dossier avec les pièces justificatives demandées.
-  - Adresser le dossier 3 mois maximum après la signature du bail à l'adresse indiquée.
+  - Adresser le dossier 3 mois maximum après la signature du bail à l'adresse
+    indiquée.
 type: float
 unit: €
 periodicite: autre
@@ -33,3 +37,4 @@ legend: maximum
 montant: 300
 link: https://www.yeps.fr/offre/region-avance-remboursable-regionale-au-depot-de-garantie-pour-son-premier-logement/
 instructions: https://www.yeps.fr/offre/region-avance-remboursable-regionale-au-depot-de-garantie-pour-son-premier-logement/
+private: true

--- a/data/benefits/javascript/region-nouvelle-aquitaine-erasmus-stage.yml
+++ b/data/benefits/javascript/region-nouvelle-aquitaine-erasmus-stage.yml
@@ -2,7 +2,8 @@ label: erasmus+ Stage - Étudiants
 institution: region_nouvelle_aquitaine
 description: La Région finance en partie la réalisation d'un stage professionnel
   à l'étranger d'une durée de 2 à 12 mois pour les étudiants. Un Bonus Inclusion
-  d'un montant de 250 €/mois est prévu pour les étudiants ayant moins d’opportunités.
+  d'un montant de 250 €/mois est prévu pour les étudiants ayant moins
+  d’opportunités.
 prefix: l’aide
 conditions_generales:
   - type: regions
@@ -28,3 +29,4 @@ montant: 420
 link: https://les-aides.nouvelle-aquitaine.fr/jeunesse/erasmus-stage-enseignement-superieur
 teleservice: https://rnaconnect.nouvelle-aquitaine.pro/realms/external/protocol/openid-connect/auth?response_type=code&client_id=mes-demarches.nouvelle-aquitaine.fr&redirect_uri=https%3A%2F%2Fmes-demarches.nouvelle-aquitaine.fr%2FcraPortailFO%2Fsso%2Flogin?codeDispositif%3DMI_VOLET5_APP_25_26&state=80625f45-96b9-4b6c-a110-c15a1601e56f&login=true&scope=openid
 is_teleservice_need_register: true
+private: true


### PR DESCRIPTION
## Dispositif : erasmus+ Stage - Étudiants
- Institution : region_nouvelle_aquitaine

### Lien(s) cassé(s) détecté(s)

- [link] https://les-aides.nouvelle-aquitaine.fr/jeunesse/erasmus-stage-enseignement-superieur → **404** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.