### PR TITLE
veille: bourses sanitaires et sociales — lien(s) cassé(s), passage en private

### DIFF
--- a/data/benefits/javascript/martinique-bourses-sanitaires-et-sociales.yml
+++ b/data/benefits/javascript/martinique-bourses-sanitaires-et-sociales.yml
@@ -1,11 +1,12 @@
 label: bourses sanitaires et sociales
 institution: martinique
 description:
-  "La Collectivité Territoriale verse des bourses aux étudiants et étudiantes inscrits
-  dans une formation sanitaire ou sociale dispensée par un établissement agréé et
-  préparant à un diplôme d'Etat : travail social, paramédical ou maïeutique. La
-  bourse est attribuée selon la situation matérielle de la personne qui fait la demande
-  si celle-ci est indépendante financièrement, ou de sa famille dans le cas contraire."
+  "La Collectivité Territoriale verse des bourses aux étudiants et étudiantes
+  inscrits dans une formation sanitaire ou sociale dispensée par un établissement
+  agréé et préparant à un diplôme d'Etat : travail social, paramédical ou maïeutique.
+  La bourse est attribuée selon la situation matérielle de la personne qui fait la
+  demande si celle-ci est indépendante financièrement, ou de sa famille dans le cas
+  contraire."
 prefix: les
 conditions_generales:
   - type: regions
@@ -18,3 +19,4 @@ teleservice: https://ct-martinique-production.mgcloud.fr/account-management/ctma
 type: bool
 periodicite: annuelle
 interestFlag: _interetAidesSanitaireSocial
+private: true


### PR DESCRIPTION
## Dispositif : bourses sanitaires et sociales
- Institution : martinique

### Lien(s) cassé(s) détecté(s)

- [link] https://www.spot.mq/zoom-sur/lancement-de-la-campagne-2024-2025-26-juillet-2024 → **503** — à vérifier
- [instructions] https://www.spot.mq/trouver-un-dispositif/bourse-sanitaire-et-sociale → **503** — à vérifier

### Action proposée
- `private` : `None` → `true`

> Le dispositif est passé en `private: true` car son/ses lien(s) semblent morts. **À vérifier manuellement** : si le lien est en fait valide (protection anti-bot), rejeter cette PR et ajouter le domaine à `veille-link-ignore.yml`.

> PR générée automatiquement par l'agent Veille (aj-llm) — à valider par un humain.